### PR TITLE
docs: add CONTRIBUTING.md with AI policy and guidance

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,8 @@ Maintaining merge commits keeps feature branches visible in project history and 
 - Keep commit messages clear and specific.
 - Use short, descriptive branch names (for example: `docs/add-contributing-guide`, `fix/api-auth-header`).
 
+For more information, see RMI's git practices: https://rmi.github.io/practices/git.html
+
 ## Development and Testing
 
 Before opening a PR, run checks from the repository root:
@@ -115,3 +117,4 @@ By contributing, you agree your contributions are licensed under this repository
 
 ## References
 
+- RMI engineering practices: https://rmi.github.io/practices/


### PR DESCRIPTION
This PR targets #11.
It introduces a new `CONTRIBUTING.md` file, which contains social and practical guidelines for contributing to this project.

The document pulls significantly from PBTAR's contributing guidelines: https://github.com/RMI/pbtar/blob/main/CONTRIBUTING.md.
It expands on it by including precise expectations around AI usage and PR scope, with external linking to our [practices](https://rmi.github.io/practices/pull_request.html).

The goal of this is to try to get ahead of the "Eternal September" of LLM and Agentic PRs in open source work. 