### PR TITLE
Add auth envvars to env.example

### DIFF
--- a/env.example
+++ b/env.example
@@ -6,7 +6,13 @@ SEED_LOG_LEVEL=info
 # ------------------------------
 
 # API
+
 AUTH_DISABLED=true
+
+# AUTH_DISABLED=false
+# AUTH_ISSUER=https://rmi-spd.us.auth0.com/
+# AUTH_AUDIENCE=https://stitch-api.local
+# AUTH_JWKS_URI=https://rmi-spd.us.auth0.com/.well-known/jwks.json
 
 # ------------------------------
 


### PR DESCRIPTION
Adds auth envvars to env.example (and by extension `.env`) to prevent startup failure in api container when AUTH_DISABLED=FALSE.

Commented out for now, see https://rmi1.atlassian.net/browse/STIT-413