### PR TITLE
Add API docs link to diagnostics panel

### DIFF
--- a/deployments/stitch-frontend/src/components/ColophonPanel.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.jsx
@@ -100,10 +100,15 @@ function redactToken(token) {
 
 function getApiDocsUrl(apiBaseUrl) {
   if (!apiBaseUrl) {
-    return "";
+    return null;
   }
 
-  return apiBaseUrl.replace(/\/api\/v1\/?$/, "/docs");
+  const match = apiBaseUrl.match(/^(.*)\/api\/v1\/?$/);
+  if (!match) {
+    return null;
+  }
+
+  return `${match[1]}/docs`;
 }
 
 export default function ColophonPanel({ diagnosticsOpen = false }) {
@@ -255,15 +260,24 @@ export default function ColophonPanel({ diagnosticsOpen = false }) {
                   : "Copy token"}
             </button>
 
-            <a
-              href={apiDocsUrl}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm hover:bg-slate-100"
-              title="Open FastAPI docs"
-            >
-              API docs
-            </a>
+            {apiDocsUrl ? (
+              <a
+                href={apiDocsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm hover:bg-slate-100"
+                title="Open FastAPI docs"
+              >
+                API docs
+              </a>
+            ) : (
+              <span
+                className="rounded border border-red-300 bg-red-50 px-3 py-1.5 text-sm text-red-700"
+                title="API docs URL unavailable for current API base URL"
+              >
+                API docs unavailable
+              </span>
+            )}
 
             <button
               type="button"

--- a/deployments/stitch-frontend/src/components/ColophonPanel.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.jsx
@@ -118,7 +118,7 @@ export default function ColophonPanel({ diagnosticsOpen = false }) {
   const [tokenCopied, setTokenCopied] = useState(false);
   const [tokenCopyError, setTokenCopyError] = useState(false);
 
-  const apiDocsUrl = useMemo(() => getApiDocsUrl(config.apiBaseUrl), []);
+  const apiDocsUrl = getApiDocsUrl(config.apiBaseUrl);
 
   useEffect(() => {
     let cancelled = false;
@@ -258,7 +258,7 @@ export default function ColophonPanel({ diagnosticsOpen = false }) {
             <a
               href={apiDocsUrl}
               target="_blank"
-              rel="noreferrer"
+              rel="noopener noreferrer"
               className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm hover:bg-slate-100"
               title="Open FastAPI docs"
             >

--- a/deployments/stitch-frontend/src/components/ColophonPanel.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.jsx
@@ -98,6 +98,14 @@ function redactToken(token) {
   return `${token.slice(0, 12)}...${token.slice(-8)}`;
 }
 
+function getApiDocsUrl(apiBaseUrl) {
+  if (!apiBaseUrl) {
+    return "";
+  }
+
+  return apiBaseUrl.replace(/\/api\/v1\/?$/, "/docs");
+}
+
 export default function ColophonPanel({ diagnosticsOpen = false }) {
   const systemInfo = useSystemInfo();
   const backendDiagnostics = useBackendDiagnostics(diagnosticsOpen);
@@ -109,6 +117,8 @@ export default function ColophonPanel({ diagnosticsOpen = false }) {
   const [copyError, setCopyError] = useState(false);
   const [tokenCopied, setTokenCopied] = useState(false);
   const [tokenCopyError, setTokenCopyError] = useState(false);
+
+  const apiDocsUrl = useMemo(() => getApiDocsUrl(config.apiBaseUrl), []);
 
   useEffect(() => {
     let cancelled = false;
@@ -244,6 +254,16 @@ export default function ColophonPanel({ diagnosticsOpen = false }) {
                   ? "Token copy failed"
                   : "Copy token"}
             </button>
+
+            <a
+              href={apiDocsUrl}
+              target="_blank"
+              rel="noreferrer"
+              className="rounded border border-slate-300 bg-white px-3 py-1.5 text-sm hover:bg-slate-100"
+              title="Open FastAPI docs"
+            >
+              API docs
+            </a>
 
             <button
               type="button"

--- a/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const makeConfig = (apiBaseUrl) => ({
+const mockConfig = vi.hoisted(() => ({
   appEnv: "local",
-  apiBaseUrl,
+  apiBaseUrl: "http://localhost:8000/api/v1",
   build: {
     appVersion: "0.0.0",
     buildId: "local-build",
@@ -12,40 +12,197 @@ const makeConfig = (apiBaseUrl) => ({
     viteVersion: "^7.2.4",
     buildTime: "2026-04-06T12:00:00Z",
   },
-});
+}));
 
 vi.mock("../config/env", () => ({
-  default: makeConfig("http://localhost:8000/api/v1"),
+  default: mockConfig,
 }));
 
 describe("ColophonPanel", () => {
   let fetchMock;
+  let clipboardSpy;
 
   beforeEach(() => {
-    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: vi.fn() });
+    fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({
+        status: "ok",
+        service: "stitch-api",
+        runtime: {
+          environment: "dev",
+          started_at: "2026-04-06T10:00:00Z",
+          uptime_seconds: 123.456,
+        },
+        auth: {
+          disabled: false,
+          startup_validated: true,
+        },
+        frontend: {
+          origin: "http://localhost:3000",
+        },
+        database: {
+          dialect: "postgresql",
+          host: "localhost",
+          port: 5432,
+          database: "stitch",
+          reachable: true,
+        },
+        build: {
+          app_version: "0.1.0",
+          build_id: "api-local",
+          git_sha: "1234567890abcdef",
+          build_time: "2026-04-06T09:59:00Z",
+        },
+      }),
+    });
     vi.stubGlobal("fetch", fetchMock);
+
+    if (!navigator.clipboard) {
+      Object.defineProperty(navigator, "clipboard", {
+        configurable: true,
+        value: {
+          writeText: vi.fn(),
+        },
+      });
+    }
+
+    clipboardSpy = vi
+      .spyOn(navigator.clipboard, "writeText")
+      .mockResolvedValue(undefined);
+
+    Object.defineProperty(navigator, "language", {
+      configurable: true,
+      value: "en-US",
+    });
+
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "VitestBrowser/1.0",
+    });
+
+    Object.defineProperty(navigator, "connection", {
+      configurable: true,
+      value: {
+        effectiveType: "4g",
+        downlink: 10,
+      },
+    });
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1440,
+    });
+
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 900,
+    });
+
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
   });
 
   afterEach(() => {
+    clipboardSpy?.mockRestore();
     vi.unstubAllGlobals();
+    mockConfig.apiBaseUrl = "http://localhost:8000/api/v1";
   });
 
-  it("renders API docs link when URL is valid", async () => {
+  it("renders frontend, backend, and runtime diagnostics", async () => {
     const { default: ColophonPanel } = await import("./ColophonPanel");
+
+    render(<ColophonPanel diagnosticsOpen />);
+
+    expect(screen.getByText("Frontend Build Info")).toBeInTheDocument();
+    expect(screen.getByText("Backend Diagnostics")).toBeInTheDocument();
+    expect(screen.getByText("Runtime Info")).toBeInTheDocument();
+
+    expect(
+      screen.getByText("http://localhost:8000/api/v1"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("local-build")).toBeInTheDocument();
+    expect(screen.getByText("abcdef1")).toBeInTheDocument();
+    expect(screen.getByText("v20.19.0")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("stitch-api")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("postgresql")).toBeInTheDocument();
+    const reachableLabel = screen.getByText("DB Reachable");
+    expect(reachableLabel.closest("div")).toHaveTextContent("true");
+    const validatedLabel = screen.getByText("Auth Validated");
+    expect(validatedLabel.closest("div")).toHaveTextContent("true");
+    expect(screen.getByText("VitestBrowser/1.0")).toBeInTheDocument();
+    expect(screen.getByText("1440x900")).toBeInTheDocument();
+    expect(screen.getByText("2x")).toBeInTheDocument();
+    expect(screen.getByText("4g (10 Mbps)")).toBeInTheDocument();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/v1/health/details",
+      {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
+  });
+
+  it("renders API docs link with correct URL", async () => {
+    const { default: ColophonPanel } = await import("./ColophonPanel");
+
     render(<ColophonPanel diagnosticsOpen />);
 
     const link = screen.getByRole("link", { name: "API docs" });
+
+    expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "http://localhost:8000/docs");
   });
 
   it("renders unavailable state when API docs URL cannot be derived", async () => {
-    vi.doMock("../config/env", () => ({
-      default: makeConfig("http://localhost:8000"),
-    }));
-
+    mockConfig.apiBaseUrl = "http://localhost:8000";
     const { default: ColophonPanel } = await import("./ColophonPanel");
+
     render(<ColophonPanel diagnosticsOpen />);
 
     expect(screen.getByText("API docs unavailable")).toBeInTheDocument();
+    expect(
+      screen.queryByRole("link", { name: "API docs" }),
+    ).not.toBeInTheDocument();
+  });
+
+  it("copies the diagnostics payload", async () => {
+    const { default: ColophonPanel } = await import("./ColophonPanel");
+
+    render(<ColophonPanel diagnosticsOpen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("stitch-api")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Copied!" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(clipboardSpy).toHaveBeenCalledTimes(1);
+
+    const copiedText = clipboardSpy.mock.calls[0][0];
+    expect(copiedText).toContain("Bearer Token: [redacted - use Copy token]");
+    expect(copiedText).toContain("### Frontend Build Info ###");
+    expect(copiedText).toContain("API Base URL: http://localhost:8000/api/v1");
+    expect(copiedText).toContain("App Version: 0.0.0");
+    expect(copiedText).toContain("Git SHA: abcdef1");
+    expect(copiedText).toContain("### Backend Diagnostics ###");
+    expect(copiedText).toContain("Service: stitch-api");
+    expect(copiedText).toContain("DB Reachable: true");
+    expect(copiedText).toContain("### Runtime Info ###");
+    expect(copiedText).toContain("User Agent: VitestBrowser/1.0");
   });
 });

--- a/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
@@ -25,83 +25,20 @@ describe("ColophonPanel", () => {
   beforeEach(() => {
     fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: vi.fn().mockResolvedValue({
-        status: "ok",
-        service: "stitch-api",
-        runtime: {
-          environment: "dev",
-          started_at: "2026-04-06T10:00:00Z",
-          uptime_seconds: 123.456,
-        },
-        auth: {
-          disabled: false,
-          startup_validated: true,
-        },
-        frontend: {
-          origin: "http://localhost:3000",
-        },
-        database: {
-          dialect: "postgresql",
-          host: "localhost",
-          port: 5432,
-          database: "stitch",
-          reachable: true,
-        },
-        build: {
-          app_version: "0.1.0",
-          build_id: "api-local",
-          git_sha: "1234567890abcdef",
-          build_time: "2026-04-06T09:59:00Z",
-        },
-      }),
+      json: vi.fn().mockResolvedValue({ status: "ok" }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
     if (!navigator.clipboard) {
       Object.defineProperty(navigator, "clipboard", {
         configurable: true,
-        value: {
-          writeText: vi.fn(),
-        },
+        value: { writeText: vi.fn() },
       });
     }
 
     clipboardSpy = vi
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined);
-
-    Object.defineProperty(navigator, "language", {
-      configurable: true,
-      value: "en-US",
-    });
-
-    Object.defineProperty(navigator, "userAgent", {
-      configurable: true,
-      value: "VitestBrowser/1.0",
-    });
-
-    Object.defineProperty(navigator, "connection", {
-      configurable: true,
-      value: {
-        effectiveType: "4g",
-        downlink: 10,
-      },
-    });
-
-    Object.defineProperty(window, "innerWidth", {
-      configurable: true,
-      value: 1440,
-    });
-
-    Object.defineProperty(window, "innerHeight", {
-      configurable: true,
-      value: 900,
-    });
-
-    Object.defineProperty(window, "devicePixelRatio", {
-      configurable: true,
-      value: 2,
-    });
   });
 
   afterEach(() => {
@@ -109,76 +46,17 @@ describe("ColophonPanel", () => {
     vi.unstubAllGlobals();
   });
 
-  it("renders frontend, backend, and runtime diagnostics", async () => {
+  it("renders API docs link with correct URL", async () => {
     const { default: ColophonPanel } = await import("./ColophonPanel");
 
     render(<ColophonPanel diagnosticsOpen />);
 
-    expect(screen.getByText("Frontend Build Info")).toBeInTheDocument();
-    expect(screen.getByText("Backend Diagnostics")).toBeInTheDocument();
-    expect(screen.getByText("Runtime Info")).toBeInTheDocument();
+    const link = screen.getByRole("link", { name: "API docs" });
 
-    expect(
-      screen.getByText("http://localhost:8000/api/v1"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("local-build")).toBeInTheDocument();
-    expect(screen.getByText("abcdef1")).toBeInTheDocument();
-    expect(screen.getByText("v20.19.0")).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(screen.getByText("stitch-api")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("postgresql")).toBeInTheDocument();
-    const reachableLabel = screen.getByText("DB Reachable");
-    expect(reachableLabel.closest("div")).toHaveTextContent("true");
-    const validatedLabel = screen.getByText("Auth Validated");
-    expect(validatedLabel.closest("div")).toHaveTextContent("true");
-    expect(screen.getByText("VitestBrowser/1.0")).toBeInTheDocument();
-    expect(screen.getByText("1440x900")).toBeInTheDocument();
-    expect(screen.getByText("2x")).toBeInTheDocument();
-    expect(screen.getByText("4g (10 Mbps)")).toBeInTheDocument();
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:8000/api/v1/health/details",
-      {
-        method: "GET",
-        headers: {
-          Accept: "application/json",
-        },
-      },
+    expect(link).toBeInTheDocument();
+    expect(link).toHaveAttribute(
+      "href",
+      "http://localhost:8000/docs"
     );
-  });
-
-  it("copies the diagnostics payload", async () => {
-    const { default: ColophonPanel } = await import("./ColophonPanel");
-
-    render(<ColophonPanel diagnosticsOpen />);
-
-    await waitFor(() => {
-      expect(screen.getByText("stitch-api")).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Copied!" }),
-      ).toBeInTheDocument();
-    });
-
-    expect(clipboardSpy).toHaveBeenCalledTimes(1);
-
-    const copiedText = clipboardSpy.mock.calls[0][0];
-    expect(copiedText).toContain("Bearer Token: [redacted - use Copy token]");
-    expect(copiedText).toContain("### Frontend Build Info ###");
-    expect(copiedText).toContain("API Base URL: http://localhost:8000/api/v1");
-    expect(copiedText).toContain("App Version: 0.0.0");
-    expect(copiedText).toContain("Git SHA: abcdef1");
-    expect(copiedText).toContain("### Backend Diagnostics ###");
-    expect(copiedText).toContain("Service: stitch-api");
-    expect(copiedText).toContain("DB Reachable: true");
-    expect(copiedText).toContain("### Runtime Info ###");
-    expect(copiedText).toContain("User Agent: VitestBrowser/1.0");
   });
 });

--- a/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
@@ -25,25 +25,129 @@ describe("ColophonPanel", () => {
   beforeEach(() => {
     fetchMock = vi.fn().mockResolvedValue({
       ok: true,
-      json: vi.fn().mockResolvedValue({ status: "ok" }),
+      json: vi.fn().mockResolvedValue({
+        status: "ok",
+        service: "stitch-api",
+        runtime: {
+          environment: "dev",
+          started_at: "2026-04-06T10:00:00Z",
+          uptime_seconds: 123.456,
+        },
+        auth: {
+          disabled: false,
+          startup_validated: true,
+        },
+        frontend: {
+          origin: "http://localhost:3000",
+        },
+        database: {
+          dialect: "postgresql",
+          host: "localhost",
+          port: 5432,
+          database: "stitch",
+          reachable: true,
+        },
+        build: {
+          app_version: "0.1.0",
+          build_id: "api-local",
+          git_sha: "1234567890abcdef",
+          build_time: "2026-04-06T09:59:00Z",
+        },
+      }),
     });
     vi.stubGlobal("fetch", fetchMock);
 
     if (!navigator.clipboard) {
       Object.defineProperty(navigator, "clipboard", {
         configurable: true,
-        value: { writeText: vi.fn() },
+        value: {
+          writeText: vi.fn(),
+        },
       });
     }
 
     clipboardSpy = vi
       .spyOn(navigator.clipboard, "writeText")
       .mockResolvedValue(undefined);
+
+    Object.defineProperty(navigator, "language", {
+      configurable: true,
+      value: "en-US",
+    });
+
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: "VitestBrowser/1.0",
+    });
+
+    Object.defineProperty(navigator, "connection", {
+      configurable: true,
+      value: {
+        effectiveType: "4g",
+        downlink: 10,
+      },
+    });
+
+    Object.defineProperty(window, "innerWidth", {
+      configurable: true,
+      value: 1440,
+    });
+
+    Object.defineProperty(window, "innerHeight", {
+      configurable: true,
+      value: 900,
+    });
+
+    Object.defineProperty(window, "devicePixelRatio", {
+      configurable: true,
+      value: 2,
+    });
   });
 
   afterEach(() => {
     clipboardSpy?.mockRestore();
     vi.unstubAllGlobals();
+  });
+
+  it("renders frontend, backend, and runtime diagnostics", async () => {
+    const { default: ColophonPanel } = await import("./ColophonPanel");
+
+    render(<ColophonPanel diagnosticsOpen />);
+
+    expect(screen.getByText("Frontend Build Info")).toBeInTheDocument();
+    expect(screen.getByText("Backend Diagnostics")).toBeInTheDocument();
+    expect(screen.getByText("Runtime Info")).toBeInTheDocument();
+
+    expect(
+      screen.getByText("http://localhost:8000/api/v1"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("local-build")).toBeInTheDocument();
+    expect(screen.getByText("abcdef1")).toBeInTheDocument();
+    expect(screen.getByText("v20.19.0")).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("stitch-api")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("postgresql")).toBeInTheDocument();
+    const reachableLabel = screen.getByText("DB Reachable");
+    expect(reachableLabel.closest("div")).toHaveTextContent("true");
+    const validatedLabel = screen.getByText("Auth Validated");
+    expect(validatedLabel.closest("div")).toHaveTextContent("true");
+    expect(screen.getByText("VitestBrowser/1.0")).toBeInTheDocument();
+    expect(screen.getByText("1440x900")).toBeInTheDocument();
+    expect(screen.getByText("2x")).toBeInTheDocument();
+    expect(screen.getByText("4g (10 Mbps)")).toBeInTheDocument();
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8000/api/v1/health/details",
+      {
+        method: "GET",
+        headers: {
+          Accept: "application/json",
+        },
+      },
+    );
   });
 
   it("renders API docs link with correct URL", async () => {
@@ -54,9 +158,38 @@ describe("ColophonPanel", () => {
     const link = screen.getByRole("link", { name: "API docs" });
 
     expect(link).toBeInTheDocument();
-    expect(link).toHaveAttribute(
-      "href",
-      "http://localhost:8000/docs"
-    );
+    expect(link).toHaveAttribute("href", "http://localhost:8000/docs");
+  });
+
+  it("copies the diagnostics payload", async () => {
+    const { default: ColophonPanel } = await import("./ColophonPanel");
+
+    render(<ColophonPanel diagnosticsOpen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("stitch-api")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Copied!" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(clipboardSpy).toHaveBeenCalledTimes(1);
+
+    const copiedText = clipboardSpy.mock.calls[0][0];
+    expect(copiedText).toContain("Bearer Token: [redacted - use Copy token]");
+    expect(copiedText).toContain("### Frontend Build Info ###");
+    expect(copiedText).toContain("API Base URL: http://localhost:8000/api/v1");
+    expect(copiedText).toContain("App Version: 0.0.0");
+    expect(copiedText).toContain("Git SHA: abcdef1");
+    expect(copiedText).toContain("### Backend Diagnostics ###");
+    expect(copiedText).toContain("Service: stitch-api");
+    expect(copiedText).toContain("DB Reachable: true");
+    expect(copiedText).toContain("### Runtime Info ###");
+    expect(copiedText).toContain("User Agent: VitestBrowser/1.0");
   });
 });

--- a/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
@@ -1,9 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const mockConfig = vi.hoisted(() => ({
+const makeConfig = (apiBaseUrl) => ({
   appEnv: "local",
-  apiBaseUrl: "http://localhost:8000/api/v1",
+  apiBaseUrl,
   build: {
     appVersion: "0.0.0",
     buildId: "local-build",
@@ -12,184 +12,40 @@ const mockConfig = vi.hoisted(() => ({
     viteVersion: "^7.2.4",
     buildTime: "2026-04-06T12:00:00Z",
   },
-}));
+});
 
 vi.mock("../config/env", () => ({
-  default: mockConfig,
+  default: makeConfig("http://localhost:8000/api/v1"),
 }));
 
 describe("ColophonPanel", () => {
   let fetchMock;
-  let clipboardSpy;
 
   beforeEach(() => {
-    fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: vi.fn().mockResolvedValue({
-        status: "ok",
-        service: "stitch-api",
-        runtime: {
-          environment: "dev",
-          started_at: "2026-04-06T10:00:00Z",
-          uptime_seconds: 123.456,
-        },
-        auth: {
-          disabled: false,
-          startup_validated: true,
-        },
-        frontend: {
-          origin: "http://localhost:3000",
-        },
-        database: {
-          dialect: "postgresql",
-          host: "localhost",
-          port: 5432,
-          database: "stitch",
-          reachable: true,
-        },
-        build: {
-          app_version: "0.1.0",
-          build_id: "api-local",
-          git_sha: "1234567890abcdef",
-          build_time: "2026-04-06T09:59:00Z",
-        },
-      }),
-    });
+    fetchMock = vi.fn().mockResolvedValue({ ok: true, json: vi.fn() });
     vi.stubGlobal("fetch", fetchMock);
-
-    if (!navigator.clipboard) {
-      Object.defineProperty(navigator, "clipboard", {
-        configurable: true,
-        value: {
-          writeText: vi.fn(),
-        },
-      });
-    }
-
-    clipboardSpy = vi
-      .spyOn(navigator.clipboard, "writeText")
-      .mockResolvedValue(undefined);
-
-    Object.defineProperty(navigator, "language", {
-      configurable: true,
-      value: "en-US",
-    });
-
-    Object.defineProperty(navigator, "userAgent", {
-      configurable: true,
-      value: "VitestBrowser/1.0",
-    });
-
-    Object.defineProperty(navigator, "connection", {
-      configurable: true,
-      value: {
-        effectiveType: "4g",
-        downlink: 10,
-      },
-    });
-
-    Object.defineProperty(window, "innerWidth", {
-      configurable: true,
-      value: 1440,
-    });
-
-    Object.defineProperty(window, "innerHeight", {
-      configurable: true,
-      value: 900,
-    });
-
-    Object.defineProperty(window, "devicePixelRatio", {
-      configurable: true,
-      value: 2,
-    });
   });
 
   afterEach(() => {
-    clipboardSpy?.mockRestore();
     vi.unstubAllGlobals();
   });
 
-  it("renders frontend, backend, and runtime diagnostics", async () => {
+  it("renders API docs link when URL is valid", async () => {
     const { default: ColophonPanel } = await import("./ColophonPanel");
-
-    render(<ColophonPanel diagnosticsOpen />);
-
-    expect(screen.getByText("Frontend Build Info")).toBeInTheDocument();
-    expect(screen.getByText("Backend Diagnostics")).toBeInTheDocument();
-    expect(screen.getByText("Runtime Info")).toBeInTheDocument();
-
-    expect(
-      screen.getByText("http://localhost:8000/api/v1"),
-    ).toBeInTheDocument();
-    expect(screen.getByText("local-build")).toBeInTheDocument();
-    expect(screen.getByText("abcdef1")).toBeInTheDocument();
-    expect(screen.getByText("v20.19.0")).toBeInTheDocument();
-
-    await waitFor(() => {
-      expect(screen.getByText("stitch-api")).toBeInTheDocument();
-    });
-
-    expect(screen.getByText("postgresql")).toBeInTheDocument();
-    const reachableLabel = screen.getByText("DB Reachable");
-    expect(reachableLabel.closest("div")).toHaveTextContent("true");
-    const validatedLabel = screen.getByText("Auth Validated");
-    expect(validatedLabel.closest("div")).toHaveTextContent("true");
-    expect(screen.getByText("VitestBrowser/1.0")).toBeInTheDocument();
-    expect(screen.getByText("1440x900")).toBeInTheDocument();
-    expect(screen.getByText("2x")).toBeInTheDocument();
-    expect(screen.getByText("4g (10 Mbps)")).toBeInTheDocument();
-
-    expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:8000/api/v1/health/details",
-      {
-        method: "GET",
-        headers: {
-          Accept: "application/json",
-        },
-      },
-    );
-  });
-
-  it("renders API docs link with correct URL", async () => {
-    const { default: ColophonPanel } = await import("./ColophonPanel");
-
     render(<ColophonPanel diagnosticsOpen />);
 
     const link = screen.getByRole("link", { name: "API docs" });
-
-    expect(link).toBeInTheDocument();
     expect(link).toHaveAttribute("href", "http://localhost:8000/docs");
   });
 
-  it("copies the diagnostics payload", async () => {
-    const { default: ColophonPanel } = await import("./ColophonPanel");
+  it("renders unavailable state when API docs URL cannot be derived", async () => {
+    vi.doMock("../config/env", () => ({
+      default: makeConfig("http://localhost:8000"),
+    }));
 
+    const { default: ColophonPanel } = await import("./ColophonPanel");
     render(<ColophonPanel diagnosticsOpen />);
 
-    await waitFor(() => {
-      expect(screen.getByText("stitch-api")).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByRole("button", { name: "Copy" }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByRole("button", { name: "Copied!" }),
-      ).toBeInTheDocument();
-    });
-
-    expect(clipboardSpy).toHaveBeenCalledTimes(1);
-
-    const copiedText = clipboardSpy.mock.calls[0][0];
-    expect(copiedText).toContain("Bearer Token: [redacted - use Copy token]");
-    expect(copiedText).toContain("### Frontend Build Info ###");
-    expect(copiedText).toContain("API Base URL: http://localhost:8000/api/v1");
-    expect(copiedText).toContain("App Version: 0.0.0");
-    expect(copiedText).toContain("Git SHA: abcdef1");
-    expect(copiedText).toContain("### Backend Diagnostics ###");
-    expect(copiedText).toContain("Service: stitch-api");
-    expect(copiedText).toContain("DB Reachable: true");
-    expect(copiedText).toContain("### Runtime Info ###");
-    expect(copiedText).toContain("User Agent: VitestBrowser/1.0");
+    expect(screen.getByText("API docs unavailable")).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
Adds a direct link to the FastAPI docs in the diagnostics (colophon) panel.

- Adds an "API docs" button next to "Copy token"
- Derives docs URL from `apiBaseUrl` by replacing `/api/v1` with `/docs`
- Includes test coverage to validate correct URL generation

This improves developer ergonomics by making it easy to jump directly to API docs from the running frontend environment.