### PR TITLE
prepare db deployment for CD

### DIFF
--- a/deployments/db/00-init-roles.sh
+++ b/deployments/db/00-init-roles.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eux
+set -eu
 
 # This script runs automatically on first database initialization
 # via /docker-entrypoint-initdb.d.

--- a/deployments/db/00-init-roles.sh
+++ b/deployments/db/00-init-roles.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-set -eu
+set -eux
 
 # This script runs automatically on first database initialization
 # via /docker-entrypoint-initdb.d.
@@ -42,7 +42,6 @@ if [ -z "$(
     -c "CREATE ROLE stitch_migrator LOGIN PASSWORD '$MIG_ESCAPED';"
 else
   echo "stitch_migrator already exists"
-  exit 1
 fi
 
 # 2) create stitch_app
@@ -55,7 +54,6 @@ if [ -z "$(
     -c "CREATE ROLE stitch_app LOGIN PASSWORD '$APP_ESCAPED';"
 else
   echo "stitch_app already exists"
-  exit 1
 fi
 
 # 3) Grants: connect to DB (DB name is an identifier; we can use double-quoting safely via shell)

--- a/deployments/db/README.md
+++ b/deployments/db/README.md
@@ -144,7 +144,7 @@ docker run \
   -e POSTGRES_PORT='5432' \
   -e POSTGRES_USER='stitch_migrator' \
   -e POSTGRES_PASSWORD='CHANGE_ME123!' \
-  -e POSSTGRES_DB=<database_name>
+  -e POSTGRES_DB=<database_name> \
   --rm \
   stitch-api:latest python -m stitch.api.db.init_job
 ```

--- a/deployments/db/README.md
+++ b/deployments/db/README.md
@@ -101,14 +101,14 @@ Portal → Databases
 Create database named:
 
 ```
-stitch
+<database_name>
 ```
 
 #### Verify Connectivity
 
 ```bash
-pg_isready -d stitch -U postgres -h <POSTGRES_HOST>
-psql -d stitch -U postgres -h <POSTGRES_HOST>
+pg_isready -d <database_name> -U postgres -h <POSTGRES_HOST>
+psql -d <database_name> -U postgres -h <POSTGRES_HOST>
 ```
 
 If connection fails, verify firewall rules.
@@ -118,7 +118,7 @@ If connection fails, verify firewall rules.
 #### Initialize Roles
 
 ```bash
-POSTGRES_DB=stitch \
+POSTGRES_DB=<database_name> \
     POSTGRES_USER=postgres \
     PGHOST=<POSTGRES_HOST> \
     STITCH_MIGRATOR_PASSWORD=CHANGE_ME123! \
@@ -129,8 +129,8 @@ POSTGRES_DB=stitch \
 Verify:
 
 ```bash
-psql -d stitch -U stitch_migrator -h <POSTGRES_HOST>
-psql -d stitch -U stitch_app -h <POSTGRES_HOST>
+psql -d <database_name> -U stitch_migrator -h <POSTGRES_HOST>
+psql -d <database_name> -U stitch_app -h <POSTGRES_HOST>
 ```
 
 ---
@@ -141,11 +141,10 @@ psql -d stitch -U stitch_app -h <POSTGRES_HOST>
 docker run \
   -e LOG_LEVEL='info' \
   -e POSTGRES_HOST=<POSTGRES_HOST> \
-  -e POSTGRES_USER=stitch_migrator \
-  -e POSTGRES_PASSWORD=CHANGE_ME123! \
   -e POSTGRES_PORT='5432' \
   -e POSTGRES_USER='stitch_migrator' \
   -e POSTGRES_PASSWORD='CHANGE_ME123!' \
+  -e POSSTGRES_DB=<database_name>
   --rm \
   stitch-api:latest python -m stitch.api.db.init_job
 ```


### PR DESCRIPTION
Changes to DB deployment discovered while preparing CD pipeline:

do not fail on existing roles, and update docs to allow alternate db names