### PR TITLE
Ci/deploy pipeline

### DIFF
--- a/.github/scripts/build_pr_summary_comment.py
+++ b/.github/scripts/build_pr_summary_comment.py
@@ -13,14 +13,16 @@ def build_comment_body(root: Path) -> str:
     print("Parsing comment artifact files:")
     for path in files:
         print(f" - {path}")
+        text = None
         try:
             text = path.read_text()
             items.append(json.loads(text))
         except Exception as exc:
             parse_warnings.append(f"{path.name}: failed to parse JSON ({exc})")
             print(f"   ERROR parsing {path}: {exc}")
-            print("   File contents:")
-            print(text)
+            if text is not None:
+                print("   File contents:")
+                print(text)
 
     warnings = list(parse_warnings)
     sections = {}

--- a/.github/scripts/build_pr_summary_comment.py
+++ b/.github/scripts/build_pr_summary_comment.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from os import getenv
 
 
 def build_comment_body(root: Path) -> str:
@@ -31,7 +32,7 @@ def build_comment_body(root: Path) -> str:
 
     short_sha = ""
     for item in items:
-        git_sha = str(item.get("data", {}).get("git_sha", "")).strip()
+        git_sha = str(getenv("HEAD_SHA")).strip()
         if git_sha:
             short_sha = git_sha[:7]
             break

--- a/.github/scripts/build_pr_summary_comment.py
+++ b/.github/scripts/build_pr_summary_comment.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+
+import json
+from pathlib import Path
+
+
+def build_comment_body(root: Path) -> str:
+    files = sorted(root.rglob("*.json"))
+    items = []
+    parse_warnings = []
+
+    print("Parsing comment artifact files:")
+    for path in files:
+        print(f" - {path}")
+        try:
+            text = path.read_text()
+            items.append(json.loads(text))
+        except Exception as exc:
+            parse_warnings.append(f"{path.name}: failed to parse JSON ({exc})")
+            print(f"   ERROR parsing {path}: {exc}")
+            print("   File contents:")
+            print(text)
+
+    warnings = list(parse_warnings)
+    sections = {}
+
+    for item in items:
+        for warning in item.get("warnings", []):
+            warnings.append(f"{item.get('name', 'unknown')}: {warning}")
+        sections.setdefault(item.get("section", "other"), []).append(item)
+
+    short_sha = ""
+    for item in items:
+        git_sha = str(item.get("data", {}).get("git_sha", "")).strip()
+        if git_sha:
+            short_sha = git_sha[:7]
+            break
+
+    title = "## CD summary"
+    if short_sha:
+        title = f"{title} `{short_sha}`"
+
+    marker = "<!-- stitch-cd-summary -->"
+    lines = [title, "", marker, ""]
+
+    frontend_url = ""
+    for item in items:
+        if item.get("name") == "frontend":
+            frontend_url = str(item.get("data", {}).get("url", "")).strip()
+            if frontend_url:
+                break
+
+    if frontend_url:
+        lines.append(f"Frontend: {frontend_url}")
+        lines.append("")
+
+    if warnings:
+        lines.append("### Warnings")
+        lines.extend([f"- {warning}" for warning in warnings])
+        lines.append("")
+
+    section_order = ["deployments", "database", "jobs", "images"]
+    seen = set()
+    ordered_sections = []
+
+    for section in section_order:
+        if section in sections:
+            ordered_sections.append(section)
+            seen.add(section)
+
+    for section in sections:
+        if section not in seen:
+            ordered_sections.append(section)
+
+    for section in ordered_sections:
+        group = sections[section]
+        lines.append("<details>")
+        lines.append(f"<summary>{section.capitalize()} ({len(group)})</summary>")
+        lines.append("")
+
+        keys = []
+        for item in group:
+            for key in item.get("data", {}).keys():
+                if key not in keys:
+                    keys.append(key)
+
+        if not keys:
+            lines.append("_No data_")
+            lines.append("")
+            lines.append("</details>")
+            lines.append("")
+            continue
+
+        lines.append("| " + " | ".join(keys) + " |")
+        lines.append("| " + " | ".join(["---"] * len(keys)) + " |")
+
+        for item in sorted(group, key=lambda value: value.get("name", "")):
+            row = [str(item.get("data", {}).get(key, "")) for key in keys]
+            lines.append("| " + " | ".join(row) + " |")
+
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    return "\n".join(lines).strip() + "\n"
+
+
+def main() -> None:
+    root = Path(".comment-artifacts")
+    output_path = Path(".comment-body.md")
+    body = build_comment_body(root)
+    print(body)
+    output_path.write_text(body)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -1,0 +1,160 @@
+name: CD Pipeline
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  build_api_docker_image:
+    name: "Build and publish API"
+    uses: ./.github/workflows/build-and-push-Docker-image.yml
+    secrets: inherit
+    permissions:
+      packages: write
+      contents: read
+    with:
+      dockerfile: deployments/api/Dockerfile
+      image-name: ${{ github.event.repository.name }}-api
+      image-tag: ${{
+          github.event_name == 'pull_request' && format('{0}{1}','pr', github.event.pull_request.number) ||
+          github.event_name == 'schedule' && 'nightly' ||
+          github.event_name == 'push' && github.ref_name ||
+          github.event_name == 'workflow_dispatch' && github.ref_name ||
+          github.sha
+        }}
+
+  build_entity_linkage_docker_image:
+    name: "Build and publish Entity Linkage"
+    uses: ./.github/workflows/build-and-push-Docker-image.yml
+    secrets: inherit
+    permissions:
+      packages: write
+      contents: read
+    with:
+      dockerfile: deployments/entity-linkage/Dockerfile
+      image-name: ${{ github.event.repository.name }}-entity-linkage
+      image-tag: ${{
+          github.event_name == 'pull_request' && format('{0}{1}','pr', github.event.pull_request.number) ||
+          github.event_name == 'schedule' && 'nightly' ||
+          github.event_name == 'push' && github.ref_name ||
+          github.event_name == 'workflow_dispatch' && github.ref_name ||
+          github.sha
+        }}
+
+  build_seed_docker_image:
+    name: "Build and publish Seed"
+    uses: ./.github/workflows/build-and-push-Docker-image.yml
+    secrets: inherit
+    permissions:
+      packages: write
+      contents: read
+    with:
+      dockerfile: deployments/seed/Dockerfile
+      image-name: ${{ github.event.repository.name }}-seed
+      image-tag: ${{
+          github.event_name == 'pull_request' && format('{0}{1}','pr', github.event.pull_request.number) ||
+          github.event_name == 'schedule' && 'nightly' ||
+          github.event_name == 'push' && github.ref_name ||
+          github.event_name == 'workflow_dispatch' && github.ref_name ||
+          github.sha
+        }}
+
+  deploy-db:
+    name: "Create DB"
+    uses: ./.github/workflows/deploy-db.yml
+    secrets: inherit
+
+  run-db-init:
+    name: "Run DB init"
+    uses: ./.github/workflows/run-db-init.yml
+    secrets: inherit
+    needs: [build_api_docker_image, deploy-db]
+    with:
+      full-image-name: ${{ needs.build_api_docker_image.outputs.digest-image-name }}
+      postgres-host: ${{ needs.deploy-db.outputs.postgres-host }}
+      postgres-port: ${{ needs.deploy-db.outputs.postgres-port }}
+      postgres-db: ${{ needs.deploy-db.outputs.postgres-db }}
+
+  deploy-api:
+    name: "Deploy API"
+    uses: ./.github/workflows/deploy-container.yml
+    secrets: inherit
+    needs: [build_api_docker_image, deploy-db, run-db-init]
+    with:
+      full-image-name: ${{ needs.build_api_docker_image.outputs.digest-image-name }}
+      containerAppName: ${{
+          github.event_name == 'pull_request' && format('{0}{1}','pr', github.event.pull_request.number) ||
+          github.event_name == 'schedule' && 'nightly' ||
+          github.event_name == 'push' && github.ref_name ||
+          github.event_name == 'workflow_dispatch' && github.ref_name ||
+          github.sha
+        }}-api
+      environment-variables: >-
+        LOG_LEVEL=debug
+        FRONTEND_ORIGIN_URL=${{
+          github.event_name == 'pull_request' &&
+          format('https://witty-mushroom-017a3dc1e-{0}.westus2.1.azurestaticapps.net', github.event.pull_request.number) ||
+          github.event_name == 'push' && github.ref_name == 'main' &&
+          'https://witty-mushroom-017a3dc1e.1.azurestaticapps.net' ||
+          github.event_name == 'push' &&
+          format('https://witty-mushroom-017a3dc1e-{0}.westus2.1.azurestaticapps.net', github.ref_name) ||
+          'http://localhost:3000'
+        }}
+        AUTH_DISABLED=true
+        ENVIRONMENT=${{
+          (github.event_name == 'pull_request' && format('{0}-{1}', 'pr', github.event.pull_request.number)) ||
+          github.ref_name
+        }}
+        POSTGRES_HOST=${{ needs.deploy-db.outputs.postgres-host }}
+        POSTGRES_PORT=${{ needs.deploy-db.outputs.postgres-port }}
+        POSTGRES_DB=${{ needs.deploy-db.outputs.postgres-db }}
+        POSTGRES_USER=${{ needs.deploy-db.outputs.postgres-user }}
+        PGSSLMODE=require
+      inject-stitch-app-password: true
+      deployment-label: api
+
+  deploy-entity-linkage:
+    name: "Deploy entity linkage"
+    uses: ./.github/workflows/deploy-container.yml
+    secrets: inherit
+    needs: [build_entity_linkage_docker_image, deploy-api]
+    with:
+      full-image-name: ${{ needs.build_entity_linkage_docker_image.outputs.digest-image-name }}
+      containerAppName: ${{
+          github.event_name == 'pull_request' && format('{0}{1}','pr', github.event.pull_request.number) ||
+          github.event_name == 'schedule' && 'nightly' ||
+          github.event_name == 'push' && github.ref_name ||
+          github.event_name == 'workflow_dispatch' && github.ref_name ||
+          github.sha
+        }}-entity-linkage
+      environment-variables: >-
+        LOG_LEVEL=info
+        AUTH_DISABLED=true
+        ENTITY_LINKAGE_API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
+        ENTITY_LINKAGE_FRONTEND_ORIGIN_URL=${{
+          github.event_name == 'pull_request' &&
+          format('https://witty-mushroom-017a3dc1e-{0}.westus2.1.azurestaticapps.net', github.event.pull_request.number) ||
+          github.event_name == 'push' && github.ref_name == 'main' &&
+          'https://witty-mushroom-017a3dc1e.1.azurestaticapps.net' ||
+          github.event_name == 'push' &&
+          format('https://witty-mushroom-017a3dc1e-{0}.westus2.1.azurestaticapps.net', github.ref_name) ||
+          'http://localhost:3000'
+        }}
+      deployment-label: entity-linkage
+
+  run-seed:
+    name: "Run seed"
+    uses: ./.github/workflows/run-seed.yml
+    secrets: inherit
+    needs: [build_seed_docker_image, deploy-api]
+    with:
+      full-image-name: ${{ needs.build_seed_docker_image.outputs.digest-image-name }}
+      api-url: ${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
+
+  comment-summary:
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    uses: ./.github/workflows/comment-pr-summary.yml
+    secrets: inherit
+    needs: [build_api_docker_image, build_entity_linkage_docker_image, build_seed_docker_image, deploy-db, run-db-init, deploy-api, deploy-entity-linkage, run-seed, deploy-frontend]

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -157,4 +157,4 @@ jobs:
     if: ${{ always() && github.event_name == 'pull_request' }}
     uses: ./.github/workflows/comment-pr-summary.yml
     secrets: inherit
-    needs: [build_api_docker_image, build_entity_linkage_docker_image, build_seed_docker_image, deploy-db, run-db-init, deploy-api, deploy-entity-linkage, run-seed, deploy-frontend]
+    needs: [build_api_docker_image, build_entity_linkage_docker_image, build_seed_docker_image, deploy-db, run-db-init, deploy-api, deploy-entity-linkage, run-seed]

--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -1,0 +1,188 @@
+on:
+  workflow_call:
+    inputs:
+      image-name:
+        required: true
+        type: string
+      image-tag:
+        required: true
+        type: string
+      dockerfile:
+        required: true
+        type: string
+    outputs:
+      full-image-name:
+        description: "Full pushed image name including host/registry, name, and tag"
+        value: ${{ jobs.docker-build.outputs.full-image-name }}
+      digest-image-name:
+        description: "Full pushed image name including host/registry, name, and digest"
+        value: ${{ jobs.docker-build.outputs.digest-image-name }}
+
+jobs:
+  docker-build:
+    runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
+    timeout-minutes: 25
+    outputs:
+      full-image-name: ${{ steps.export-outputs.outputs.full-image-name }}
+      digest-image-name: ${{ steps.export-outputs.outputs.digest-image-name }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Prepare Environment
+        id: prepare-environment
+        env:
+          registry: "ghcr.io"
+          image_name: ${{ github.repository_owner }}/${{ inputs.image-name }}
+        run: |
+          NOW="$(date -u +'%Y%m%dT%H%M%SZ')"
+          BUILD_TIME="$(date -u +'%Y-%m-%dT%H:%M:%SZ')"
+
+          echo "now=$NOW" >> "$GITHUB_OUTPUT"
+          echo "now=$NOW"
+          echo "build-time=$BUILD_TIME" >> "$GITHUB_OUTPUT"
+          echo "build-time=$BUILD_TIME"
+
+          registry_image=$(
+            echo "$registry/$image_name" | \
+            tr '[:upper:]' '[:lower:]' \
+          )
+          REGISTRY_IMAGE=${registry_image}
+          echo "registry-image=$REGISTRY_IMAGE"
+          echo "registry-image=$REGISTRY_IMAGE" >> "$GITHUB_OUTPUT"
+
+      - name: Identify LABELs in dockerfile
+        id: custom-labels
+        run: |
+          DOCKERFILE_LABELS="$(grep "^LABEL" ${{ inputs.dockerfile }} | sed 's/^LABEL[[:space:]]*//')"
+          echo "$DOCKERFILE_LABELS"
+          echo "DOCKERFILE_LABELS<<EOF" >> "$GITHUB_ENV"
+          echo "$DOCKERFILE_LABELS" >> "$GITHUB_ENV"
+          echo 'EOF' >> "$GITHUB_ENV"
+          echo 'dockerfile-labels<<EOF' >> "$GITHUB_OUTPUT"
+          echo "$DOCKERFILE_LABELS" >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
+
+      # Setup docker metadata, including tags and labels (and annotations)
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v6
+        env:
+          now: ${{ steps.prepare-environment.outputs.now }}
+        with:
+          images: ${{ steps.prepare-environment.outputs.registry-image }}
+          annotations: |
+            ${{ env.DOCKERFILE_LABELS }}
+          labels: |
+            ${{ env.DOCKERFILE_LABELS }}
+          tags: |
+            type=schedule,enable=true,pattern={{date 'YYYYMMDD[T]HHmmss[Z]' tz='UTC'}}
+            type=schedule,enable=true,pattern=nightly,priority=950
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value=${{ inputs.image-tag }},priority=1100
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Log in to registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      # Actually build the image (for a single architecture)!
+      - name: Build
+        id: build
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./${{ inputs.dockerfile }}
+          labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          build-args: |
+            APP_VERSION=${{
+              (github.event_name == 'pull_request' && format('{0}{1}-{2}', 'pr', github.event.pull_request.number, github.event.pull_request.head.sha)) ||
+              github.ref_name
+            }}
+            BUILD_ID=gha-${{ github.run_id }}.${{ github.run_attempt }}
+            GIT_SHA=${{ github.sha }}
+            BUILD_TIME=${{ steps.prepare-environment.outputs.build-time }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
+
+      - name: Export Outputs
+        id: export-outputs
+        env:
+          build_time: ${{ steps.prepare-environment.outputs.build-time }}
+          commit_time: ${{ github.event.pull_request.updated_at || github.event.head_commit.timestamp || '' }}
+          git_sha: ${{ github.sha }}
+          head_sha: ${{ github.event.pull_request.head.sha }}
+        run: |
+          echo "DOCKER_METADATA_OUTPUT_JSON=$DOCKER_METADATA_OUTPUT_JSON"
+          jq --version
+
+          full_image_name=$(echo "$DOCKER_METADATA_OUTPUT_JSON" | jq -r '.tags[0]')
+          digest_image_name="${full_image_name%@*}@${{ steps.build.outputs.digest }}"
+
+          echo "full-image-name=$full_image_name"
+          echo "full-image-name=$full_image_name" >> "$GITHUB_OUTPUT"
+
+          echo "digest-image-name=$digest_image_name"
+          echo "digest-image-name=$digest_image_name" >> "$GITHUB_OUTPUT"
+
+          mkdir -p /tmp/comment-json
+          json_filename=$(
+            echo "comment-json-image-${{ inputs.image-name }}.json" | \
+            tr '/' '-'
+          )
+          echo "json-filename=$json_filename"
+          echo "json-filename=$json_filename" >> "$GITHUB_ENV"
+          json_file="/tmp/comment-json/$json_filename"
+          echo "json-file=$json_file"
+
+          jq \
+            -n \
+            --arg section "images" \
+            --arg kind "docker_image" \
+            --arg name "${{ inputs.image-name }}" \
+            --arg build_time "$build_time" \
+            --arg commit_time "$commit_time" \
+            --arg git_sha "$git_sha" \
+            --arg full_image_name "$full_image_name" \
+            --arg digest_image_name "$digest_image_name" \
+            '{
+              "section": $section,
+              "kind": $kind,
+              "name": $name,
+              "warnings": [],
+              "data": {
+                "build_time": $build_time,
+                "commit_time": $commit_time,
+                "git_sha": $git_sha,
+                "image": ("`" + $full_image_name + "`"),
+                "image_digest": ("`" + $digest_image_name + "`")
+              }
+            }' \
+            > "$json_file"
+
+          echo "Generated comment JSON:"
+          cat "$json_file"
+
+      - name: Upload comment JSON
+        uses: actions/upload-artifact@v7
+        with:
+          name: ${{ env.json-filename }}
+          path: /tmp/comment-json/*
+          if-no-files-found: error
+          retention-days: 1

--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Identify LABELs in dockerfile
         id: custom-labels
         run: |
-          DOCKERFILE_LABELS="$(grep "^LABEL" ${{ inputs.dockerfile }} | sed 's/^LABEL[[:space:]]*//')"
+          DOCKERFILE_LABELS="$(grep "^LABEL" ${{ inputs.dockerfile }} | sed 's/^LABEL[[:space:]]*//' || true)"
           echo "$DOCKERFILE_LABELS"
           echo "DOCKERFILE_LABELS<<EOF" >> "$GITHUB_ENV"
           echo "$DOCKERFILE_LABELS" >> "$GITHUB_ENV"

--- a/.github/workflows/build-and-push-Docker-image.yml
+++ b/.github/workflows/build-and-push-Docker-image.yml
@@ -180,7 +180,7 @@ jobs:
           cat "$json_file"
 
       - name: Upload comment JSON
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@v4
         with:
           name: ${{ env.json-filename }}
           path: /tmp/comment-json/*

--- a/.github/workflows/close-ci-environment.yml
+++ b/.github/workflows/close-ci-environment.yml
@@ -130,3 +130,71 @@ jobs:
             --yes
 
           echo "Container App '$CONTAINER_APP_NAME' deleted."
+
+  delete-entity-linkage-container-app:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+
+    env:
+      CONTAINER_APP_NAME: ${{
+          github.event_name == 'pull_request' && format('{0}{1}', 'pr', github.event.pull_request.number) ||
+          github.ref_name
+        }}-entity-linkage
+      RESOURCE_GROUP: STITCH-DEV-RG
+
+    steps:
+      - name: Azure login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Ensure containerapp extension is available
+        run: |
+          az extension add --name containerapp --upgrade --allow-preview true
+
+      - name: Delete Container App if it exists
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Checking for Container App: $CONTAINER_APP_NAME"
+
+          EXISTS="$(
+            az containerapp show \
+              --name "$CONTAINER_APP_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --query "name" \
+              --output tsv 2>/dev/null || true
+          )"
+
+          if [ -z "$EXISTS" ]; then
+            echo "Container App '$CONTAINER_APP_NAME' does not exist. Skipping."
+            exit 0
+          fi
+
+          az containerapp delete \
+            --name "$CONTAINER_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --yes
+
+          echo "Container App '$CONTAINER_APP_NAME' deleted."
+
+  close-static-web-app-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      checks: write
+      contents: read
+      id-token: write
+      pull-requests: write
+
+    steps:
+      - name: Close Azure Static Web Apps preview
+        uses: Azure/static-web-apps-deploy@v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: "close"

--- a/.github/workflows/close-ci-environment.yml
+++ b/.github/workflows/close-ci-environment.yml
@@ -4,8 +4,6 @@ name: Close CI environment
 on:
   pull_request:
     types: [closed]
-    branches:
-      - main
   workflow_call:
 
 jobs:

--- a/.github/workflows/close-ci-environment.yml
+++ b/.github/workflows/close-ci-environment.yml
@@ -1,0 +1,132 @@
+---
+name: Close CI environment
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+  workflow_call:
+
+jobs:
+  drop-db:
+    runs-on: ubuntu-latest
+
+    # Same connection settings pattern as your deploy-db.yml
+    env:
+      PGHOST: ${{ vars.PGHOST_DEV }}
+      PGPORT: ${{ vars.PGPORT || '5432' }}
+      PGUSER: ${{ vars.PGUSER_DEV || 'postgres' }}
+      PGPASSWORD: ${{ secrets.PGPASSWORD_DEV }}
+      PGSSLMODE: ${{ vars.PGSSLMODE || 'require' }}
+      PGDATABASE: ${{ vars.PGDATABASE || 'postgres' }}
+
+      # For PR close events, just use the PR number naming scheme.
+      DB_NAME_RAW: ${{
+          (github.event_name == 'push' && github.ref_name) ||
+          (github.event_name == 'pull_request' && github.base_ref == 'production' && github.head_ref) ||
+          (github.event_name == 'pull_request' && format('{0}-{1}', 'pr', github.event.pull_request.number)) ||
+          github.ref_name
+        }}
+
+    steps:
+      - name: Install psql client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Normalize DB name
+        id: normalize-name
+        run: |
+          set -euox pipefail
+          RAW_NAME="${DB_NAME_RAW}"
+          # Lowercase
+          CLEAN=$(echo "$RAW_NAME" | tr '[:upper:]' '[:lower:]')
+          # Replace anything not a-z, 0-9, or underscore with underscore
+          CLEAN=$(echo "$CLEAN" | sed -E 's/[^a-z0-9_]/_/g')
+          # Trim to 63 chars (Postgres identifier limit)
+          CLEAN=$(echo "$CLEAN" | cut -c1-63)
+          echo "db-name=$CLEAN" >> "$GITHUB_OUTPUT"
+
+      - name: Drop database if it exists
+        env:
+          DB_NAME: ${{ steps.normalize-name.outputs.db-name }}
+        run: |
+          set -euox pipefail
+
+          echo "Target server: $PGHOST"
+          echo "Dropping DB: $DB_NAME"
+
+          # Check existence first (DROP DATABASE doesn't support IF EXISTS in older setups;
+          # it does in modern PG, but the explicit check keeps logs clearer.)
+          EXISTS=$(psql -X -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" || true)
+
+          if [ "$EXISTS" != "1" ]; then
+            echo "Database '$DB_NAME' does not exist. Skipping."
+            exit 0
+          fi
+
+          # Terminate active connections to allow drop
+          psql -X -v ON_ERROR_STOP=1 -c "
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = '${DB_NAME}'
+              AND pid <> pg_backend_pid();
+          "
+
+          # Drop database
+          psql -X -v ON_ERROR_STOP=1 -c "DROP DATABASE \"${DB_NAME}\";"
+
+          echo "Database '$DB_NAME' dropped."
+
+  delete-api-container-app:
+    permissions:
+      id-token: write
+      contents: read
+    runs-on: ubuntu-latest
+
+    env:
+      CONTAINER_APP_NAME: ${{
+          github.event_name == 'pull_request' && format('{0}{1}', 'pr', github.event.pull_request.number) ||
+          github.ref_name
+        }}-api
+      RESOURCE_GROUP: STITCH-DEV-RG
+
+    steps:
+      - name: Azure login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - name: Ensure containerapp extension is available
+        run: |
+          az extension add --name containerapp --upgrade --allow-preview true
+
+      - name: Delete Container App if it exists
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          echo "Checking for Container App: $CONTAINER_APP_NAME"
+
+          EXISTS="$(
+            az containerapp show \
+              --name "$CONTAINER_APP_NAME" \
+              --resource-group "$RESOURCE_GROUP" \
+              --query "name" \
+              --output tsv 2>/dev/null || true
+          )"
+
+          if [ -z "$EXISTS" ]; then
+            echo "Container App '$CONTAINER_APP_NAME' does not exist. Skipping."
+            exit 0
+          fi
+
+          az containerapp delete \
+            --name "$CONTAINER_APP_NAME" \
+            --resource-group "$RESOURCE_GROUP" \
+            --yes
+
+          echo "Container App '$CONTAINER_APP_NAME' deleted."

--- a/.github/workflows/comment-pr-summary.yml
+++ b/.github/workflows/comment-pr-summary.yml
@@ -1,0 +1,45 @@
+name: Comment PR summary
+
+on:
+  workflow_call:
+
+jobs:
+  comment-summary:
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Download comment JSON artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: comment-json-*
+          path: .comment-artifacts
+          merge-multiple: true
+
+      - name: Inspect downloaded comment JSON artifacts
+        shell: bash
+        run: |
+          set -euo pipefail
+          echo "Downloaded comment artifacts:"
+          find .comment-artifacts -maxdepth 2 -type f | sort | sed -n '1,200p'
+
+      - name: Build summary comment
+        id: build-comment
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          python3 .github/scripts/build_pr_summary_comment.py
+
+          echo "comment_body_path=.comment-body.md" >> "$GITHUB_OUTPUT"
+
+      - name: Create or update summary comment
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          body-path: ${{ steps.build-comment.outputs.comment_body_path }}

--- a/.github/workflows/comment-pr-summary.yml
+++ b/.github/workflows/comment-pr-summary.yml
@@ -31,6 +31,8 @@ jobs:
       - name: Build summary comment
         id: build-comment
         shell: bash
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -55,37 +55,6 @@ jobs:
       container-app-fqdn: ${{ steps.export-app-url.outputs.container_app_fqdn }}
 
     steps:
-      - name: Dump OIDC claims
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
-            echo "GitHub OIDC request variables are unavailable"
-            exit 1
-          fi
-
-          response="$(
-            curl -sS \
-              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
-              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
-          )"
-
-          token="$(echo "$response" | jq -r '.value')"
-          if [ -z "$token" ] || [ "$token" = "null" ]; then
-            echo "Failed to mint GitHub OIDC token"
-            echo "$response" | jq .
-            exit 1
-          fi
-
-          payload_b64="$(echo "$token" | cut -d '.' -f2)"
-          payload_json="$(
-            python3 -c 'import base64, json, sys; payload = sys.argv[1]; padding = "=" * (-len(payload) % 4); obj = json.loads(base64.urlsafe_b64decode(payload + padding)); keys = ["iss", "aud", "sub", "repository", "repository_owner", "ref", "sha", "event_name", "job_workflow_ref"]; print(json.dumps({k: obj.get(k) for k in keys}, indent=2, sort_keys=True))' "$payload_b64"
-          )"
-
-          echo "GitHub OIDC token claims:"
-          echo "$payload_json"
-
       - name: Azure login
         uses: azure/login@v3
         with:

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -80,28 +80,7 @@ jobs:
 
           payload_b64="$(echo "$token" | cut -d '.' -f2)"
           payload_json="$(
-            python3 - <<'PY' "$payload_b64"
-              import base64
-              import json
-              import sys
-
-              payload = sys.argv[1]
-              padding = '=' * (-len(payload) % 4)
-              decoded = base64.urlsafe_b64decode(payload + padding)
-              obj = json.loads(decoded)
-              keys = [
-                  "iss",
-                  "aud",
-                  "sub",
-                  "repository",
-                  "repository_owner",
-                  "ref",
-                  "sha",
-                  "event_name",
-                  "job_workflow_ref",
-              ]
-              print(json.dumps({k: obj.get(k) for k in keys}, indent=2, sort_keys=True))
-              PY
+            python3 -c 'import base64, json, sys; payload = sys.argv[1]; padding = "=" * (-len(payload) % 4); obj = json.loads(base64.urlsafe_b64decode(payload + padding)); keys = ["iss", "aud", "sub", "repository", "repository_owner", "ref", "sha", "event_name", "job_workflow_ref"]; print(json.dumps({k: obj.get(k) for k in keys}, indent=2, sort_keys=True))' "$payload_b64"
           )"
 
           echo "GitHub OIDC token claims:"

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -1,0 +1,153 @@
+on:
+  workflow_call:
+    inputs:
+      full-image-name:
+        description: "Full pushed image name including host/registry, name, and tag"
+        required: true
+        type: string
+      containerAppName:
+        description: "The name of the Azure Container App."
+        required: true
+        type: string
+      containerAppEnvironment:
+        description: "The name of the Azure Container App environment to deploy to."
+        required: false
+        default: "stitch-dev"
+        type: string
+      targetPort:
+        description: "Port the application listens on"
+        required: false
+        default: 8000
+        type: number
+      deployment-label:
+        description: "Short label for reporting"
+        required: false
+        default: "container-app"
+        type: string
+      environment-variables:
+        description: "Whitespace-delimited non-secret KEY=value pairs"
+        required: false
+        default: ""
+        type: string
+      inject-stitch-app-password:
+        required: false
+        default: false
+        type: boolean
+
+    outputs:
+      container-app-url:
+        description: "HTTPS URL of the deployed Azure Container App"
+        value: ${{ jobs.deploy-container-app.outputs.container-app-url }}
+      container-app-fqdn:
+        description: "Ingress FQDN of the deployed Azure Container App"
+        value: ${{ jobs.deploy-container-app.outputs.container-app-fqdn }}
+
+jobs:
+  deploy-container-app:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+      packages: read
+    timeout-minutes: 25
+    outputs:
+      container-app-url: ${{ steps.export-app-url.outputs.container_app_url }}
+      container-app-fqdn: ${{ steps.export-app-url.outputs.container_app_fqdn }}
+
+    steps:
+
+      - name: Azure login
+        uses: azure/login@v3
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+
+      - run: echo "fullname=${{ inputs.full-image-name }}"
+
+      - name: Assemble environment variables
+        id: envvars
+        shell: bash
+        run: |
+          set -euo pipefail
+          envvars='${{ inputs.environment-variables }}'
+          echo "$envvars"
+          if [ "${{ inputs.inject-stitch-app-password }}" = "true" ]; then
+            envvars="$envvars POSTGRES_PASSWORD=${{ secrets.STITCH_APP_PASSWORD_DEV }}"
+            echo "Also adding POSTGRES_PASSWORD"
+          fi
+          echo "environment_variables<<EOF" >> "$GITHUB_OUTPUT"
+          echo "$envvars" >> "$GITHUB_OUTPUT"
+          echo "EOF" >> "$GITHUB_OUTPUT"
+
+      - name: Build and deploy Container App
+        uses: azure/container-apps-deploy-action@v1
+        with:
+          imageToDeploy: ${{ inputs.full-image-name }}
+          resourceGroup: STITCH-DEV-RG
+          containerAppName: ${{ inputs.containerAppName }}
+          containerAppEnvironment: ${{ inputs.containerAppEnvironment }}
+          targetPort: ${{ inputs.targetPort }}
+          environmentVariables: ${{ steps.envvars.outputs.environment_variables }}
+          ingress: "external"
+
+      - name: Export application URL
+        id: export-app-url
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          fqdn="$(
+            az containerapp show \
+              --name "${{ inputs.containerAppName }}" \
+              --resource-group "STITCH-DEV-RG" \
+              --query "properties.configuration.ingress.fqdn" \
+              --output tsv
+          )"
+
+          if [ -z "$fqdn" ]; then
+            echo "Failed to resolve container app ingress FQDN" >&2
+            exit 1
+          fi
+
+          echo "Resolved FQDN: $fqdn"
+          echo "container_app_fqdn=$fqdn" >> "$GITHUB_OUTPUT"
+          echo "container_app_url=https://$fqdn" >> "$GITHUB_OUTPUT"
+
+      - name: Write comment JSON
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/comment-json
+          json_file="/tmp/comment-json/comment-json-deploy-${{ inputs.deployment-label }}.json"
+
+          jq -n \
+            --arg section "deployments" \
+            --arg kind "container_app" \
+            --arg name "${{ inputs.deployment-label }}" \
+            --arg service "${{ inputs.deployment-label }}" \
+            --arg url "[open](${{ steps.export-app-url.outputs.container_app_url }})" \
+            --arg fqdn '`${{ steps.export-app-url.outputs.container_app_fqdn }}`' \
+            '{
+              "section": $section,
+              "kind": $kind,
+              "name": $name,
+              "warnings": [],
+              "data": {
+                "service": $service,
+                "url": $url,
+                "fqdn": $fqdn
+              }
+            }' > "$json_file"
+
+          jq empty "$json_file"
+          cat "$json_file"
+
+      - name: Upload comment JSON artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: comment-json-deploy-${{ inputs.deployment-label }}
+          path: /tmp/comment-json/*.json
+          if-no-files-found: error

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -81,27 +81,27 @@ jobs:
           payload_b64="$(echo "$token" | cut -d '.' -f2)"
           payload_json="$(
             python3 - <<'PY' "$payload_b64"
-import base64
-import json
-import sys
+              import base64
+              import json
+              import sys
 
-payload = sys.argv[1]
-padding = '=' * (-len(payload) % 4)
-decoded = base64.urlsafe_b64decode(payload + padding)
-obj = json.loads(decoded)
-keys = [
-    "iss",
-    "aud",
-    "sub",
-    "repository",
-    "repository_owner",
-    "ref",
-    "sha",
-    "event_name",
-    "job_workflow_ref",
-]
-print(json.dumps({k: obj.get(k) for k in keys}, indent=2, sort_keys=True))
-PY
+              payload = sys.argv[1]
+              padding = '=' * (-len(payload) % 4)
+              decoded = base64.urlsafe_b64decode(payload + padding)
+              obj = json.loads(decoded)
+              keys = [
+                  "iss",
+                  "aud",
+                  "sub",
+                  "repository",
+                  "repository_owner",
+                  "ref",
+                  "sha",
+                  "event_name",
+                  "job_workflow_ref",
+              ]
+              print(json.dumps({k: obj.get(k) for k in keys}, indent=2, sort_keys=True))
+              PY
           )"
 
           echo "GitHub OIDC token claims:"

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -55,6 +55,57 @@ jobs:
       container-app-fqdn: ${{ steps.export-app-url.outputs.container_app_fqdn }}
 
     steps:
+      - name: Dump OIDC claims
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          if [ -z "${ACTIONS_ID_TOKEN_REQUEST_URL:-}" ] || [ -z "${ACTIONS_ID_TOKEN_REQUEST_TOKEN:-}" ]; then
+            echo "GitHub OIDC request variables are unavailable"
+            exit 1
+          fi
+
+          response="$(
+            curl -sS \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=api://AzureADTokenExchange"
+          )"
+
+          token="$(echo "$response" | jq -r '.value')"
+          if [ -z "$token" ] || [ "$token" = "null" ]; then
+            echo "Failed to mint GitHub OIDC token"
+            echo "$response" | jq .
+            exit 1
+          fi
+
+          payload_b64="$(echo "$token" | cut -d '.' -f2)"
+          payload_json="$(
+            python3 - <<'PY' "$payload_b64"
+import base64
+import json
+import sys
+
+payload = sys.argv[1]
+padding = '=' * (-len(payload) % 4)
+decoded = base64.urlsafe_b64decode(payload + padding)
+obj = json.loads(decoded)
+keys = [
+    "iss",
+    "aud",
+    "sub",
+    "repository",
+    "repository_owner",
+    "ref",
+    "sha",
+    "event_name",
+    "job_workflow_ref",
+]
+print(json.dumps({k: obj.get(k) for k in keys}, indent=2, sort_keys=True))
+PY
+          )"
+
+          echo "GitHub OIDC token claims:"
+          echo "$payload_json"
 
       - name: Azure login
         uses: azure/login@v3

--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -1,0 +1,166 @@
+---
+on:
+  workflow_call:
+    outputs:
+      postgres-host:
+        description: "Database server hostname"
+        value: ${{ jobs.create-db.outputs.postgres-host }}
+      postgres-port:
+        description: "Database server port"
+        value: ${{ jobs.create-db.outputs.postgres-port }}
+      postgres-db:
+        description: "Database name"
+        value: ${{ jobs.create-db.outputs.postgres-db }}
+      postgres-user:
+        description: "Application database user"
+        value: ${{ jobs.create-db.outputs.postgres-user }}
+
+name: Create Database
+
+jobs:
+  create-db:
+    runs-on: ubuntu-latest
+    outputs:
+      postgres-host: ${{ steps.export-db-config.outputs.postgres-host }}
+      postgres-port: ${{ steps.export-db-config.outputs.postgres-port }}
+      postgres-db: ${{ steps.export-db-config.outputs.postgres-db }}
+      postgres-user: ${{ steps.export-db-config.outputs.postgres-user }}
+
+    env:
+      PGHOST: ${{ vars.PGHOST_DEV }}
+      PGPORT: ${{ vars.PGPORT || '5432' }}
+      PGUSER: ${{ vars.PGUSER_DEV || 'postgres' }}
+      PGPASSWORD: ${{ secrets.PGPASSWORD_DEV }}
+      PGSSLMODE: ${{ vars.PGSSLMODE || 'require' }}
+      PGDATABASE: ${{ vars.PGDATABASE || 'postgres' }}
+      DB_NAME_RAW: ${{
+          (github.event_name == 'push' && github.ref_name) ||
+          (github.event_name == 'pull_request' && github.base_ref == 'production' && github.head_ref) ||
+          (github.event_name == 'pull_request' && format('{0}-{1}', 'pr', github.event.pull_request.number)) ||
+          github.ref_name
+        }}
+
+    steps:
+      - name: Install psql client
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y postgresql-client
+
+      - name: Normalize DB name
+        id: normalize-name
+        run: |
+          set -euox pipefail
+          RAW_NAME="${DB_NAME_RAW}"
+          # Lowercase
+          CLEAN=$(echo "$RAW_NAME" | tr '[:upper:]' '[:lower:]')
+          # Replace anything not a-z, 0-9, or underscore with underscore
+          CLEAN=$(echo "$CLEAN" | sed -E 's/[^a-z0-9_]/_/g')
+          # Trim to 63 chars (Postgres identifier limit)
+          CLEAN=$(echo "$CLEAN" | cut -c1-63)
+          echo "db-name=$CLEAN" >> "$GITHUB_OUTPUT"
+
+      - name: Export DB config
+        id: export-db-config
+        run: |
+          set -euo pipefail
+          echo "postgres-host=${PGHOST}" >> "$GITHUB_OUTPUT"
+          echo "postgres-port=${PGPORT}" >> "$GITHUB_OUTPUT"
+          echo "postgres-db=${{ steps.normalize-name.outputs.db-name }}" >> "$GITHUB_OUTPUT"
+          echo "postgres-user=stitch_app" >> "$GITHUB_OUTPUT"
+
+      - name: Drop database on push to main
+        if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+        env:
+          DB_NAME: ${{ steps.normalize-name.outputs.db-name }}
+        run: |
+          set -euo pipefail
+
+          echo "Target server: $PGHOST"
+          echo "Resetting DB: $DB_NAME"
+
+          EXISTS=$(psql -X -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" || true)
+
+          if [ "$EXISTS" = "1" ]; then
+            psql -X -v ON_ERROR_STOP=1 -c "
+              SELECT pg_terminate_backend(pid)
+              FROM pg_stat_activity
+              WHERE datname = '${DB_NAME}'
+                AND pid <> pg_backend_pid();
+            "
+
+            psql -X -v ON_ERROR_STOP=1 -c "DROP DATABASE \"${DB_NAME}\";"
+            echo "Database '$DB_NAME' dropped."
+          else
+            echo "Database '$DB_NAME' does not exist. Nothing to drop."
+          fi
+
+      - name: Create database if it doesn't exist
+        env:
+          DB_NAME: ${{ steps.normalize-name.outputs.db-name }}
+        run: |
+          set -euo pipefail
+
+          echo "Target server: $PGHOST"
+          echo "Creating DB: $DB_NAME"
+
+          # Check existence first (CREATE DATABASE doesn't support IF NOT EXISTS)
+          EXISTS=$(psql -X -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}'" || true)
+
+          if [ "$EXISTS" = "1" ]; then
+            echo "Database '$DB_NAME' already exists. Skipping."
+          else
+            psql -X -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"${DB_NAME}\";"
+            echo "Database '$DB_NAME' created."
+          fi
+
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Run DB initialization script
+        env:
+          POSTGRES_DB: ${{ steps.normalize-name.outputs.db-name }}
+          POSTGRES_USER: ${{ env.PGUSER }}
+          STITCH_MIGRATOR_PASSWORD: ${{ secrets.STITCH_MIGRATOR_PASSWORD_DEV }}
+          STITCH_APP_PASSWORD: ${{ secrets.STITCH_APP_PASSWORD_DEV }}
+        run: deployments/db/00-init-roles.sh
+
+
+      - name: Write comment JSON
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/comment-json
+          json_file="/tmp/comment-json/comment-json-db-deploy.json"
+
+          jq -n \
+            --arg section "database" \
+            --arg kind "postgres_database" \
+            --arg name "db" \
+            --arg db_name "${{ steps.normalize-name.outputs.db-name }}" \
+            --arg postgres_host "\`${PGHOST}\`" \
+            --arg postgres_port "\`${PGPORT}\`" \
+            --arg postgres_db "\`${{ steps.normalize-name.outputs.db-name }}\`" \
+            '{
+              "section": $section,
+              "kind": $kind,
+              "name": $name,
+              "warnings": [],
+              "data": {
+                "db_name": $db_name,
+                "postgres_host": $postgres_host,
+                "postgres_port": $postgres_port,
+                "postgres_db": $postgres_db
+              }
+            }' > "$json_file"
+
+          jq empty "$json_file"
+          cat "$json_file"
+
+      - name: Upload comment JSON artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: comment-json-db-deploy
+          path: /tmp/comment-json/*.json
+          if-no-files-found: error

--- a/.github/workflows/run-db-init.yml
+++ b/.github/workflows/run-db-init.yml
@@ -1,0 +1,101 @@
+---
+on:
+  workflow_call:
+    inputs:
+      full-image-name:
+        description: "Full pushed image name including host/registry, name, and digest"
+        required: true
+        type: string
+      postgres-host:
+        required: true
+        type: string
+      postgres-port:
+        required: false
+        default: "5432"
+        type: string
+      postgres-db:
+        required: true
+        type: string
+      postgres-sslmode:
+        required: false
+        default: "require"
+        type: string
+
+name: Run DB Init
+
+jobs:
+  run-db-init:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 25
+
+    steps:
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Pull init image
+        run: docker pull "${{ inputs.full-image-name }}"
+
+      - name: Run DB init job
+        env:
+          LOG_LEVEL: info
+          POSTGRES_HOST: ${{ inputs.postgres-host }}
+          POSTGRES_PORT: ${{ inputs.postgres-port }}
+          POSTGRES_DB: ${{ inputs.postgres-db }}
+          POSTGRES_USER: stitch_migrator
+          POSTGRES_PASSWORD: ${{ secrets.STITCH_MIGRATOR_PASSWORD_DEV }}
+          PGSSLMODE: ${{ inputs.postgres-sslmode }}
+        run: |
+          set -euo pipefail
+
+          docker run --rm \
+            -e LOG_LEVEL \
+            -e POSTGRES_HOST \
+            -e POSTGRES_PORT \
+            -e POSTGRES_DB \
+            -e POSTGRES_USER \
+            -e POSTGRES_PASSWORD \
+            -e PGSSLMODE \
+            "${{ inputs.full-image-name }}" \
+            python -m stitch.api.db.init_job
+
+
+      - name: Write comment JSON
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/comment-json
+          json_file="/tmp/comment-json/comment-json-db-init.json"
+
+          jq -n \
+            --arg section "jobs" \
+            --arg kind "db_init" \
+            --arg name "db-init" \
+            --arg job "db-init" \
+            --arg image '`${{ inputs.full-image-name }}`' \
+            --arg postgres_db '`${{ inputs.postgres-db }}`' \
+            '{
+              "section": $section,
+              "kind": $kind,
+              "name": $name,
+              "warnings": [],
+              "data": {
+                "job": $job,
+                "image": $image,
+                "postgres_db": $postgres_db
+              }
+            }' > "$json_file"
+
+          jq empty "$json_file"
+          cat "$json_file"
+
+      - name: Upload comment JSON artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: comment-json-db-init
+          path: /tmp/comment-json/*.json
+          if-no-files-found: error

--- a/.github/workflows/run-seed.yml
+++ b/.github/workflows/run-seed.yml
@@ -1,0 +1,93 @@
+name: Run seed job
+
+on:
+  workflow_call:
+    inputs:
+      full-image-name:
+        description: "Full pushed image name including host/registry, name, and digest"
+        required: true
+        type: string
+      api-url:
+        description: "Base API URL for the deployed API"
+        required: true
+        type: string
+
+jobs:
+  run-seed:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    timeout-minutes: 25
+
+    steps:
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Pull seed image
+        run: docker pull "${{ inputs.full-image-name }}"
+
+      - name: Checkout
+        uses: actions/checkout@v5
+
+      - name: Run seed job
+        env:
+          API_BASE_URL: ${{ inputs.api-url }}
+          FAKER_POST_COUNT: "5"
+          LOG_LEVEL: "INFO"
+          RANDOM_SEED: "8675309"
+          SEED_SOURCE: "mixed"
+          NULL_PROBABILITY: "0.3"
+          STATIC_PAYLOAD_DIR: "/mnt/data"
+        run: |
+          set -euo pipefail
+
+          docker run --rm \
+            -e LOG_LEVEL \
+            -e API_BASE_URL \
+            -e FAKER_POST_COUNT \
+            -e RANDOM_SEED \
+            -e SEED_SOURCE \
+            -e NULL_PROBABILITY \
+            -e STATIC_PAYLOAD_DIR \
+            -v "$GITHUB_WORKSPACE/deployments/seed/data:/mnt/data:ro" \
+            "${{ inputs.full-image-name }}"
+
+
+      - name: Write comment JSON
+        if: ${{ github.event_name == 'pull_request' }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p /tmp/comment-json
+          json_file="/tmp/comment-json/comment-json-seed.json"
+
+          jq -n \
+            --arg section "jobs" \
+            --arg kind "seed_run" \
+            --arg name "seed" \
+            --arg job "seed" \
+            --arg api_url '`${{ inputs.api-url }}`' \
+            --arg image '`${{ inputs.full-image-name }}`' \
+            '{
+              "section": $section,
+              "kind": $kind,
+              "name": $name,
+              "warnings": ["Seed ran without auth"],
+              "data": {
+                "job": $job,
+                "api_url": $api_url,
+                "image": $image
+              }
+            }' > "$json_file"
+
+          jq empty "$json_file"
+          cat "$json_file"
+
+      - name: Upload comment JSON artifact
+        if: ${{ github.event_name == 'pull_request' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: comment-json-seed
+          path: /tmp/comment-json/*.json
+          if-no-files-found: error

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -1,21 +1,21 @@
 # CI/CD Deployments
 
-The CD pipeline is managed by the github workflow `build-and-deploy.yml`.
+The CD pipeline is managed by the GitHub workflow `build-and-deploy.yml`.
 
-It builds:
-* the docker images for:
-    * `api` (which is also used for DB migration)
-    * `entity-linkage,`
-    * `seed`, 
+It builds Docker images for:
 
-It then handles deployments:
+* `api` (also used for DB migration)
+* `entity-linkage`
+* `seed`
 
-* DB (assumes an existing Azure PostgreSQL flexible host)
-* API Container app (Assumes an existing Container Apps environment)
-* entity-linkage Container app (deploys to same environment)
+It then handles deployments for:
 
-Note that for PR Preview environments, all preview databases are on the same
-shared Postgres Host, and the container apps are all in the same dev ACA
+* the database, assuming an existing Azure PostgreSQL flexible server
+* the API Container App, assuming an existing Container Apps environment
+* the entity-linkage Container App in the same environment
+
+For PR preview environments, all preview databases are on the same shared
+Postgres host, and the container apps are all in the same dev ACA
 environment.
 
 It also handles running `db-init` (`api` container with different script) and
@@ -49,28 +49,15 @@ All federated credential fields must match exactly:
 If Azure starts returning `AADSTS7002138`, recreating the affected federated
 credential is usually faster than editing it in place.
 
-Roles for MSI:
+Managed identity roles:
 
-Reader
- stitch-dev
-Container Apps Environment
-GHActions-stitch-cicd
-
-Reader
- STITCH-DEV-RG
-Resource Group
-GHActions-stitch-cicd
-
-Container Apps Contributor
- STITCH-DEV-RG
-Resource Group
-GHActions-stitch-cicd
+* `Reader` on `stitch-dev` (Container Apps Environment)
+* `Reader` on `STITCH-DEV-RG` (Resource Group)
+* `Container Apps Contributor` on `STITCH-DEV-RG` (Resource Group)
 
 ## Setup Notes
 
-Setting up Secrets:
-
-In Repo settings, under "Secrets and variables"/"Actions", add:
+In repo settings, under `Secrets and variables` > `Actions`, add:
 
 ### Secrets
 

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -27,8 +27,27 @@ Permissions for Azure Resources are handled through a managed identity, which GH
 Actions runners use with `Azure/login` step.
 For this repo, we're using `GHActions-stitch-cicd`.
 
-Note that a federated identity record for the GH repository needs to be added to
-the MSI
+The repo secrets must point at that exact identity:
+
+* `AZURE_CLIENT_ID`: managed identity client ID
+* `AZURE_SUBSCRIPTION_ID`: Azure subscription containing the target resources
+* `AZURE_TENANT_ID`: tenant for the managed identity
+
+Note that federated identity records for this GitHub repository need to be
+added to the managed identity. For the current workflows, the required subjects
+are:
+
+* `repo:RMI/stitch:pull_request`
+* `repo:RMI/stitch:ref:refs/heads/main`
+
+All federated credential fields must match exactly:
+
+* Issuer: `https://token.actions.githubusercontent.com`
+* Audience: `api://AzureADTokenExchange`
+* Subject: case-sensitive exact match
+
+If Azure starts returning `AADSTS7002138`, recreating the affected federated
+credential is usually faster than editing it in place.
 
 Roles for MSI:
 
@@ -55,9 +74,9 @@ In Repo settings, under "Secrets and variables"/"Actions", add:
 
 ### Secrets
 
-* `AZURE_CLIENT_ID`: For Managed Identity
-* `AZURE_SUBSCRIPTION_ID`: For Managed Identity
-* `AZURE_TENANT_ID`: For Managed Identity
+* `AZURE_CLIENT_ID`: Client ID for `GHActions-stitch-cicd`
+* `AZURE_SUBSCRIPTION_ID`: Subscription for the target Azure resources
+* `AZURE_TENANT_ID`: Tenant for `GHActions-stitch-cicd`
 * `PGPASSWORD_DEV`: superuser (`postgres`) password for DB
 * `STITCH_APP_PASSWORD_DEV`: password that API user will connect to DB
 * `STITCH_MIGRATOR_PASSWORD_DEV`: password that migrator user will connect to DB

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -1,0 +1,69 @@
+# CI/CD Deployments
+
+The CD pipeline is managed by the github workflow `build-and-deploy.yml`.
+
+It builds:
+* the docker images for:
+    * `api` (which is also used for DB migration)
+    * `entity-linkage,`
+    * `seed`, 
+
+It then handles deployments:
+
+* DB (assumes an existing Azure PostgreSQL flexible host)
+* API Container app (Assumes an existing Container Apps environment)
+* entity-linkage Container app (deploys to same environment)
+
+Note that for PR Preview environments, all preview databases are on the same
+shared Postgres Host, and the container apps are all in the same dev ACA
+environment.
+
+It also handles running `db-init` (`api` container with different script) and
+`seed`, both directly from GH Actions (rather than starting on Azure).
+
+## Azure Permissions
+
+Permissions for Azure Resources are handled through a managed identity, which GH
+Actions runners use with `Azure/login` step.
+For this repo, we're using `GHActions-stitch-cicd`.
+
+Note that a federated identity record for the GH repository needs to be added to
+the MSI
+
+Roles for MSI:
+
+Reader
+ stitch-dev
+Container Apps Environment
+GHActions-stitch-cicd
+
+Reader
+ STITCH-DEV-RG
+Resource Group
+GHActions-stitch-cicd
+
+Container Apps Contributor
+ STITCH-DEV-RG
+Resource Group
+GHActions-stitch-cicd
+
+## Setup Notes
+
+Setting up Secrets:
+
+In Repo settings, under "Secrets and variables"/"Actions", add:
+
+### Secrets
+
+* `AZURE_CLIENT_ID`: For Managed Identity
+* `AZURE_SUBSCRIPTION_ID`: For Managed Identity
+* `AZURE_TENANT_ID`: For Managed Identity
+* `PGPASSWORD_DEV`: superuser (`postgres`) password for DB
+* `STITCH_APP_PASSWORD_DEV`: password that API user will connect to DB
+* `STITCH_MIGRATOR_PASSWORD_DEV`: password that migrator user will connect to DB
+  for DDL operations
+* `AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN`: Token for Azure SWA
+
+### Variables
+
+* `PGHOST_DEV`: Host for postgres server

--- a/env.example
+++ b/env.example
@@ -31,7 +31,13 @@ STITCH_DB_SCHEMA_MODE=if-empty
 # Frontend
 # Browser runtime config is loaded from deployments/stitch-frontend/public/config.json.
 # Preview/prod deployments should write that file at deploy time.
+# Local Docker still passes these at frontend build time via docker-compose.yml.
 # Only compile-time frontend flags belong in env files.
+VITE_API_URL=http://localhost:8000/api/v1
+VITE_AUTH0_DOMAIN=https://rmi-spd.us.auth0.com
+VITE_AUTH0_CLIENT_ID=TS1V1soQbccAV1sitFFCfUaIlSwHD2S2
+VITE_AUTH0_AUDIENCE=https://stitch-api.local
+VITE_ENTITY_LINKAGE_URL=http://localhost:8001/api/v1
 VITE_USE_MOCK_DATA=false
 
 # ------------------------------

--- a/env.example
+++ b/env.example
@@ -8,6 +8,7 @@ ENTITY_LINKAGE_LOG_LEVEL=info
 
 # API
 AUTH_DISABLED=true
+ENVIRONMENT=DevelopmentDocker
 
 # ------------------------------
 
@@ -27,14 +28,11 @@ STITCH_DB_SCHEMA_MODE=if-empty
 
 # ------------------------------
 
-# Frontend (public)
-VITE_API_URL=http://localhost:8000/api/v1
+# Frontend
+# Browser runtime config is loaded from deployments/stitch-frontend/public/config.json.
+# Preview/prod deployments should write that file at deploy time.
+# Only compile-time frontend flags belong in env files.
 VITE_USE_MOCK_DATA=false
-VITE_AUTH0_DOMAIN=https://rmi-spd.us.auth0.com
-VITE_AUTH0_CLIENT_ID=TS1V1soQbccAV1sitFFCfUaIlSwHD2S2
-VITE_AUTH0_AUDIENCE=https://stitch-api.local
-VITE_ENTITY_LINKAGE_URL=http://localhost:8001/api/v1
-
 
 # ------------------------------
 


### PR DESCRIPTION
Adds a GitHub Actions CD pipeline for Stitch preview and main deployments.

This PR introduces reusable workflows to:

* Build and publish Docker images for api, entity-linkage, and seed (lightly modified from PACTA workflows)
* Provision and initialize a Postgres database for preview/main environments
* Deploy the API and entity-linkage services to Azure Container Apps
* Run DB init and seed jobs from GitHub Actions
* Tear down preview resources when PRs close
* Post a PR summary comment with deployment/job/image details

It also adds deployment setup documentation in `deployments/CI_DEPLOYMENTS.md` and updates `env.example` to reflect the current local/frontend configuration.

Note This does NOT handle frontend build or deploy, which will be handled in a separate PR