### PR TITLE
Don't run seed job if no new DB

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -146,9 +146,10 @@ jobs:
 
   run-seed:
     name: "Run seed"
+    if: ${{ needs.deploy-db.outputs.database-created == 'true' }}
     uses: ./.github/workflows/run-seed.yml
     secrets: inherit
-    needs: [build_seed_docker_image, deploy-api]
+    needs: [build_seed_docker_image, deploy-db, deploy-api]
     with:
       full-image-name: ${{ needs.build_seed_docker_image.outputs.digest-image-name }}
       api-url: ${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}

--- a/.github/workflows/deploy-db.yml
+++ b/.github/workflows/deploy-db.yml
@@ -2,6 +2,9 @@
 on:
   workflow_call:
     outputs:
+      database-created:
+        description: "Whether this workflow created the database during this run"
+        value: ${{ jobs.create-db.outputs.database-created }}
       postgres-host:
         description: "Database server hostname"
         value: ${{ jobs.create-db.outputs.postgres-host }}
@@ -21,6 +24,7 @@ jobs:
   create-db:
     runs-on: ubuntu-latest
     outputs:
+      database-created: ${{ steps.create-db.outputs.database-created }}
       postgres-host: ${{ steps.export-db-config.outputs.postgres-host }}
       postgres-port: ${{ steps.export-db-config.outputs.postgres-port }}
       postgres-db: ${{ steps.export-db-config.outputs.postgres-db }}
@@ -95,6 +99,7 @@ jobs:
           fi
 
       - name: Create database if it doesn't exist
+        id: create-db
         env:
           DB_NAME: ${{ steps.normalize-name.outputs.db-name }}
         run: |
@@ -108,9 +113,11 @@ jobs:
 
           if [ "$EXISTS" = "1" ]; then
             echo "Database '$DB_NAME' already exists. Skipping."
+            echo "database-created=false" >> "$GITHUB_OUTPUT"
           else
             psql -X -v ON_ERROR_STOP=1 -c "CREATE DATABASE \"${DB_NAME}\";"
             echo "Database '$DB_NAME' created."
+            echo "database-created=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Checkout code


### PR DESCRIPTION
Adds output to DB deploy process to signal if new database was created. If not, skip the `seed` job.

Resolves issue in PR preview environments where `seed` would run regularly, and overpopulate the merge review (since all resources have matches)