### PR TITLE
feat(auth): extract permissions claim from access tokens [STIT-334]

### DIFF
--- a/packages/stitch-auth/src/stitch/auth/claims.py
+++ b/packages/stitch-auth/src/stitch/auth/claims.py
@@ -7,4 +7,5 @@ class TokenClaims(BaseModel):
     sub: str
     email: str | None = None
     name: str | None = None
+    permissions: frozenset[str] = Field(default_factory=frozenset)
     raw: dict[str, Any] = Field(default_factory=dict)

--- a/packages/stitch-auth/src/stitch/auth/validator.py
+++ b/packages/stitch-auth/src/stitch/auth/validator.py
@@ -1,4 +1,5 @@
 from datetime import timedelta
+from typing import Any
 
 import jwt
 from jwt import PyJWKClient
@@ -8,7 +9,27 @@ from .errors import JWKSFetchError, TokenExpiredError, TokenValidationError
 from .settings import OIDCSettings
 
 
+def _extract_permissions(payload: dict[str, Any]) -> frozenset[str]:
+    """Extract RBAC permissions from the token payload.
+
+    Auth0-specific: reads the `permissions` array claim. To support another
+    IdP, dispatch here off OIDCSettings rather than expanding TokenClaims.
+    """
+    if "permissions" not in payload or payload["permissions"] is None:
+        return frozenset()
+
+    value = payload["permissions"]
+    if not isinstance(value, list):
+        raise TokenValidationError("permissions claim must be a list of strings")
+    if not all(isinstance(item, str) for item in value):
+        raise TokenValidationError("permissions claim must be a list of strings")
+    return frozenset(value)
+
+
 class JWTValidator:
+    _settings: OIDCSettings
+    _jwks_client: PyJWKClient
+
     def __init__(self, settings: OIDCSettings) -> None:
         self._settings = settings
         self._jwks_client = PyJWKClient(
@@ -47,10 +68,12 @@ class JWTValidator:
 
         email = payload.get("email") or payload.get("preferred_username")
         name = payload.get("name")
+        permissions = _extract_permissions(payload)
 
         return TokenClaims(
             sub=payload["sub"],
             email=email,
             name=name,
+            permissions=permissions,
             raw=payload,
         )

--- a/packages/stitch-auth/tests/test_claims_unit.py
+++ b/packages/stitch-auth/tests/test_claims_unit.py
@@ -94,4 +94,4 @@ class TestTokenClaimsPermissions:
         claims = TokenClaims(sub="auth0|abc", permissions=["a"])
 
         with pytest.raises(AttributeError):
-            claims.permissions.add("b")  # type: ignore[attr-defined]
+            claims.permissions.add("b")

--- a/packages/stitch-auth/tests/test_claims_unit.py
+++ b/packages/stitch-auth/tests/test_claims_unit.py
@@ -55,3 +55,43 @@ class TestTokenClaimsConstruction:
         """Auth0-style sub with pipe separator."""
         claims = TokenClaims(sub="auth0|abc123")
         assert claims.sub == "auth0|abc123"
+
+
+class TestTokenClaimsPermissions:
+    """TokenClaims.permissions field semantics."""
+
+    def test_permissions_defaults_to_empty_frozenset(self):
+        claims = TokenClaims(sub="auth0|abc")
+
+        assert claims.permissions == frozenset()
+        assert isinstance(claims.permissions, frozenset)
+
+    def test_permissions_accepts_list_and_coerces_to_frozenset(self):
+        claims = TokenClaims(
+            sub="auth0|abc",
+            permissions=["resource:read:public", "resource:read:licensed:wm"],
+        )
+
+        assert claims.permissions == frozenset(
+            {"resource:read:public", "resource:read:licensed:wm"}
+        )
+        assert isinstance(claims.permissions, frozenset)
+
+    def test_permissions_accepts_frozenset_directly(self):
+        source = frozenset({"a", "b"})
+        claims = TokenClaims(sub="auth0|abc", permissions=source)
+
+        assert claims.permissions == source
+        assert isinstance(claims.permissions, frozenset)
+
+    def test_permissions_deduplicates(self):
+        claims = TokenClaims(sub="auth0|abc", permissions=["a", "a", "b"])
+
+        assert claims.permissions == frozenset({"a", "b"})
+        assert len(claims.permissions) == 2
+
+    def test_permissions_is_immutable_after_construction(self):
+        claims = TokenClaims(sub="auth0|abc", permissions=["a"])
+
+        with pytest.raises(AttributeError):
+            claims.permissions.add("b")  # type: ignore[attr-defined]

--- a/packages/stitch-auth/tests/test_validator_unit.py
+++ b/packages/stitch-auth/tests/test_validator_unit.py
@@ -186,3 +186,117 @@ class TestJWTValidatorErrors:
 
         with pytest.raises(TokenValidationError):
             validator.validate(token)
+
+
+class TestJWTValidatorPermissions:
+    """Extraction of the Auth0 RBAC `permissions` claim (rfc9068_profile_authz)."""
+
+    def test_extracts_permissions_when_present(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(
+            extra_claims={
+                "permissions": [
+                    "resource:read:public",
+                    "resource:read:licensed:wm",
+                ],
+            },
+        )
+        validator = JWTValidator(oidc_settings)
+
+        claims = validator.validate(token)
+
+        assert claims.permissions == frozenset(
+            {"resource:read:public", "resource:read:licensed:wm"}
+        )
+        assert isinstance(claims.permissions, frozenset)
+
+    def test_permissions_empty_when_claim_absent(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory()
+        validator = JWTValidator(oidc_settings)
+
+        claims = validator.validate(token)
+
+        assert claims.permissions == frozenset()
+
+    def test_permissions_empty_when_claim_is_null(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(extra_claims={"permissions": None})
+        validator = JWTValidator(oidc_settings)
+
+        claims = validator.validate(token)
+
+        assert claims.permissions == frozenset()
+
+    def test_permissions_empty_when_claim_is_empty_list(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(extra_claims={"permissions": []})
+        validator = JWTValidator(oidc_settings)
+
+        claims = validator.validate(token)
+
+        assert claims.permissions == frozenset()
+
+    def test_permissions_deduplicates_at_validator_level(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(extra_claims={"permissions": ["a", "a", "b"]})
+        validator = JWTValidator(oidc_settings)
+
+        claims = validator.validate(token)
+
+        assert claims.permissions == frozenset({"a", "b"})
+
+    def test_raw_payload_still_contains_permissions(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(extra_claims={"permissions": ["a"]})
+        validator = JWTValidator(oidc_settings)
+
+        claims = validator.validate(token)
+
+        assert claims.raw["permissions"] == ["a"]
+
+    def test_rejects_permissions_as_string(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(
+            extra_claims={
+                "permissions": "resource:read:public resource:read:licensed:wm",
+            },
+        )
+        validator = JWTValidator(oidc_settings)
+
+        with pytest.raises(TokenValidationError, match="permissions"):
+            validator.validate(token)
+
+    def test_rejects_permissions_with_non_string_entries(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(extra_claims={"permissions": [123, "valid"]})
+        validator = JWTValidator(oidc_settings)
+
+        with pytest.raises(TokenValidationError, match="permissions"):
+            validator.validate(token)
+
+    def test_rejects_permissions_with_dict_entries(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(extra_claims={"permissions": [{"x": 1}]})
+        validator = JWTValidator(oidc_settings)
+
+        with pytest.raises(TokenValidationError, match="permissions"):
+            validator.validate(token)
+
+    def test_rejects_permissions_as_dict(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        token = token_factory(extra_claims={"permissions": {"a": True}})
+        validator = JWTValidator(oidc_settings)
+
+        with pytest.raises(TokenValidationError, match="permissions"):
+            validator.validate(token)


### PR DESCRIPTION
## Summary

- `TokenClaims` now exposes a `permissions: frozenset[str]` field
- `JWTValidator` reads Auth0's `permissions` array claim (rfc9068_profile_authz dialect)
- Missing/null/empty → empty frozenset; malformed shape → `TokenValidationError`
- Extract-only — no enforcement here. Wiring `permissions` into `stitch-api` route guards is a follow-up.

## Test plan

- [x] `pytest packages/stitch-auth` — 40 passed (14 new)
- [x] `make api-test-exact` — 134 passed, no consumer regression
- [x] `make check` — lint/format/type/frontend all green
- [ ] smoke against a real Auth0 token in the running app