### PR TITLE
feat: user name & email nullable

### DIFF
--- a/deployments/api/src/stitch/api/auth.py
+++ b/deployments/api/src/stitch/api/auth.py
@@ -12,7 +12,7 @@ from starlette.status import HTTP_401_UNAUTHORIZED
 from stitch.auth import JWTValidator, OIDCSettings, TokenClaims
 from stitch.auth.errors import AuthError, JWKSFetchError
 
-from stitch.api.db.config import UnitOfWorkDep
+from stitch.api.db.config import SessionFactoryDep
 from stitch.api.db.model.user import User as UserModel
 from stitch.api.entities import User
 from stitch.api.settings import get_settings
@@ -109,37 +109,48 @@ async def get_token_claims(
 Claims = Annotated[TokenClaims, Depends(get_token_claims)]
 
 
-async def get_current_user(claims: Claims, uow: UnitOfWorkDep) -> User:
+async def get_current_user(
+    claims: Claims, session_factory: SessionFactoryDep
+) -> User:
     """Resolve TokenClaims to a User entity. JIT provision on first login.
 
-    Race-safe: uses a savepoint so concurrent first-login requests
-    don't corrupt the outer transaction on IntegrityError.
+    Runs in a dedicated session so user creation and claim back-fill
+    persist even if the request handler later errors. On IntegrityError,
+    re-queries by sub: a found row means a concurrent first-login won the
+    race; not finding the row means an unrelated constraint failed and the
+    original exception is re-raised so it isn't masked.
     """
-    session = uow.session
+    async with session_factory() as session:
+        try:
+            user_model = (
+                await session.execute(
+                    select(UserModel).where(UserModel.sub == claims.sub)
+                )
+            ).scalar_one_or_none()
 
-    user_model = (
-        await session.execute(select(UserModel).where(UserModel.sub == claims.sub))
-    ).scalar_one_or_none()
+            if user_model is not None:
+                user_model.name = claims.name or user_model.name
+                user_model.email = claims.email or user_model.email
+            else:
+                user_model = UserModel(
+                    sub=claims.sub,
+                    name=claims.name,
+                    email=claims.email,
+                )
+                session.add(user_model)
 
-    if user_model is not None:
-        user_model.name = claims.name or user_model.name
-        user_model.email = claims.email or user_model.email
+            await session.commit()
+        except IntegrityError:
+            await session.rollback()
+            user_model = (
+                await session.execute(
+                    select(UserModel).where(UserModel.sub == claims.sub)
+                )
+            ).scalar_one_or_none()
+            if user_model is None:
+                raise
+
         return _to_entity(user_model)
-
-    try:
-        async with session.begin_nested():
-            user_model = UserModel(
-                sub=claims.sub,
-                name=claims.name,
-                email=claims.email,
-            )
-            session.add(user_model)
-    except IntegrityError:
-        user_model = (
-            await session.execute(select(UserModel).where(UserModel.sub == claims.sub))
-        ).scalar_one()
-
-    return _to_entity(user_model)
 
 
 def _to_entity(model: UserModel) -> User:

--- a/deployments/api/src/stitch/api/auth.py
+++ b/deployments/api/src/stitch/api/auth.py
@@ -109,9 +109,7 @@ async def get_token_claims(
 Claims = Annotated[TokenClaims, Depends(get_token_claims)]
 
 
-async def get_current_user(
-    claims: Claims, session_factory: SessionFactoryDep
-) -> User:
+async def get_current_user(claims: Claims, session_factory: SessionFactoryDep) -> User:
     """Resolve TokenClaims to a User entity. JIT provision on first login.
 
     Runs in a dedicated session so user creation and claim back-fill

--- a/deployments/api/src/stitch/api/db/model/user.py
+++ b/deployments/api/src/stitch/api/db/model/user.py
@@ -9,5 +9,5 @@ class User(Base):
 
     id: Mapped[int] = mapped_column(primary_key=True)
     sub: Mapped[str] = mapped_column(String(255), nullable=False, index=True)
-    name: Mapped[str]
-    email: Mapped[str]
+    name: Mapped[str | None] = mapped_column(String(255), nullable=True)
+    email: Mapped[str | None] = mapped_column(String(255), nullable=True)

--- a/deployments/api/src/stitch/api/entities.py
+++ b/deployments/api/src/stitch/api/entities.py
@@ -3,7 +3,7 @@ from datetime import datetime
 from enum import StrEnum
 from typing import Literal
 
-from pydantic import BaseModel, EmailStr, Field, computed_field
+from pydantic import BaseModel, Field, computed_field
 
 from stitch.ogsi.model import GEM_SRC, LLM_SRC, RMI_SRC, WM_SRC
 from stitch.ogsi.model.types import (
@@ -34,8 +34,8 @@ class User(BaseModel):
     id: int = Field(...)
     sub: str = Field(...)
     role: str | None = None
-    email: EmailStr
-    name: str
+    email: str | None = None
+    name: str | None = None
 
 
 class PaginationParams(BaseModel):

--- a/deployments/api/tests/test_auth_integration.py
+++ b/deployments/api/tests/test_auth_integration.py
@@ -203,9 +203,7 @@ class TestGetCurrentUserJITProvisioning:
     ):
         """Claim back-fill persists even if the caller's transaction rolls back."""
         async with integration_session_factory() as session:
-            session.add(
-                UserModel(sub="auth0|durable-backfill", name=None, email=None)
-            )
+            session.add(UserModel(sub="auth0|durable-backfill", name=None, email=None))
             await session.commit()
 
         claims = _make_claims(

--- a/deployments/api/tests/test_auth_integration.py
+++ b/deployments/api/tests/test_auth_integration.py
@@ -2,7 +2,6 @@
 
 import pytest
 from sqlalchemy import select
-from sqlalchemy.exc import NoResultFound
 
 
 from stitch.auth import TokenClaims
@@ -14,8 +13,8 @@ from stitch.api.db.model.user import User as UserModel
 
 def _make_claims(
     sub: str = "auth0|user-1",
-    email: str = "user@example.com",
-    name: str = "Test User",
+    email: str | None = "user@example.com",
+    name: str | None = "Test User",
 ) -> TokenClaims:
     return TokenClaims(sub=sub, email=email, name=name, raw={})
 
@@ -103,18 +102,57 @@ class TestGetCurrentUserJITProvisioning:
             assert row.email == "new@example.com"
 
     @pytest.mark.anyio
-    async def test_error_when_missing_claim(
+    async def test_creates_user_with_null_claims(
         self,
         integration_session_factory,
     ):
-        """Name defaults to empty string when claims.name is None."""
-        claims = TokenClaims(
-            sub="auth0|no-name", email="valid@example.com", name=None, raw={}
+        """User can be JIT-provisioned when name and email claims are absent."""
+        claims = _make_claims(sub="auth0|no-claims", email=None, name=None)
+
+        async with UnitOfWork(integration_session_factory) as uow:
+            user = await get_current_user(claims, uow)
+
+        assert user.sub == "auth0|no-claims"
+        assert user.email is None
+        assert user.name is None
+
+        async with integration_session_factory() as session:
+            row = (
+                await session.execute(
+                    select(UserModel).where(UserModel.sub == "auth0|no-claims")
+                )
+            ).scalar_one()
+            assert row.email is None
+            assert row.name is None
+
+    @pytest.mark.anyio
+    async def test_backfills_missing_fields_on_subsequent_login(
+        self,
+        integration_session_factory,
+    ):
+        """Null name/email columns get populated when later claims provide them."""
+        async with integration_session_factory() as session:
+            session.add(UserModel(sub="auth0|backfill", name=None, email=None))
+            await session.commit()
+
+        claims = _make_claims(
+            sub="auth0|backfill", name="Filled In", email="filled@example.com"
         )
 
         async with UnitOfWork(integration_session_factory) as uow:
-            with pytest.raises(NoResultFound):
-                await get_current_user(claims, uow)
+            user = await get_current_user(claims, uow)
+
+        assert user.name == "Filled In"
+        assert user.email == "filled@example.com"
+
+        async with integration_session_factory() as session:
+            row = (
+                await session.execute(
+                    select(UserModel).where(UserModel.sub == "auth0|backfill")
+                )
+            ).scalar_one()
+            assert row.name == "Filled In"
+            assert row.email == "filled@example.com"
 
     @pytest.mark.anyio
     async def test_handles_concurrent_first_login(

--- a/deployments/api/tests/test_auth_integration.py
+++ b/deployments/api/tests/test_auth_integration.py
@@ -1,7 +1,11 @@
 """Integration tests for auth module JIT user provisioning."""
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
 
 
 from stitch.auth import TokenClaims
@@ -30,8 +34,7 @@ class TestGetCurrentUserJITProvisioning:
         """New user created in DB on first login."""
         claims = _make_claims(sub="auth0|new-user")
 
-        async with UnitOfWork(integration_session_factory) as uow:
-            user = await get_current_user(claims, uow)
+        user = await get_current_user(claims, integration_session_factory)
 
         assert user.sub == "auth0|new-user"
         assert user.email == "user@example.com"
@@ -64,8 +67,7 @@ class TestGetCurrentUserJITProvisioning:
             sub="auth0|existing", name="Updated", email="new@example.com"
         )
 
-        async with UnitOfWork(integration_session_factory) as uow:
-            user = await get_current_user(claims, uow)
+        user = await get_current_user(claims, integration_session_factory)
 
         assert user.sub == "auth0|existing"
         assert user.name == "Updated"
@@ -89,8 +91,7 @@ class TestGetCurrentUserJITProvisioning:
             sub="auth0|updatable", name="New Name", email="new@example.com"
         )
 
-        async with UnitOfWork(integration_session_factory) as uow:
-            await get_current_user(claims, uow)
+        await get_current_user(claims, integration_session_factory)
 
         async with integration_session_factory() as session:
             row = (
@@ -109,8 +110,7 @@ class TestGetCurrentUserJITProvisioning:
         """User can be JIT-provisioned when name and email claims are absent."""
         claims = _make_claims(sub="auth0|no-claims", email=None, name=None)
 
-        async with UnitOfWork(integration_session_factory) as uow:
-            user = await get_current_user(claims, uow)
+        user = await get_current_user(claims, integration_session_factory)
 
         assert user.sub == "auth0|no-claims"
         assert user.email is None
@@ -139,8 +139,7 @@ class TestGetCurrentUserJITProvisioning:
             sub="auth0|backfill", name="Filled In", email="filled@example.com"
         )
 
-        async with UnitOfWork(integration_session_factory) as uow:
-            user = await get_current_user(claims, uow)
+        user = await get_current_user(claims, integration_session_factory)
 
         assert user.name == "Filled In"
         assert user.email == "filled@example.com"
@@ -172,7 +171,90 @@ class TestGetCurrentUserJITProvisioning:
             sub="auth0|race-user", name="Racer", email="racer@example.com"
         )
 
-        async with UnitOfWork(integration_session_factory) as uow:
-            user = await get_current_user(claims, uow)
+        user = await get_current_user(claims, integration_session_factory)
 
         assert user.sub == "auth0|race-user"
+
+    @pytest.mark.anyio
+    async def test_provisioning_survives_caller_rollback(
+        self,
+        integration_session_factory,
+    ):
+        """JIT-provisioned user persists even if the caller's transaction rolls back."""
+        claims = _make_claims(sub="auth0|durable")
+
+        with pytest.raises(RuntimeError):
+            async with UnitOfWork(integration_session_factory):
+                await get_current_user(claims, integration_session_factory)
+                raise RuntimeError("simulated handler failure")
+
+        async with integration_session_factory() as session:
+            row = (
+                await session.execute(
+                    select(UserModel).where(UserModel.sub == "auth0|durable")
+                )
+            ).scalar_one()
+            assert row.sub == "auth0|durable"
+
+    @pytest.mark.anyio
+    async def test_backfill_survives_caller_rollback(
+        self,
+        integration_session_factory,
+    ):
+        """Claim back-fill persists even if the caller's transaction rolls back."""
+        async with integration_session_factory() as session:
+            session.add(
+                UserModel(sub="auth0|durable-backfill", name=None, email=None)
+            )
+            await session.commit()
+
+        claims = _make_claims(
+            sub="auth0|durable-backfill",
+            name="Filled",
+            email="filled@example.com",
+        )
+
+        with pytest.raises(RuntimeError):
+            async with UnitOfWork(integration_session_factory):
+                await get_current_user(claims, integration_session_factory)
+                raise RuntimeError("simulated handler failure")
+
+        async with integration_session_factory() as session:
+            row = (
+                await session.execute(
+                    select(UserModel).where(UserModel.sub == "auth0|durable-backfill")
+                )
+            ).scalar_one()
+            assert row.name == "Filled"
+            assert row.email == "filled@example.com"
+
+
+class TestGetCurrentUserIntegrityErrorHandling:
+    """Unit tests for narrowed IntegrityError recovery."""
+
+    @pytest.mark.anyio
+    async def test_unrelated_integrity_error_propagates(self):
+        """An IntegrityError without a concurrent row must propagate, not be masked."""
+        miss_result = MagicMock()
+        miss_result.scalar_one_or_none = MagicMock(return_value=None)
+
+        session = MagicMock(spec=AsyncSession)
+        session.execute = AsyncMock(return_value=miss_result)
+        session.add = MagicMock()
+        session.commit = AsyncMock(
+            side_effect=IntegrityError(
+                "INSERT INTO users", {}, Exception("simulated check constraint")
+            )
+        )
+        session.rollback = AsyncMock()
+        session.__aenter__ = AsyncMock(return_value=session)
+        session.__aexit__ = AsyncMock(return_value=None)
+
+        factory = MagicMock(return_value=session)
+
+        claims = _make_claims(sub="auth0|broken")
+
+        with pytest.raises(IntegrityError):
+            await get_current_user(claims, factory)
+
+        session.rollback.assert_awaited_once()

--- a/env.example
+++ b/env.example
@@ -8,8 +8,13 @@ STITCH_LLM_LOG_LEVEL=info
 # ------------------------------
 
 # API
-AUTH_DISABLED=true
 ENVIRONMENT=DevelopmentDocker
+
+# API Auth
+AUTH_DISABLED=true
+# AUTH_ISSUER="https://<domain>.<region>.auth0.com/"
+# AUTH_AUDIENCE="https://<audienc>"
+# AUTH_JWKS_URI="https:/<domain>.<region>.auth0.com/.well-known/jwks.json"
 
 # ------------------------------
 


### PR DESCRIPTION
- Makes `name` and `email` nullable on `users` table. User identity is now pegged just to `sub` and `id`, but since no auditing features exist (yet), we can handle this later.
- provisions users in separate session/transaction so users still persist if the rest of the request fails

**Verification**
 - additional unit tests
- Full local setup with `AUTH_DISABLED=false` & hack to add my personal bearer token to the `seed` container's env (not committed). Seed populates, entity linkage an LLM backfill fully functional.