### PR TITLE
feat(api): gate source data on licensed permission claim [STIT-334]

### DIFF
--- a/deployments/api/src/stitch/api/auth.py
+++ b/deployments/api/src/stitch/api/auth.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from functools import lru_cache
-from typing import Annotated
+from typing import Annotated, get_args
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -11,6 +11,7 @@ from starlette.status import HTTP_401_UNAUTHORIZED
 
 from stitch.auth import JWTValidator, OIDCSettings, TokenClaims
 from stitch.auth.errors import AuthError, JWKSFetchError
+from stitch.ogsi.model.types import OGSISrcKey
 
 from stitch.api.db.config import SessionFactoryDep
 from stitch.api.db.model.user import User as UserModel
@@ -34,6 +35,9 @@ _DEV_CLAIMS = TokenClaims(
     sub="dev|local-placeholder",
     email="dev@example.com",
     name="Dev User",
+    permissions=frozenset(
+        f"resource:read:licensed:{src}" for src in get_args(OGSISrcKey)
+    ),
     raw={},
 )
 
@@ -87,7 +91,7 @@ async def get_token_claims(
 
     validator = get_jwt_validator()
     try:
-        return await asyncio.to_thread(validator.validate, token)
+        claims = await asyncio.to_thread(validator.validate, token)
     except JWKSFetchError:
         logger.error(
             "JWKS endpoint unreachable or returned invalid data", exc_info=True
@@ -104,6 +108,12 @@ async def get_token_claims(
             detail="Invalid or expired token",
             headers={"WWW-Authenticate": "Bearer"},
         )
+
+    if not claims.permissions:
+        logger.warning(
+            "authenticated token has no permissions; user will see null-shell data"
+        )
+    return claims
 
 
 Claims = Annotated[TokenClaims, Depends(get_token_claims)]

--- a/deployments/api/src/stitch/api/db/model/og_field_query_mixin.py
+++ b/deployments/api/src/stitch/api/db/model/og_field_query_mixin.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import Any, ClassVar, Self
 
 from sqlalchemy import (
@@ -24,6 +24,7 @@ from stitch.api.entities import OGFieldQueryParams, OGSI_SOURCE_DEFAULT
 from stitch.ogsi.model import LocationType
 from stitch.ogsi.model.types import (
     FieldStatus,
+    OGSISrcKey,
     PrimaryHydrocarbonGroup,
     ProductionConventionality,
 )
@@ -103,9 +104,10 @@ class OGFieldQueryMixin:
         cls,
         session: AsyncSession,
         params: OGFieldQueryParams,
+        licensed_sources: Collection[OGSISrcKey] | None = None,
     ) -> Sequence[Self]:
         """Execute a filtered, sorted, paginated query and return (rows, total)."""
-        base = cls._base_query(params)
+        base = cls._base_query(params, licensed_sources=licensed_sources)
         stmt = cls._apply_pagination(base, params)
         rows = (await session.scalars(stmt)).all()
         return rows
@@ -115,12 +117,15 @@ class OGFieldQueryMixin:
         cls,
         session: AsyncSession,
         params: OGFieldQueryParams | None = None,
+        licensed_sources: Collection[OGSISrcKey] | None = None,
     ) -> int:
         """Return the total number of matching rows (unfiltered when params is None)."""
         if params is None:
             stmt = select(func.count()).select_from(cls)
         else:
-            stmt = select(func.count()).select_from(cls._base_query(params).subquery())
+            stmt = select(func.count()).select_from(
+                cls._base_query(params, licensed_sources=licensed_sources).subquery()
+            )
         return await session.scalar(stmt) or 0
 
     # ------------------------------------------------------------------
@@ -131,20 +136,32 @@ class OGFieldQueryMixin:
 
     @classmethod
     def _base_query[QM: OGFieldQueryMixin](
-        cls: type[QM], params: OGFieldQueryParams
+        cls: type[QM],
+        params: OGFieldQueryParams,
+        licensed_sources: Collection[OGSISrcKey] | None = None,
     ) -> Select[tuple[QM]]:
         """Filtered + sorted SELECT with no pagination.
 
         Override this in subclasses to modify the FROM clause (e.g. add joins).
         """
         stmt: Select[tuple[QM]] = select(cls).distinct()
-        for cond in cls._build_conditions(params):
+        for cond in cls._build_conditions(params, licensed_sources=licensed_sources):
             stmt = stmt.where(cond)
         return stmt.order_by(*cls._create_sort_clauses(params))
 
     @classmethod
-    def _build_conditions(cls, params: OGFieldQueryParams) -> list[ColumnElement[bool]]:
-        """Build WHERE conditions from filter params."""
+    def _build_conditions(
+        cls,
+        params: OGFieldQueryParams,
+        licensed_sources: Collection[OGSISrcKey] | None = None,
+    ) -> list[ColumnElement[bool]]:
+        """Build WHERE conditions from filter params.
+
+        ``params.source`` and ``licensed_sources`` are conceptually distinct:
+        the former is the user-requested existence filter; the latter is the
+        server-derived data-access filter. They are applied as separate
+        predicates so the intent stays explicit.
+        """
         conditions: list[ColumnElement[bool]] = []
 
         if params.q:
@@ -170,6 +187,8 @@ class OGFieldQueryMixin:
                 dict.fromkeys(getattr(params, "source", OGSI_SOURCE_DEFAULT))
             )
             conditions.append(source_col.in_(sources))
+            if licensed_sources is not None:
+                conditions.append(source_col.in_(list(dict.fromkeys(licensed_sources))))
 
         return conditions
 

--- a/deployments/api/src/stitch/api/db/model/oil_gas_field_source.py
+++ b/deployments/api/src/stitch/api/db/model/oil_gas_field_source.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from typing import Any, ClassVar, override
 
 from pydantic import TypeAdapter
@@ -46,7 +46,11 @@ class OilGasFieldSourceModel(OGFieldQueryMixin, TimestampMixin, UserAuditMixin, 
 
     @classmethod
     @override
-    def _base_query(cls, params: OGFieldQueryParams):
+    def _base_query(
+        cls,
+        params: OGFieldQueryParams,
+        licensed_sources: Collection[OGSISrcKey] | None = None,
+    ):
         """Filter to sources with at least one active membership."""
 
         active_membership = (
@@ -56,7 +60,7 @@ class OilGasFieldSourceModel(OGFieldQueryMixin, TimestampMixin, UserAuditMixin, 
             .exists()
         )
         stmt = select(cls).where(active_membership)
-        for cond in cls._build_conditions(params):
+        for cond in cls._build_conditions(params, licensed_sources=licensed_sources):
             stmt = stmt.where(cond)
         return stmt.order_by(*cls._create_sort_clauses(params))
 

--- a/deployments/api/src/stitch/api/db/og_field_resource_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_resource_actions.py
@@ -62,16 +62,16 @@ def _priority_values() -> tuple[int, ...]:
 async def query(
     session: AsyncSession,
     params: OGFieldQueryParams,
-    redacted_sources: Collection[OGSISrcKey] = (),
+    licensed_sources: Collection[OGSISrcKey] | None = None,
 ) -> tuple[list[OGFieldListItemView], int]:
-    """Query redaction-aware coalesced resource list items with provenance."""
+    """Query coalesced resource list items, restricted to licensed sources."""
     if params.sort_by == "source":
         raise HTTPException(
             status_code=422,
             detail="sort_by=source is not supported for resource list queries.",
         )
 
-    coalesced = _build_redacted_resource_list_cte(params, redacted_sources)
+    coalesced = _build_licensed_resource_list_cte(params, licensed_sources)
     filtered = select(coalesced)
     for condition in _build_final_conditions(coalesced, params):
         filtered = filtered.where(condition)
@@ -89,9 +89,9 @@ async def query(
     return [_list_item_from_row(row) for row in rows], total
 
 
-def _build_redacted_resource_list_cte(
+def _build_licensed_resource_list_cte(
     params: OGFieldQueryParams,
-    redacted_sources: Collection[OGSISrcKey],
+    licensed_sources: Collection[OGSISrcKey] | None,
 ):
     s = OilGasFieldSourceModel
     m = MembershipModel
@@ -99,13 +99,14 @@ def _build_redacted_resource_list_cte(
     p = OGFieldSourcePriority
 
     selected_sources = list(dict.fromkeys(params.source))
-    redacted = list(dict.fromkeys(redacted_sources))
     source_join_conditions = [
         s.id == m.source_pk,
         s.source == m.source,
     ]
-    if redacted:
-        source_join_conditions.append(s.source.not_in(redacted))
+    if licensed_sources is not None:
+        source_join_conditions.append(
+            s.source.in_(list(dict.fromkeys(licensed_sources)))
+        )
 
     qualified = (
         select(
@@ -189,7 +190,7 @@ def _build_redacted_resource_list_cte(
             provenance_subquery.label(f"{field_name}{_PROVENANCE_SUFFIX}"),
         )
 
-    return coalesced.cte("redacted_resource_list")
+    return coalesced.cte("licensed_resource_list")
 
 
 def _json_value_is_present(col) -> ColumnElement[bool]:
@@ -254,7 +255,11 @@ def _list_item_from_row(row: RowMapping) -> OGFieldListItemView:
     return OGFieldListItemView(id=row["id"], data=data, provenance=provenance)
 
 
-async def get(session: AsyncSession, id: int) -> OGFieldResource:
+async def get(
+    session: AsyncSession,
+    id: int,
+    licensed_sources: Collection[OGSISrcKey] | None = None,
+) -> OGFieldResource:
     stmt = (
         select(ResourceModel)
         .options(selectinload(ResourceModel.memberships))
@@ -266,7 +271,9 @@ async def get(session: AsyncSession, id: int) -> OGFieldResource:
             status_code=HTTP_404_NOT_FOUND, detail=f"No Resource with id `{id}` found."
         )
     await session.refresh(model, ["memberships"])
-    return await resource_model_to_entity(session, model)
+    return await resource_model_to_entity(
+        session, model, licensed_sources=licensed_sources
+    )
 
 
 async def create(

--- a/deployments/api/src/stitch/api/db/og_field_source_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_source_actions.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 
 from sqlalchemy import select
 
@@ -12,6 +12,7 @@ from stitch.api.db.errors import (
 from stitch.api.db.utils import partition_by_id_none
 from stitch.api.entities import OGFieldQueryParams, User
 from stitch.ogsi.model import OGFieldSource, OGFieldResource
+from stitch.ogsi.model.types import OGSISrcKey
 
 from .model import (
     OilGasFieldSourceModel,
@@ -123,9 +124,16 @@ async def attach_sources_to_resource(
     return await resource_model_to_entity(session, resource)
 
 
-async def get_source(session: AsyncSession, id: int) -> OGFieldSource:
+async def get_source(
+    session: AsyncSession,
+    id: int,
+    licensed_sources: Collection[OGSISrcKey] | None = None,
+) -> OGFieldSource:
     model = await session.get(OilGasFieldSourceModel, id)
     if model is None:
+        raise SourceNotFoundError(f"No OG Field Source found for id `{id}`")
+    if licensed_sources is not None and model.source not in licensed_sources:
+        # Hide existence of unlicensed source rows.
         raise SourceNotFoundError(f"No OG Field Source found for id `{id}`")
     return model.as_entity()
 
@@ -141,7 +149,12 @@ async def get_sources(
 async def query(
     session: AsyncSession,
     params: OGFieldQueryParams,
+    licensed_sources: Collection[OGSISrcKey] | None = None,
 ) -> tuple[Sequence[OGFieldSource], int]:
-    models = await OilGasFieldSourceModel.query(session, params)
-    total = await OilGasFieldSourceModel.count(session, params)
+    models = await OilGasFieldSourceModel.query(
+        session, params, licensed_sources=licensed_sources
+    )
+    total = await OilGasFieldSourceModel.count(
+        session, params, licensed_sources=licensed_sources
+    )
     return tuple(m.as_entity() for m in models), total

--- a/deployments/api/src/stitch/api/db/utils.py
+++ b/deployments/api/src/stitch/api/db/utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Sequence
+from collections.abc import Collection, Sequence
 from functools import reduce
 from typing import Protocol
 
@@ -35,9 +35,15 @@ def partition_by_id_none[T: Identified](
 
 
 async def resource_model_to_entity(
-    session: AsyncSession, model: ResourceModel
+    session: AsyncSession,
+    model: ResourceModel,
+    licensed_sources: Collection[OGSISrcKey] | None = None,
 ) -> OGFieldResource:
     src_data = await model.get_source_data(session)
+    # Write paths must pass licensed_sources=None: the returned entity
+    # feeds back into resource construction and must not be redacted.
+    if licensed_sources is not None:
+        src_data = [s for s in src_data if s.source in licensed_sources]
     constituent_models = await ResourceModel.get_constituents_by_root_id(
         session, model.id
     )

--- a/deployments/api/src/stitch/api/permissions/__init__.py
+++ b/deployments/api/src/stitch/api/permissions/__init__.py
@@ -27,5 +27,5 @@ def licensed_sources(claims: TokenClaims) -> frozenset[OGSISrcKey]:
         if candidate in _VALID_SOURCES:
             out.add(cast(OGSISrcKey, candidate))
         else:
-            logger.debug("ignoring unknown source in permission: %r", perm)
+            logger.warning("ignoring unknown source in permission: %r", perm)
     return frozenset(out)

--- a/deployments/api/src/stitch/api/permissions/__init__.py
+++ b/deployments/api/src/stitch/api/permissions/__init__.py
@@ -1,0 +1,31 @@
+"""Auth0 permission claim parsing.
+
+All knowledge of permission-string grammar lives here. Callers receive a
+typed `frozenset[OGSISrcKey]`; new permission shapes are added as new
+free functions in this module without touching the rest of the API.
+"""
+
+import logging
+from typing import cast, get_args
+
+from stitch.auth import TokenClaims
+from stitch.ogsi.model.types import OGSISrcKey
+
+logger = logging.getLogger(__name__)
+
+_LICENSED_PREFIX = "resource:read:licensed:"
+_VALID_SOURCES: frozenset[str] = frozenset(get_args(OGSISrcKey))
+
+
+def licensed_sources(claims: TokenClaims) -> frozenset[OGSISrcKey]:
+    """Return the set of OGSI sources the caller is licensed to read."""
+    out: set[OGSISrcKey] = set()
+    for perm in claims.permissions:
+        if not perm.startswith(_LICENSED_PREFIX):
+            continue
+        candidate = perm[len(_LICENSED_PREFIX) :]
+        if candidate in _VALID_SOURCES:
+            out.add(cast(OGSISrcKey, candidate))
+        else:
+            logger.debug("ignoring unknown source in permission: %r", perm)
+    return frozenset(out)

--- a/deployments/api/src/stitch/api/routers/oil_gas_field_sources.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_field_sources.py
@@ -2,16 +2,18 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, HTTPException, Query
 from stitch.ogsi.model import OGFieldSource
 
-from stitch.api.auth import CurrentUser
+from stitch.api.auth import Claims, CurrentUser
 from stitch.api.db import og_field_source_actions
 from stitch.api.db.config import UnitOfWorkDep
+from stitch.api.db.errors import SourceNotFoundError
 from stitch.api.entities import (
     OGFieldQueryParams,
     PaginatedResponse,
 )
+from stitch.api.permissions import licensed_sources
 
 router = APIRouter(prefix="/oil-gas-field-sources", tags=["oil_gas_field_sources"])
 
@@ -43,10 +45,13 @@ async def create_oil_gas_field_source(
 async def query_oil_gas_field_sources(
     uow: UnitOfWorkDep,
     user: CurrentUser,
+    claims: Claims,
     params: Annotated[OGFieldQueryParams, Query()],
 ) -> PaginatedResponse[OGFieldSource]:
     items, total_count = await og_field_source_actions.query(
-        session=uow.session, params=params
+        session=uow.session,
+        params=params,
+        licensed_sources=licensed_sources(claims),
     )
     return PaginatedResponse(
         items=list(items),
@@ -57,5 +62,14 @@ async def query_oil_gas_field_sources(
 
 
 @router.get("/{id}", response_model=OGFieldSource)
-async def get_oil_gas_field(id: int, uow: UnitOfWorkDep, user: CurrentUser):
-    return await og_field_source_actions.get_source(session=uow.session, id=id)
+async def get_oil_gas_field(
+    id: int, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims
+):
+    try:
+        return await og_field_source_actions.get_source(
+            session=uow.session,
+            id=id,
+            licensed_sources=licensed_sources(claims),
+        )
+    except SourceNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc))

--- a/deployments/api/src/stitch/api/routers/oil_gas_fields.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_fields.py
@@ -20,11 +20,12 @@ from stitch.api.db.errors import (
     ResourceNotFoundError,
     ResourceIntegrityError,
 )
-from stitch.api.auth import CurrentUser
+from stitch.api.auth import Claims, CurrentUser
 from stitch.api.db.utils import (
     resource_to_view,
     resource_to_detail_view,
 )
+from stitch.api.permissions import licensed_sources
 
 from stitch.ogsi.model import (
     OGFieldDetailView,
@@ -48,10 +49,13 @@ async def get_all_resources(
     *,
     uow: UnitOfWorkDep,
     _user: CurrentUser,
+    claims: Claims,
     params: Annotated[OGFieldQueryParams, Query()],
 ) -> PaginatedResponse[OGFieldListItemView]:
     items, total_count = await resource_actions.query(
-        session=uow.session, params=params
+        session=uow.session,
+        params=params,
+        licensed_sources=licensed_sources(claims),
     )
     return PaginatedResponse(
         items=items,
@@ -204,17 +208,21 @@ async def deny_merge_candidate(
 
 @router.get("/{id}", response_model=OGFieldView)
 async def get_resource(
-    *, uow: UnitOfWorkDep, user: CurrentUser, id: int
+    *, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims, id: int
 ) -> OGFieldView:
-    res: OGFieldResource = await resource_actions.get(session=uow.session, id=id)
+    res: OGFieldResource = await resource_actions.get(
+        session=uow.session, id=id, licensed_sources=licensed_sources(claims)
+    )
     return resource_to_view(resource=res)
 
 
 @router.get("/{id}/detail", response_model=OGFieldDetailView)
 async def get_resource_detail(
-    *, uow: UnitOfWorkDep, user: CurrentUser, id: int
+    *, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims, id: int
 ) -> OGFieldDetailView:
-    res: OGFieldResource = await resource_actions.get(session=uow.session, id=id)
+    res: OGFieldResource = await resource_actions.get(
+        session=uow.session, id=id, licensed_sources=licensed_sources(claims)
+    )
     return resource_to_detail_view(resource=res)
 
 

--- a/deployments/api/tests/conftest.py
+++ b/deployments/api/tests/conftest.py
@@ -2,6 +2,7 @@
 
 from collections.abc import AsyncIterator
 from functools import partial
+from typing import get_args
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -9,16 +10,29 @@ from httpx import ASGITransport, AsyncClient
 from polyfactory.pytest_plugin import register_fixture
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from stitch.auth import TokenClaims
+from stitch.ogsi.model.types import OGSISrcKey
+
 from stitch.api.db.config import UnitOfWork, get_uow
 from stitch.api.db.model import (
     StitchBase,
     UserModel,
 )
-from stitch.api.auth import get_current_user
+from stitch.api.auth import get_current_user, get_token_claims
 from stitch.api.entities import User
 from stitch.api.main import app
 from .factories import OGFieldBaseFactory, ResourceFactory
 from .utils import make_create_resource, make_resource, make_source
+
+
+_ALL_LICENSED_CLAIMS = TokenClaims(
+    sub="test|user-1",
+    email="test@test.com",
+    name="Test User",
+    permissions=frozenset(
+        f"resource:read:licensed:{src}" for src in get_args(OGSISrcKey)
+    ),
+)
 
 
 @pytest.fixture
@@ -97,7 +111,11 @@ async def async_client(test_user: User) -> AsyncIterator[AsyncClient]:
     def override_get_current_user() -> User:
         return test_user
 
+    def override_get_token_claims() -> TokenClaims:
+        return _ALL_LICENSED_CLAIMS
+
     app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_token_claims] = override_get_token_claims
 
     async with AsyncClient(
         transport=ASGITransport(app=app),
@@ -172,8 +190,12 @@ async def integration_client(
     def override_get_current_user() -> User:
         return test_user
 
+    def override_get_token_claims() -> TokenClaims:
+        return _ALL_LICENSED_CLAIMS
+
     app.dependency_overrides[get_uow] = override_get_uow
     app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_token_claims] = override_get_token_claims
 
     async with AsyncClient(
         transport=ASGITransport(app=app),

--- a/deployments/api/tests/db/test_resource_actions.py
+++ b/deployments/api/tests/db/test_resource_actions.py
@@ -389,7 +389,59 @@ class TestResourceQueryAction:
         assert items[0].provenance["operators"] == "rmi"
 
     @pytest.mark.anyio
-    async def test_redacted_owner_operator_lists_fall_through_to_lower_priority_source(
+    async def test_licensed_sources_none_returns_all(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        """``licensed_sources=None`` must be a no-op preserving every membership."""
+        resource_id = await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+            {"source": "gem", "name": "GEM Name", "country": "CAN"},
+        )
+
+        params = _QueryParams(page=1, page_size=10)
+        items, total = await resource_actions.query(
+            seeded_integration_session, params, licensed_sources=None
+        )
+
+        assert total == 1
+        assert [item.id for item in items] == [resource_id]
+        assert items[0].data.name == "RMI Name"
+        assert items[0].provenance["name"] == "rmi"
+
+    @pytest.mark.anyio
+    async def test_licensed_sources_empty_returns_null_shells_for_all(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        """An empty allowlist still returns rows, but with null-shell data."""
+        resource_id = await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+            {"source": "gem", "name": "GEM Name", "country": "CAN"},
+        )
+
+        params = _QueryParams(page=1, page_size=10)
+        items, total = await resource_actions.query(
+            seeded_integration_session,
+            params,
+            licensed_sources=frozenset(),
+        )
+
+        assert total == 1
+        assert [item.id for item in items] == [resource_id]
+        assert items[0].data.name is None
+        assert items[0].data.country is None
+        assert items[0].provenance["name"] is None
+        assert items[0].provenance["country"] is None
+
+    @pytest.mark.anyio
+    async def test_unlicensed_owner_operator_lists_fall_through_to_lower_priority_source(
         self,
         seeded_integration_session: AsyncSession,
         test_user: User,
@@ -417,7 +469,7 @@ class TestResourceQueryAction:
         items, total = await resource_actions.query(
             seeded_integration_session,
             params,
-            redacted_sources=["rmi"],
+            licensed_sources=frozenset({"gem", "wm", "llm"}),
         )
 
         assert total == 1
@@ -434,7 +486,7 @@ class TestResourceQueryAction:
         assert items[0].provenance["operators"] == "gem"
 
     @pytest.mark.anyio
-    async def test_redacted_source_falls_through_to_lower_priority_source(
+    async def test_unlicensed_source_falls_through_to_lower_priority_source(
         self,
         seeded_integration_session: AsyncSession,
         test_user: User,
@@ -450,7 +502,7 @@ class TestResourceQueryAction:
         items, total = await resource_actions.query(
             seeded_integration_session,
             params,
-            redacted_sources=["wm"],
+            licensed_sources=frozenset({"rmi", "gem", "llm"}),
         )
 
         assert total == 1
@@ -459,7 +511,7 @@ class TestResourceQueryAction:
         assert items[0].provenance["name"] == "llm"
 
     @pytest.mark.anyio
-    async def test_only_redacted_selected_sources_still_return_resource(
+    async def test_only_unlicensed_selected_sources_still_return_resource(
         self,
         seeded_integration_session: AsyncSession,
         test_user: User,
@@ -474,7 +526,7 @@ class TestResourceQueryAction:
         items, total = await resource_actions.query(
             seeded_integration_session,
             params,
-            redacted_sources=["wm"],
+            licensed_sources=frozenset({"rmi", "gem", "llm"}),
         )
 
         assert total == 1
@@ -489,7 +541,7 @@ class TestResourceQueryAction:
         assert items[0].provenance["operators"] is None
 
     @pytest.mark.anyio
-    async def test_filters_apply_to_final_coalesced_values_after_redaction(
+    async def test_filters_apply_to_final_coalesced_values_after_licensing(
         self,
         seeded_integration_session: AsyncSession,
         test_user: User,
@@ -520,7 +572,7 @@ class TestResourceQueryAction:
         items, total = await resource_actions.query(
             seeded_integration_session,
             params,
-            redacted_sources=["rmi"],
+            licensed_sources=frozenset({"gem", "wm", "llm"}),
         )
 
         assert total == 1
@@ -529,7 +581,7 @@ class TestResourceQueryAction:
         assert items[0].provenance["state_province"] == "gem"
 
     @pytest.mark.anyio
-    async def test_count_is_after_redacted_coalesced_filter_before_pagination(
+    async def test_count_is_after_licensed_coalesced_filter_before_pagination(
         self,
         seeded_integration_session: AsyncSession,
         test_user: User,
@@ -555,7 +607,7 @@ class TestResourceQueryAction:
         items, total = await resource_actions.query(
             seeded_integration_session,
             params,
-            redacted_sources=["rmi"],
+            licensed_sources=frozenset({"gem", "wm", "llm"}),
         )
 
         assert total == 2

--- a/deployments/api/tests/permissions/test_licensed_sources.py
+++ b/deployments/api/tests/permissions/test_licensed_sources.py
@@ -1,0 +1,62 @@
+"""Tests for stitch.api.permissions.licensed_sources."""
+
+import logging
+
+from stitch.auth import TokenClaims
+
+from stitch.api.permissions import licensed_sources
+
+
+def _claims(*permissions: str) -> TokenClaims:
+    return TokenClaims(sub="test|user", permissions=frozenset(permissions))
+
+
+def test_empty_permissions_returns_empty_frozenset():
+    assert licensed_sources(_claims()) == frozenset()
+
+
+def test_single_valid_source():
+    assert licensed_sources(_claims("resource:read:licensed:rmi")) == frozenset({"rmi"})
+
+
+def test_multiple_valid_sources_deduped():
+    claims = _claims(
+        "resource:read:licensed:rmi",
+        "resource:read:licensed:gem",
+        "resource:read:licensed:rmi",
+    )
+    assert licensed_sources(claims) == frozenset({"rmi", "gem"})
+
+
+def test_malformed_permission_strings_ignored():
+    claims = _claims(
+        "no-prefix",
+        "resource:read:licensed:",  # empty source segment
+        "resource:read:licensed:rmi:extra",  # trailing segment is not a valid source
+    )
+    assert licensed_sources(claims) == frozenset()
+
+
+def test_unknown_source_value_ignored_with_debug_log(caplog):
+    with caplog.at_level(logging.DEBUG, logger="stitch.api.permissions"):
+        result = licensed_sources(_claims("resource:read:licensed:bogus"))
+    assert result == frozenset()
+    assert any("bogus" in rec.message for rec in caplog.records)
+
+
+def test_mixed_valid_and_unknown_only_keeps_valid():
+    claims = _claims(
+        "resource:read:licensed:rmi",
+        "resource:read:licensed:bogus",
+        "resource:read:licensed:wm",
+    )
+    assert licensed_sources(claims) == frozenset({"rmi", "wm"})
+
+
+def test_non_licensed_prefixes_ignored():
+    claims = _claims(
+        "resource:write:licensed:rmi",
+        "admin",
+        "resource:read:licensed:gem",
+    )
+    assert licensed_sources(claims) == frozenset({"gem"})

--- a/deployments/api/tests/routers/test_licensed_sources_routes.py
+++ b/deployments/api/tests/routers/test_licensed_sources_routes.py
@@ -1,0 +1,276 @@
+"""Route-level integration tests for licensed-source filtering."""
+
+from collections.abc import AsyncIterator
+
+import pytest
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
+
+from stitch.auth import TokenClaims
+
+from stitch.api.auth import get_current_user, get_token_claims
+from stitch.api.db.config import UnitOfWork, get_uow
+from stitch.api.db.model import (
+    MembershipModel,
+    MembershipStatus,
+    OilGasFieldSourceModel,
+    ResourceModel,
+    UserModel,
+)
+from stitch.api.entities import User
+from stitch.api.main import app
+
+
+def _gem_only_claims() -> TokenClaims:
+    return TokenClaims(
+        sub="test|user-1",
+        email="test@test.com",
+        name="Test User",
+        permissions=frozenset({"resource:read:licensed:gem"}),
+    )
+
+
+@pytest.fixture
+async def gem_only_client(
+    integration_session_factory: async_sessionmaker[AsyncSession],
+    test_user: User,
+    test_user_model: UserModel,
+) -> AsyncIterator[AsyncClient]:
+    """Client whose token claims license only the `gem` source."""
+    async with integration_session_factory() as session:
+        session.add(test_user_model)
+        await session.commit()
+
+    async def override_get_uow() -> AsyncIterator[UnitOfWork]:
+        async with UnitOfWork(integration_session_factory) as uow:
+            yield uow
+
+    def override_get_current_user() -> User:
+        return test_user
+
+    def override_get_token_claims() -> TokenClaims:
+        return _gem_only_claims()
+
+    app.dependency_overrides[get_uow] = override_get_uow
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_token_claims] = override_get_token_claims
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test/api/v1",
+    ) as ac:
+        yield ac
+
+
+async def _seed_resource_with_sources(
+    session_factory: async_sessionmaker[AsyncSession],
+    user: User,
+    *source_rows: dict,
+) -> int:
+    async with session_factory() as session:
+        resource = ResourceModel.create(created_by=user)
+        session.add(resource)
+        await session.flush()
+        for row in source_rows:
+            source = OilGasFieldSourceModel(
+                **row,
+                created_by_id=user.id,
+                last_updated_by_id=user.id,
+            )
+            session.add(source)
+            await session.flush()
+            session.add(
+                MembershipModel.create(
+                    created_by=user,
+                    resource_id=resource.id,
+                    source=source.source,
+                    source_pk=source.id,
+                    status=MembershipStatus.ACTIVE,
+                )
+            )
+        await session.commit()
+        return resource.id
+
+
+async def _source_id_for(
+    session_factory: async_sessionmaker[AsyncSession], src: str
+) -> int:
+    from sqlalchemy import select
+
+    async with session_factory() as session:
+        row = (
+            await session.execute(
+                select(OilGasFieldSourceModel).where(
+                    OilGasFieldSourceModel.source == src
+                )
+            )
+        ).scalar_one()
+        return row.id
+
+
+class TestOilGasFieldsLicensedSources:
+    @pytest.mark.anyio
+    async def test_list_returns_only_licensed_data(
+        self,
+        gem_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        gem_id = await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+            {"source": "gem", "name": "GEM Name", "country": "CAN"},
+        )
+        rmi_only_id = await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "rmi", "name": "Only RMI", "country": "USA"},
+        )
+
+        response = await gem_only_client.get("/oil-gas-fields/")
+
+        assert response.status_code == 200
+        data = response.json()
+        items = {item["id"]: item for item in data["items"]}
+        assert set(items.keys()) == {gem_id, rmi_only_id}
+
+        gem_item = items[gem_id]
+        assert gem_item["data"]["name"] == "GEM Name"
+        assert gem_item["data"]["country"] == "CAN"
+        assert gem_item["provenance"]["name"] == "gem"
+
+        null_item = items[rmi_only_id]
+        assert null_item["data"]["name"] is None
+        assert null_item["data"]["country"] is None
+        assert null_item["provenance"]["name"] is None
+
+    @pytest.mark.anyio
+    async def test_list_with_explicit_unlicensed_source_returns_existence_with_null_fields(
+        self,
+        gem_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        resource_id = await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "llm", "name": "LLM Name", "country": "USA"},
+        )
+
+        response = await gem_only_client.get("/oil-gas-fields/?source=llm")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 1
+        item = data["items"][0]
+        assert item["id"] == resource_id
+        assert item["data"]["name"] is None
+        assert item["data"]["country"] is None
+        assert item["provenance"]["name"] is None
+
+    @pytest.mark.anyio
+    async def test_get_resource_redacts_unlicensed_source_data(
+        self,
+        gem_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        resource_id = await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+            {"source": "gem", "name": "GEM Name", "country": "CAN"},
+        )
+
+        response = await gem_only_client.get(f"/oil-gas-fields/{resource_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["id"] == resource_id
+        assert data["name"] == "GEM Name"
+        assert data["country"] == "CAN"
+
+    @pytest.mark.anyio
+    async def test_get_detail_filters_source_data_to_licensed_only(
+        self,
+        gem_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        resource_id = await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+            {"source": "gem", "name": "GEM Name", "country": "CAN"},
+        )
+
+        response = await gem_only_client.get(f"/oil-gas-fields/{resource_id}/detail")
+
+        assert response.status_code == 200
+        data = response.json()
+        sources_in_detail = {sd["source"] for sd in data["source_data"]}
+        assert sources_in_detail == {"gem"}
+        assert data["data"]["name"] == "GEM Name"
+
+
+class TestOilGasFieldSourcesLicensedSources:
+    @pytest.mark.anyio
+    async def test_list_drops_unlicensed_rows(
+        self,
+        gem_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+            {"source": "gem", "name": "GEM Name", "country": "CAN"},
+        )
+
+        response = await gem_only_client.get("/oil-gas-field-sources/")
+
+        assert response.status_code == 200
+        data = response.json()
+        sources_returned = {item["source"] for item in data["items"]}
+        assert sources_returned == {"gem"}
+
+    @pytest.mark.anyio
+    async def test_get_unlicensed_source_returns_404(
+        self,
+        gem_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+        )
+        rmi_source_id = await _source_id_for(integration_session_factory, "rmi")
+
+        response = await gem_only_client.get(f"/oil-gas-field-sources/{rmi_source_id}")
+
+        assert response.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_get_licensed_source_returns_200(
+        self,
+        gem_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "gem", "name": "GEM Name", "country": "CAN"},
+        )
+        gem_source_id = await _source_id_for(integration_session_factory, "gem")
+
+        response = await gem_only_client.get(f"/oil-gas-field-sources/{gem_source_id}")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["source"] == "gem"
+        assert data["name"] == "GEM Name"


### PR DESCRIPTION
Wires the `resource:read:licensed:{src}` Auth0 claim through the API. Inverts the dormant `redacted_sources` blacklist into a `licensed_sources` allowlist, applied to resource list, resource detail, and source endpoints. Resources with no licensed memberships still appear, just as null shells.

Out of scope (tracked separately): `preview_merge_candidate`, write-path permissions, frontend "no licensed source" affordance.