### PR TITLE
Validate fallback email field as valid address before passing to EmailStr

### DIFF
--- a/packages/stitch-auth/src/stitch/auth/validator.py
+++ b/packages/stitch-auth/src/stitch/auth/validator.py
@@ -3,10 +3,14 @@ from typing import Any
 
 import jwt
 from jwt import PyJWKClient
+from pydantic import EmailStr, TypeAdapter, ValidationError
 
 from .claims import TokenClaims
 from .errors import JWKSFetchError, TokenExpiredError, TokenValidationError
 from .settings import OIDCSettings
+
+
+_EMAIL = TypeAdapter(EmailStr)
 
 
 def _extract_permissions(payload: dict[str, Any]) -> frozenset[str]:
@@ -24,6 +28,18 @@ def _extract_permissions(payload: dict[str, Any]) -> frozenset[str]:
     if not all(isinstance(item, str) for item in value):
         raise TokenValidationError("permissions claim must be a list of strings")
     return frozenset(value)
+
+
+def _validated_email(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+    candidate = value.strip()
+    if not candidate:
+        return None
+    try:
+        return str(_EMAIL.validate_python(candidate))
+    except ValidationError:
+        return None
 
 
 class JWTValidator:
@@ -66,7 +82,9 @@ class JWTValidator:
         except jwt.InvalidTokenError as e:
             raise TokenValidationError(str(e)) from e
 
-        email = payload.get("email") or payload.get("preferred_username")
+        email = _validated_email(payload.get("email"))
+        if email is None:
+            email = _validated_email(payload.get("preferred_username"))
         name = payload.get("name")
         permissions = _extract_permissions(payload)
 

--- a/packages/stitch-auth/src/stitch/auth/validator.py
+++ b/packages/stitch-auth/src/stitch/auth/validator.py
@@ -1,16 +1,13 @@
 from datetime import timedelta
+from email.utils import parseaddr
 from typing import Any
 
 import jwt
 from jwt import PyJWKClient
-from pydantic import EmailStr, TypeAdapter, ValidationError
 
 from .claims import TokenClaims
 from .errors import JWKSFetchError, TokenExpiredError, TokenValidationError
 from .settings import OIDCSettings
-
-
-_EMAIL = TypeAdapter(EmailStr)
 
 
 def _extract_permissions(payload: dict[str, Any]) -> frozenset[str]:
@@ -36,10 +33,21 @@ def _validated_email(value: object) -> str | None:
     candidate = value.strip()
     if not candidate:
         return None
-    try:
-        return str(_EMAIL.validate_python(candidate))
-    except ValidationError:
+    parsed_name, parsed_addr = parseaddr(candidate)
+    if parsed_name or parsed_addr != candidate:
         return None
+    if candidate.count("@") != 1:
+        return None
+    local, domain = candidate.split("@", 1)
+    if not local or not domain:
+        return None
+    if "." not in domain:
+        return None
+    if domain.startswith(".") or domain.endswith("."):
+        return None
+    if ".." in candidate:
+        return None
+    return candidate
 
 
 class JWTValidator:

--- a/packages/stitch-auth/tests/test_validator_unit.py
+++ b/packages/stitch-auth/tests/test_validator_unit.py
@@ -44,6 +44,34 @@ class TestJWTValidatorHappyPath:
 
         assert claims.email == "user@tenant.onmicrosoft.com"
 
+    def test_invalid_preferred_username_does_not_become_email(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        """Non-email preferred_username is ignored for email fallback."""
+        token = token_factory(
+            email=None,
+            extra_claims={"preferred_username": "not-an-email"},
+        )
+        validator = JWTValidator(oidc_settings)
+
+        claims = validator.validate(token)
+
+        assert claims.email is None
+
+    def test_invalid_email_claim_falls_back_to_valid_preferred_username(
+        self, oidc_settings, mock_jwks_client, token_factory
+    ):
+        """Fallback still works when the email claim itself is malformed."""
+        token = token_factory(
+            email="bad-email",
+            extra_claims={"preferred_username": "user@tenant.onmicrosoft.com"},
+        )
+        validator = JWTValidator(oidc_settings)
+
+        claims = validator.validate(token)
+
+        assert claims.email == "user@tenant.onmicrosoft.com"
+
     def test_optional_claims_can_be_absent(
         self, oidc_settings, mock_jwks_client, token_factory
     ):


### PR DESCRIPTION
implemented by codex

Followup to #85, validates the fallback `preferred_username` as an email before writing it to the `email` user field.

Note to reviewers: Opening this as one possible way to preserve the meaning of `email` field. Alternately, we could not use `EmailStr` validation, and just store a `str`, but in that case, I would suggest we call it something other than `email` in our data model