### PR TITLE
Add LLM persistence

### DIFF
--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
@@ -4,7 +4,11 @@ import { useParams, useNavigate } from "react-router-dom";
 import { useResourceDetail, useSourceDetail } from "../hooks/useResources";
 import { createAuthenticatedFetcher } from "../auth/api";
 import { useConfig } from "../config/useConfig";
-import { createLLMSuggestion } from "../queries/api";
+import {
+  createLLMSuggestion,
+  createMergeCandidate,
+  createResource,
+} from "../queries/api";
 import SourceMixBar from "../components/SourceMixBar";
 import SectionHeader from "../components/SectionHeader";
 import { FieldCard, FieldGrid } from "../components/FieldCard";
@@ -17,6 +21,71 @@ import {
   IDENTITY_FIELDS,
   PRODUCTION_FIELDS,
 } from "../constants/fieldMeta";
+
+const LLM_AUDIT_PRODUCER = "stitch-frontend";
+
+function createPersistIntentId() {
+  if (globalThis.crypto?.randomUUID) {
+    return globalThis.crypto.randomUUID();
+  }
+  return `persist-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+}
+
+function getSuggestionSubmissionKey(result) {
+  return JSON.stringify({
+    field: result.field,
+    value: result.value,
+    model: result.model,
+    observed_at: result.observed_at,
+    response_id: result.foundry_response?.id ?? null,
+  });
+}
+
+function buildSuggestionAuditPayload({ resourceId, result, persistIntentId }) {
+  return {
+    resource_id: resourceId,
+    field: result.field,
+    suggested_value: result.value,
+    rationale: result.rationale,
+    citations: result.citations,
+    model: result.model,
+    foundry_request: result.foundry_request,
+    foundry_response: result.foundry_response,
+    persist_intent_id: persistIntentId,
+  };
+}
+
+function buildLLMResourcePayload({ resourceId, result, persistIntentId }) {
+  const auditPayload = buildSuggestionAuditPayload({
+    resourceId,
+    result,
+    persistIntentId,
+  });
+
+  return {
+    id: null,
+    repointed_to: null,
+    constituents: [],
+    provenance: {},
+    view: null,
+    source_data: [
+      {
+        id: null,
+        source: "llm",
+        name: null,
+        country: null,
+        [result.field]: result.value,
+        source_record: {
+          record_id: persistIntentId,
+          run_id: null,
+          observed_at: result.observed_at,
+          producer: LLM_AUDIT_PRODUCER,
+          payload: auditPayload,
+        },
+      },
+    ],
+  };
+}
 
 function formatSuggestionValue(value) {
   if (value == null) return null;
@@ -104,11 +173,20 @@ function AISuggestionPanel({ endpoint, resourceId }) {
   const [result, setResult] = useState(null);
   const [error, setError] = useState("");
   const [isLoading, setIsLoading] = useState(false);
+  const [isPersisting, setIsPersisting] = useState(false);
+  const [persistState, setPersistState] = useState(null);
+
+  const canPersist = result?.value != null;
+  const isPersistedCurrentSuggestion =
+    result &&
+    persistState?.status === "success" &&
+    persistState.suggestionKey === getSuggestionSubmissionKey(result);
 
   async function handleGenerateSuggestion() {
     setIsLoading(true);
     setError("");
     setResult(null);
+    setPersistState(null);
 
     try {
       const suggestion = await createLLMSuggestion(
@@ -123,6 +201,59 @@ function AISuggestionPanel({ endpoint, resourceId }) {
       setError(err.message || "Failed to generate suggestion.");
     } finally {
       setIsLoading(false);
+    }
+  }
+
+  async function handlePersistSuggestion() {
+    if (!result || result.value == null) return;
+
+    setIsPersisting(true);
+    setError("");
+
+    const persistIntentId = createPersistIntentId();
+    const resourcePayload = buildLLMResourcePayload({
+      resourceId,
+      result,
+      persistIntentId,
+    });
+    const suggestionKey = getSuggestionSubmissionKey(result);
+
+    try {
+      const createdResource = await createResource(
+        config,
+        resourcePayload,
+        fetcher,
+        endpoint,
+      );
+
+      try {
+        const mergeCandidate = await createMergeCandidate(
+          config,
+          [resourceId, createdResource.id],
+          fetcher,
+          endpoint,
+        );
+        setPersistState({
+          status: "success",
+          resourceId: createdResource.id,
+          candidateId: mergeCandidate.id,
+          suggestionKey,
+        });
+      } catch {
+        setPersistState({
+          status: "partial",
+          resourceId: createdResource.id,
+          suggestionKey,
+        });
+        setError(
+          `Suggestion saved as resource ${createdResource.id}, but the merge draft was not created.`,
+        );
+      }
+    } catch (err) {
+      setPersistState(null);
+      setError(err.message || "Failed to persist suggestion.");
+    } finally {
+      setIsPersisting(false);
     }
   }
 
@@ -165,6 +296,29 @@ function AISuggestionPanel({ endpoint, resourceId }) {
         )}
 
         {result && <SuggestionResult result={result} />}
+
+        {canPersist && (
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <Button
+              onClick={handlePersistSuggestion}
+              disabled={isPersisting || isPersistedCurrentSuggestion}
+              variant="secondary"
+            >
+              {isPersisting
+                ? "Adding…"
+                : isPersistedCurrentSuggestion
+                  ? "Added to resource"
+                  : "Add to resource"}
+            </Button>
+
+            {persistState?.status === "success" &&
+              isPersistedCurrentSuggestion && (
+                <p className="text-sm text-green-700">
+                  Suggestion saved and queued for later merge review.
+                </p>
+              )}
+          </div>
+        )}
       </div>
     </section>
   );

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
@@ -10,13 +10,14 @@ import * as apiModule from "../queries/api";
 vi.mock("../hooks/useResources");
 
 let mockedRouteId = "1";
+const mockNavigate = vi.fn();
 
 vi.mock("react-router-dom", async () => {
   const actual = await vi.importActual("react-router-dom");
   return {
     ...actual,
     useParams: () => ({ id: mockedRouteId }),
-    useNavigate: () => vi.fn(),
+    useNavigate: () => mockNavigate,
   };
 });
 
@@ -72,12 +73,16 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
   mockedRouteId = "1";
+  mockNavigate.mockReset();
   vi.mocked(useAuth0).mockReturnValue(auth0TestDefaults);
   vi.mocked(useResourceDetail).mockReturnValue({
     ...defaultHookReturn,
     refetch: vi.fn(),
   });
   vi.mocked(useSourceDetail).mockReturnValue(defaultSourceDetailHookReturn);
+  vi.stubGlobal("crypto", {
+    randomUUID: () => "persist-uuid-123",
+  });
 });
 
 describe("ResourceDetailPage", () => {
@@ -367,5 +372,294 @@ describe("ResourceDetailPage", () => {
         "I could not find a grounded public source for this field.",
       ),
     ).toBeInTheDocument();
+  });
+
+  it("renders Add to resource only when the suggestion has a value", async () => {
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView,
+    });
+    vi.spyOn(apiModule, "createLLMSuggestion").mockResolvedValue({
+      resource_id: 1,
+      field: "basin",
+      value: "Songliao",
+      citations: [],
+      query_succeeded: true,
+      model: "test-model",
+      rationale: "Supported.",
+      observed_at: "2026-05-13T12:00:00Z",
+      foundry_request: {},
+      foundry_response: {},
+    });
+    const user = userEvent.setup();
+
+    renderWithQueryClient(<ResourceDetailPage />);
+    await user.click(
+      screen.getByRole("button", { name: /generate suggestion/i }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /add to resource/i }),
+    ).toBeInTheDocument();
+  });
+
+  it("creates an LLM-backed resource, then creates a merge candidate, and leaves the user on the page", async () => {
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView,
+    });
+    vi.spyOn(apiModule, "createLLMSuggestion").mockResolvedValue({
+      resource_id: 1,
+      field: "basin",
+      value: "Songliao",
+      citations: [
+        { url: "https://example.com/source", title: "Example Source" },
+      ],
+      query_succeeded: true,
+      model: "test-model",
+      rationale: "Supported.",
+      observed_at: "2026-05-13T12:00:00Z",
+      foundry_request: { request: true },
+      foundry_response: { response: true },
+    });
+    const createResourceSpy = vi
+      .spyOn(apiModule, "createResource")
+      .mockResolvedValue({ id: 123 });
+    const createMergeCandidateSpy = vi
+      .spyOn(apiModule, "createMergeCandidate")
+      .mockResolvedValue({ id: 88, resource_ids: [1, 123] });
+    const user = userEvent.setup();
+
+    renderWithQueryClient(<ResourceDetailPage />);
+    await user.click(
+      screen.getByRole("button", { name: /generate suggestion/i }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /add to resource/i }),
+    );
+
+    expect(createResourceSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiBaseUrl: "http://localhost:8000/api/v1",
+        stitchLlmBaseUrl: "http://localhost:8002/api/v1",
+      }),
+      {
+        id: null,
+        repointed_to: null,
+        constituents: [],
+        provenance: {},
+        view: null,
+        source_data: [
+          {
+            id: null,
+            source: "llm",
+            name: null,
+            country: null,
+            basin: "Songliao",
+            source_record: {
+              record_id: "persist-uuid-123",
+              run_id: null,
+              observed_at: "2026-05-13T12:00:00Z",
+              producer: "stitch-frontend",
+              payload: {
+                resource_id: 1,
+                field: "basin",
+                suggested_value: "Songliao",
+                rationale: "Supported.",
+                citations: [
+                  {
+                    url: "https://example.com/source",
+                    title: "Example Source",
+                  },
+                ],
+                model: "test-model",
+                foundry_request: { request: true },
+                foundry_response: { response: true },
+                persist_intent_id: "persist-uuid-123",
+              },
+            },
+          },
+        ],
+      },
+      expect.any(Function),
+      "oil-gas-fields",
+    );
+    expect(createMergeCandidateSpy).toHaveBeenCalledWith(
+      expect.any(Object),
+      [1, 123],
+      expect.any(Function),
+      "oil-gas-fields",
+    );
+    expect(
+      await screen.findByText(
+        "Suggestion saved and queued for later merge review.",
+      ),
+    ).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      "/merge-candidate-review?candidate=88",
+    );
+  });
+
+  it("renders structured create-resource validation errors instead of object coercions", async () => {
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView,
+    });
+    vi.spyOn(apiModule, "createLLMSuggestion").mockResolvedValue({
+      resource_id: 1,
+      field: "basin",
+      value: "Songliao",
+      citations: [],
+      query_succeeded: true,
+      model: "test-model",
+      rationale: "Supported.",
+      observed_at: "2026-05-13T12:00:00Z",
+      foundry_request: {},
+      foundry_response: {},
+    });
+    vi.spyOn(apiModule, "createResource").mockRejectedValue(
+      new Error(
+        JSON.stringify(
+          [
+            {
+              loc: ["body", "source_data", 0, "llm", "name"],
+              msg: "Field required",
+            },
+            {
+              loc: ["body", "source_data", 0, "llm", "country"],
+              msg: "Field required",
+            },
+          ],
+          null,
+          2,
+        ),
+      ),
+    );
+    const user = userEvent.setup();
+
+    renderWithQueryClient(<ResourceDetailPage />);
+    await user.click(
+      screen.getByRole("button", { name: /generate suggestion/i }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /add to resource/i }),
+    );
+
+    expect(await screen.findByText(/Field required/)).toBeInTheDocument();
+    expect(
+      screen.queryByText("[object Object],[object Object]"),
+    ).not.toBeInTheDocument();
+  });
+
+  it("shows partial-failure messaging when merge candidate creation fails after resource creation", async () => {
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView,
+    });
+    vi.spyOn(apiModule, "createLLMSuggestion").mockResolvedValue({
+      resource_id: 1,
+      field: "basin",
+      value: "Songliao",
+      citations: [],
+      query_succeeded: true,
+      model: "test-model",
+      rationale: "Supported.",
+      observed_at: "2026-05-13T12:00:00Z",
+      foundry_request: {},
+      foundry_response: {},
+    });
+    vi.spyOn(apiModule, "createResource").mockResolvedValue({ id: 123 });
+    const createMergeCandidateSpy = vi
+      .spyOn(apiModule, "createMergeCandidate")
+      .mockRejectedValue(new Error("merge failed"));
+    const user = userEvent.setup();
+
+    renderWithQueryClient(<ResourceDetailPage />);
+    await user.click(
+      screen.getByRole("button", { name: /generate suggestion/i }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /add to resource/i }),
+    );
+
+    expect(createMergeCandidateSpy).toHaveBeenCalled();
+    expect(
+      await screen.findByText(
+        "Suggestion saved as resource 123, but the merge draft was not created.",
+      ),
+    ).toBeInTheDocument();
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not attempt merge-candidate creation when resource creation fails", async () => {
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView,
+    });
+    vi.spyOn(apiModule, "createLLMSuggestion").mockResolvedValue({
+      resource_id: 1,
+      field: "basin",
+      value: "Songliao",
+      citations: [],
+      query_succeeded: true,
+      model: "test-model",
+      rationale: "Supported.",
+      observed_at: "2026-05-13T12:00:00Z",
+      foundry_request: {},
+      foundry_response: {},
+    });
+    vi.spyOn(apiModule, "createResource").mockRejectedValue(
+      new Error("create failed"),
+    );
+    const createMergeCandidateSpy = vi.spyOn(apiModule, "createMergeCandidate");
+    const user = userEvent.setup();
+
+    renderWithQueryClient(<ResourceDetailPage />);
+    await user.click(
+      screen.getByRole("button", { name: /generate suggestion/i }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /add to resource/i }),
+    );
+
+    expect(createMergeCandidateSpy).not.toHaveBeenCalled();
+    expect(await screen.findByText("create failed")).toBeInTheDocument();
+  });
+
+  it("disables resubmission after a successful persist for the current suggestion", async () => {
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView,
+    });
+    vi.spyOn(apiModule, "createLLMSuggestion").mockResolvedValue({
+      resource_id: 1,
+      field: "basin",
+      value: "Songliao",
+      citations: [],
+      query_succeeded: true,
+      model: "test-model",
+      rationale: "Supported.",
+      observed_at: "2026-05-13T12:00:00Z",
+      foundry_request: {},
+      foundry_response: {},
+    });
+    vi.spyOn(apiModule, "createResource").mockResolvedValue({ id: 123 });
+    vi.spyOn(apiModule, "createMergeCandidate").mockResolvedValue({
+      id: 88,
+      resource_ids: [1, 123],
+    });
+    const user = userEvent.setup();
+
+    renderWithQueryClient(<ResourceDetailPage />);
+    await user.click(
+      screen.getByRole("button", { name: /generate suggestion/i }),
+    );
+    await user.click(
+      await screen.findByRole("button", { name: /add to resource/i }),
+    );
+
+    expect(
+      await screen.findByRole("button", { name: /added to resource/i }),
+    ).toBeDisabled();
   });
 });

--- a/deployments/stitch-frontend/src/queries/api.js
+++ b/deployments/stitch-frontend/src/queries/api.js
@@ -99,6 +99,52 @@ async function getErrorDetail(response) {
   }
 }
 
+export async function createResource(
+  config,
+  payload,
+  fetcher,
+  endpoint = "oil-gas-fields",
+) {
+  const url = `${config.apiBaseUrl}/${endpoint}/`;
+  const response = await fetcher(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const detail = await getErrorDetail(response);
+    const error = new Error(detail);
+    error.status = response.status;
+    throw error;
+  }
+
+  return await response.json();
+}
+
+export async function createMergeCandidate(
+  config,
+  resource_ids,
+  fetcher,
+  endpoint = "oil-gas-fields",
+) {
+  const url = `${config.apiBaseUrl}/${endpoint}/merge-candidates`;
+  const response = await fetcher(url, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ resource_ids }),
+  });
+
+  if (!response.ok) {
+    const detail = await getErrorDetail(response);
+    const error = new Error(detail);
+    error.status = response.status;
+    throw error;
+  }
+
+  return await response.json();
+}
+
 export async function getMergeCandidates(
   config,
   fetcher,
@@ -150,18 +196,8 @@ export async function reviewMergeCandidate(
   });
 
   if (!response.ok) {
-    const text = await response.text();
-    let detail = text;
-
-    try {
-      detail = text ? JSON.parse(text) : null;
-    } catch {
-      // leave as text
-    }
-
-    const error = new Error(
-      typeof detail === "string" ? detail : JSON.stringify(detail, null, 2),
-    );
+    const detail = await getErrorDetail(response);
+    const error = new Error(detail);
     error.status = response.status;
     throw error;
   }

--- a/deployments/stitch-frontend/src/queries/api.test.js
+++ b/deployments/stitch-frontend/src/queries/api.test.js
@@ -1,5 +1,12 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createLLMSuggestion, getResources, getResource } from "./api";
+import {
+  createLLMSuggestion,
+  createMergeCandidate,
+  createResource,
+  getResources,
+  getResource,
+  reviewMergeCandidate,
+} from "./api";
 
 describe("API Functions", () => {
   let mockFetcher;
@@ -251,6 +258,199 @@ describe("API Functions", () => {
       ).rejects.toMatchObject({
         message: "Service temporarily unavailable",
         status: 503,
+      });
+    });
+  });
+
+  describe("createResource", () => {
+    it("posts the resource payload to the Stitch API", async () => {
+      const payload = { source_data: [{ source: "llm" }] };
+      mockFetcher.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 123 }),
+      });
+
+      const result = await createResource(
+        config,
+        payload,
+        mockFetcher,
+        "oil-gas-fields",
+      );
+
+      expect(mockFetcher).toHaveBeenCalledWith(
+        "http://localhost:8000/api/v1/oil-gas-fields/",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(payload),
+        },
+      );
+      expect(result).toEqual({ id: 123 });
+    });
+
+    it("stringifies structured validation errors from the API", async () => {
+      mockFetcher.mockResolvedValueOnce({
+        ok: false,
+        status: 422,
+        text: async () =>
+          JSON.stringify({
+            detail: [
+              {
+                loc: ["body", "source_data", 0, "llm", "name"],
+                msg: "Field required",
+              },
+            ],
+          }),
+      });
+
+      await expect(
+        createResource(
+          config,
+          { source_data: [] },
+          mockFetcher,
+          "oil-gas-fields",
+        ),
+      ).rejects.toMatchObject({
+        message: JSON.stringify(
+          [
+            {
+              loc: ["body", "source_data", 0, "llm", "name"],
+              msg: "Field required",
+            },
+          ],
+          null,
+          2,
+        ),
+        status: 422,
+      });
+    });
+  });
+
+  describe("createMergeCandidate", () => {
+    it("posts the resource ids to create a merge candidate", async () => {
+      mockFetcher.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 88, resource_ids: [42, 123] }),
+      });
+
+      const result = await createMergeCandidate(
+        config,
+        [42, 123],
+        mockFetcher,
+        "oil-gas-fields",
+      );
+
+      expect(mockFetcher).toHaveBeenCalledWith(
+        "http://localhost:8000/api/v1/oil-gas-fields/merge-candidates",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ resource_ids: [42, 123] }),
+        },
+      );
+      expect(result).toEqual({ id: 88, resource_ids: [42, 123] });
+    });
+
+    it("surfaces API error detail and status for failed merge creation", async () => {
+      mockFetcher.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        text: async () =>
+          JSON.stringify({
+            detail: { message: "Merge candidate already exists" },
+          }),
+      });
+
+      await expect(
+        createMergeCandidate(config, [42, 123], mockFetcher, "oil-gas-fields"),
+      ).rejects.toMatchObject({
+        message: JSON.stringify(
+          { message: "Merge candidate already exists" },
+          null,
+          2,
+        ),
+        status: 409,
+      });
+    });
+  });
+
+  describe("reviewMergeCandidate", () => {
+    it("posts the requested review action and notes", async () => {
+      mockFetcher.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ id: 88, status: "approved" }),
+      });
+
+      const result = await reviewMergeCandidate(
+        config,
+        88,
+        "approve",
+        mockFetcher,
+        "oil-gas-fields",
+        "Looks good",
+      );
+
+      expect(mockFetcher).toHaveBeenCalledWith(
+        "http://localhost:8000/api/v1/oil-gas-fields/merge-candidates/88/approve",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ review_notes: "Looks good" }),
+        },
+      );
+      expect(result).toEqual({ id: 88, status: "approved" });
+    });
+
+    it("surfaces structured API error detail and status on failure", async () => {
+      mockFetcher.mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        text: async () =>
+          JSON.stringify({
+            detail: { message: "Merge candidate already reviewed" },
+          }),
+      });
+
+      await expect(
+        reviewMergeCandidate(
+          config,
+          88,
+          "approve",
+          mockFetcher,
+          "oil-gas-fields",
+        ),
+      ).rejects.toMatchObject({
+        message: JSON.stringify(
+          { message: "Merge candidate already reviewed" },
+          null,
+          2,
+        ),
+        status: 409,
+      });
+    });
+
+    it("falls back to status text when the error body is empty", async () => {
+      mockFetcher.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+        statusText: "Internal Server Error",
+        text: async () => "",
+      });
+
+      await expect(
+        reviewMergeCandidate(
+          config,
+          88,
+          "approve",
+          mockFetcher,
+          "oil-gas-fields",
+        ),
+      ).rejects.toMatchObject({
+        message: "Internal Server Error",
+        status: 500,
       });
     });
   });

--- a/deployments/stitch-llm/src/stitch/llm/entities.py
+++ b/deployments/stitch-llm/src/stitch/llm/entities.py
@@ -1,3 +1,4 @@
+from datetime import datetime
 from typing import Any
 
 from pydantic import BaseModel, EmailStr, Field
@@ -24,5 +25,6 @@ class FieldSuggestionResponse(BaseModel):
     query_succeeded: bool
     model: str
     rationale: str
+    observed_at: datetime
     foundry_request: dict[str, Any]
     foundry_response: dict[str, Any]

--- a/deployments/stitch-llm/src/stitch/llm/routers/oil_gas_fields.py
+++ b/deployments/stitch-llm/src/stitch/llm/routers/oil_gas_fields.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+from datetime import UTC, datetime
 from typing import Annotated
 
 from fastapi import APIRouter, HTTPException, Query
@@ -51,6 +52,7 @@ async def suggest_oil_gas_field_value(
     id: int,
     field: Annotated[AllowedSuggestionField, Query()],
 ) -> FieldSuggestionResponse:
+    observed_at = datetime.now(UTC)
     try:
         async with StitchApiClient() as stitch_client:
             detail_view = await stitch_client.get_oil_gas_field_detail(id)
@@ -105,6 +107,7 @@ async def suggest_oil_gas_field_value(
                 else "Foundry is not configured in auth-disabled mode; no safe "
                 "placeholder exists for this field type."
             ),
+            observed_at=observed_at,
             foundry_request={},
             foundry_response={},
         )
@@ -145,6 +148,7 @@ async def suggest_oil_gas_field_value(
         query_succeeded=True,
         model=llm_result.model,
         rationale=parsed.rationale,
+        observed_at=observed_at,
         foundry_request=llm_result.request_payload,
         foundry_response=llm_result.response_payload,
     )

--- a/deployments/stitch-llm/src/stitch/llm/suggestions.py
+++ b/deployments/stitch-llm/src/stitch/llm/suggestions.py
@@ -5,7 +5,7 @@ from typing import Any, Literal, get_args
 from pydantic import ValidationError
 
 from stitch.llm.errors import FieldAlreadyPopulatedError, ModelOutputError
-from stitch.ogsi.model import OGFieldDetailView
+from stitch.ogsi.model import OGFieldDetailView, OG_FIELD_SOURCE_VIEW_ADAPTER
 from stitch.ogsi.model.og_field import OilGasFieldBase
 from stitch.ogsi.model.types import (
     FieldStatus,
@@ -86,9 +86,7 @@ def build_field_suggestion_input(
             "Do not return a value for any field except the requested field.",
         ],
         "coalesced_resource": detail_view.data.model_dump(mode="json"),
-        "source_records": [
-            source.model_dump(mode="json") for source in detail_view.source_data
-        ],
+        "source_records": _build_prompt_source_records(detail_view),
     }
 
     return [
@@ -107,6 +105,15 @@ def build_field_suggestion_input(
             "role": "user",
             "content": _serialize_prompt_payload(payload),
         },
+    ]
+
+
+def _build_prompt_source_records(
+    detail_view: OGFieldDetailView,
+) -> list[dict[str, Any]]:
+    return [
+        OG_FIELD_SOURCE_VIEW_ADAPTER.validate_python(source).model_dump(mode="json")
+        for source in detail_view.source_data
     ]
 
 

--- a/deployments/stitch-llm/tests/test_oil_gas_fields_api.py
+++ b/deployments/stitch-llm/tests/test_oil_gas_fields_api.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from contextlib import AbstractAsyncContextManager
+import json
 
 import pytest
 from fastapi.testclient import TestClient
@@ -199,6 +200,8 @@ def test_get_suggestion_returns_validated_value(
     assert response.status_code == 200
     body = response.json()
     assert body["observed_at"].endswith("Z")
+    prompt_payload = json.loads(azure_client.calls[0]["input_messages"][1]["content"])
+    assert "source_record" not in prompt_payload["source_records"][0]
     assert body == {
         "resource_id": 42,
         "field": "basin",

--- a/deployments/stitch-llm/tests/test_oil_gas_fields_api.py
+++ b/deployments/stitch-llm/tests/test_oil_gas_fields_api.py
@@ -197,7 +197,9 @@ def test_get_suggestion_returns_validated_value(
     response = test_client.get("/api/v1/oil-gas-fields/42?field=basin")
 
     assert response.status_code == 200
-    assert response.json() == {
+    body = response.json()
+    assert body["observed_at"].endswith("Z")
+    assert body == {
         "resource_id": 42,
         "field": "basin",
         "value": "Permian Basin",
@@ -207,6 +209,7 @@ def test_get_suggestion_returns_validated_value(
         "query_succeeded": True,
         "model": "test-model",
         "rationale": "Public sources identify the basin.",
+        "observed_at": body["observed_at"],
         "foundry_request": {
             "model": "test-model",
             "input": azure_client.calls[0]["input_messages"],
@@ -318,6 +321,7 @@ def test_get_suggestion_returns_placeholder_when_auth_disabled_and_azure_missing
     assert response.json()["value"] == ":warning: placeholder LLM value"
     assert response.json()["citations"] == []
     assert response.json()["model"] == "placeholder-llm"
+    assert response.json()["observed_at"].endswith("Z")
     assert azure_client.calls == []
 
 
@@ -336,6 +340,7 @@ def test_get_suggestion_returns_null_for_non_string_placeholder_fallback(
     assert response.json()["value"] is None
     assert response.json()["citations"] == []
     assert response.json()["model"] == "placeholder-llm"
+    assert response.json()["observed_at"].endswith("Z")
     assert azure_client.calls == []
 
 

--- a/deployments/stitch-llm/tests/test_suggestions.py
+++ b/deployments/stitch-llm/tests/test_suggestions.py
@@ -1,9 +1,12 @@
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from stitch.llm.errors import FieldAlreadyPopulatedError, ModelOutputError
 from stitch.llm.suggestions import (
+    build_field_suggestion_input,
     ensure_field_is_missing,
     parse_field_suggestion_response,
     sanitize_and_validate_suggested_value,
@@ -66,6 +69,19 @@ def test_parse_field_suggestion_response_rejects_extra_non_empty_lines() -> None
         parse_field_suggestion_response(
             "VALUE: Permian Basin\nRATIONALE: Supported by sources.\nEXTRA: nope"
         )
+
+
+def test_build_field_suggestion_input_excludes_source_record_from_prompt() -> None:
+    detail_view = make_detail_view(basin=None)
+
+    input_messages = build_field_suggestion_input(
+        resource_id=42,
+        field="basin",
+        detail_view=detail_view,
+    )
+
+    payload = json.loads(input_messages[1]["content"])
+    assert "source_record" not in payload["source_records"][0]
 
 
 def test_sanitize_and_validate_suggested_value_trims_strings() -> None:


### PR DESCRIPTION
Supersedes #97 
Supported by codex

Uses source persistence mechanisms from #99 to store LLM Foundry call/response.

After GETting a response from llm service, shows a button which orchestrates:
1. POSTing a new **Resource** with that response as a LLM source (using the logged in user's credentials)
2. creating a merge candidate between the new resource, and the resource that is being backfilled

This is probably not the workflow that we want long-term, but is idiomatic in the current design. In particular, there is a real chance of "orphaned" resources, if merges are denied (or just ignored), or if there's a network failure when creating the merge request (the create and merge are not in a "transaction" and are separate processes)

That said, since we're planning to revisit the source/resource merge/create/attach workflows, this gives us what we need for now, and all the tools we will need for that conversation.

Notes:
* Currently allows for persisting of "auth_disabled" placeholder value
* This is making all the POSTs (Resource and merge candidates) from the frontend. The LLM service isn't creating the resources
* Adds frontend functions (`queries/api`) to create resources and merge candidates (previously unavailable in frontend)
* We probably need to separate the "read LLM sources" and the "inpsect LLM details permissions"