### PR TITLE
 STIT-478 simplify source data display

### DIFF
--- a/deployments/stitch-frontend/package-lock.json
+++ b/deployments/stitch-frontend/package-lock.json
@@ -32,7 +32,7 @@
         "globals": "^16.5.0",
         "jsdom": "^27.0.1",
         "prettier": "^3.7.4",
-        "vite": "^7.2.4",
+        "vite": "^7.3.3",
         "vitest": "^3.2.4"
       },
       "engines": {
@@ -5495,9 +5495,9 @@
       }
     },
     "node_modules/ws": {
-      "version": "8.18.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
-      "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
       "dev": true,
       "license": "MIT",
       "engines": {

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
@@ -13,7 +13,6 @@ import SourceMixBar from "../components/SourceMixBar";
 import SectionHeader from "../components/SectionHeader";
 import { FieldCard, FieldGrid } from "../components/FieldCard";
 import { SOURCE_LABELS } from "../constants/sourceMeta";
-import StructuredDataView from "../components/StructuredDataView";
 import Button from "../components/Button";
 import {
   AI_SUGGESTION_FIELDS,
@@ -23,6 +22,19 @@ import {
 } from "../constants/fieldMeta";
 
 const LLM_AUDIT_PRODUCER = "stitch-frontend";
+
+const OBSERVED_AT_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  year: "numeric",
+  month: "short",
+  day: "numeric",
+});
+
+function formatObservedAt(value) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return "—";
+  return OBSERVED_AT_FORMATTER.format(date);
+}
 
 function createPersistIntentId() {
   if (globalThis.crypto?.randomUUID) {
@@ -359,7 +371,48 @@ function OrganizationsSection({ data }) {
   );
 }
 
-function SourceDetailCard({ source }) {
+function TechnicalImportRecord({ sourceRecord }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const panelId = useId();
+
+  return (
+    <div className="rounded-md border border-line bg-surface">
+      <button
+        type="button"
+        aria-expanded={isOpen}
+        aria-controls={panelId}
+        onClick={() => setIsOpen((current) => !current)}
+        className="flex w-full items-center justify-between px-4 py-3 text-sm font-semibold text-ink"
+      >
+        <span>Technical import record</span>
+        <span aria-hidden="true" className="text-ink-muted">
+          {isOpen ? "−" : "+"}
+        </span>
+      </button>
+      {isOpen && (
+        <div
+          id={panelId}
+          className="space-y-3 border-t border-line px-4 py-3"
+        >
+          <FieldGrid>
+            <FieldCard label="Record ID" value={sourceRecord.record_id} />
+            <FieldCard label="Run ID" value={sourceRecord.run_id} />
+          </FieldGrid>
+          <div className="space-y-2">
+            <p className="text-xs font-semibold uppercase tracking-wide text-ink-muted">
+              Raw payload
+            </p>
+            <pre className="overflow-x-auto rounded-md border border-line bg-panel p-4 text-xs leading-6 text-ink">
+              {JSON.stringify(sourceRecord.payload, null, 2)}
+            </pre>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function SourceRow({ source }) {
   const [isOpen, setIsOpen] = useState(false);
   const panelId = useId();
   const hasId = Number.isFinite(source.id);
@@ -368,107 +421,117 @@ function SourceDetailCard({ source }) {
     isLoading,
     isError,
     error,
-  } = useSourceDetail("oil-gas-field-sources", source.id, isOpen && hasId);
+  } = useSourceDetail("oil-gas-field-sources", source.id, hasId);
+
   const sourceLabel = SOURCE_LABELS[source.source] ?? source.source;
+  const sourceRecord = sourceDetail?.source_record ?? null;
+
+  let metaLine;
+  if (sourceRecord) {
+    const producer = sourceRecord.producer ?? "—";
+    const observed = formatObservedAt(sourceRecord.observed_at);
+    metaLine = (
+      <span>
+        Imported by {producer} · {observed}
+      </span>
+    );
+  } else if (isLoading) {
+    metaLine = (
+      <span className="text-ink-muted">Loading source details…</span>
+    );
+  } else if (isError) {
+    metaLine = (
+      <span className="text-danger">Unable to load source details</span>
+    );
+  } else {
+    metaLine = <span className="text-ink-muted">Imported by — · —</span>;
+  }
 
   return (
-    <div className="rounded-md border border-gray-dark/15 bg-white p-4 space-y-4">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1">
-          <p className="text-xs font-medium uppercase tracking-wide text-gray-dark/60">
+    <div className="rounded-md border border-line bg-panel p-4">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+        <div className="min-w-0 space-y-1">
+          <p className="text-xs font-semibold uppercase tracking-wide text-ink-muted">
             {sourceLabel}
           </p>
-          <p className="text-lg font-semibold text-gray-dark">
+          <p className="text-sm text-ink">{metaLine}</p>
+          <p className="text-xs text-ink-muted">
             {source.name ?? "Unnamed source"}
           </p>
-          <p className="text-sm text-gray-dark/70">
-            Source row ID: {source.id ?? "Unavailable"}
-          </p>
         </div>
-        <button
-          type="button"
-          disabled={!hasId}
+        <Button
+          variant="secondary"
           aria-expanded={isOpen}
           aria-controls={panelId}
+          disabled={!hasId}
           onClick={() => setIsOpen((current) => !current)}
-          className="rounded-md border border-gray-dark bg-gray-light px-3 py-2 text-sm text-gray-dark hover:cursor-pointer disabled:cursor-not-allowed disabled:opacity-50"
         >
-          {isOpen ? "Hide details" : "Show details"}
-        </button>
+          {isOpen ? "Hide" : "View"}
+        </Button>
       </div>
 
-      <div
-        id={panelId}
-        hidden={!isOpen}
-        aria-hidden={!isOpen}
-        className="space-y-3 border-t border-gray-dark/10 pt-4"
-      >
-        {isLoading && (
-          <p className="text-sm text-gray-dark/70">Loading source details…</p>
-        )}
+      {isOpen && (
+        <div
+          id={panelId}
+          className="mt-4 space-y-4 border-t border-line pt-4"
+        >
+          {isLoading && (
+            <p className="text-sm text-ink-muted">Loading source details…</p>
+          )}
 
-        {isError && (
-          <p className="text-sm text-red-600">
-            Failed to load source details
-            {error?.message ? `: ${error.message}` : "."}
-          </p>
-        )}
+          {isError && (
+            <p className="text-sm text-danger">
+              Failed to load source details
+              {error?.message ? `: ${error.message}` : "."}
+            </p>
+          )}
 
-        {sourceDetail && (
-          <>
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
-              <FieldCard
-                label="Producer"
-                value={sourceDetail.source_record?.producer}
-              />
-            </div>
-            <div className="space-y-2">
-              <p className="text-xs font-medium uppercase tracking-wide text-gray-dark/60">
-                Source Record
-              </p>
-              <pre className="overflow-x-auto rounded-md bg-gray-light p-4 text-xs leading-6 text-gray-dark">
-                {JSON.stringify(sourceDetail.source_record, null, 2)}
-              </pre>
-            </div>
-          </>
-        )}
-      </div>
+          {sourceDetail && !sourceRecord && (
+            <p className="text-sm text-ink-muted">
+              No import record available.
+            </p>
+          )}
+
+          {sourceRecord && (
+            <>
+              <FieldGrid>
+                <FieldCard label="Source name" value={source.name} />
+                <FieldCard label="Producer" value={sourceRecord.producer} />
+                <FieldCard
+                  label="Observed at"
+                  value={formatObservedAt(sourceRecord.observed_at)}
+                />
+                <FieldCard label="Source row ID" value={source.id} />
+              </FieldGrid>
+              <TechnicalImportRecord sourceRecord={sourceRecord} />
+            </>
+          )}
+        </div>
+      )}
     </div>
   );
 }
 
-function SourceDetailsSection({ sources }) {
-  if (!Array.isArray(sources) || sources.length === 0) return null;
+function SourcesSection({ sources }) {
+  const hasSources = Array.isArray(sources) && sources.length > 0;
 
   return (
     <section>
-      <SectionHeader title="Source Details" />
-      <div className="space-y-4">
-        {sources.map((source) => (
-          <SourceDetailCard
-            key={`${source.source}-${source.id ?? source.name ?? "source"}`}
-            source={source}
-          />
-        ))}
-      </div>
-    </section>
-  );
-}
-
-function SourceDataSection({ sourceData }) {
-  return (
-    <section>
-      <SectionHeader title="Source data" />
-      <details className="rounded-md border border-line bg-panel px-4 py-3">
-        <summary className="cursor-pointer text-sm font-semibold text-ink">
-          Source records
-        </summary>
-        <StructuredDataView
-          data={sourceData}
-          label="Source records"
-          className="mt-4"
-        />
-      </details>
+      <SectionHeader title="Sources" />
+      {hasSources ? (
+        <div className="space-y-4">
+          {sources.map((source, idx) => (
+            <SourceRow
+              key={`${source.source}-${source.id ?? source.name ?? idx}`}
+              source={source}
+            />
+          ))}
+        </div>
+      ) : (
+        <p className="text-sm text-ink-muted">
+          No sources attached to this resource.
+        </p>
+      )}
     </section>
   );
 }
@@ -556,9 +619,7 @@ export default function ResourceDetailPage() {
 
           <AISuggestionPanel endpoint={endpoint} resourceId={numericId} />
 
-          <SourceDetailsSection sources={detailView.source_data} />
-
-          <SourceDataSection sourceData={detailView.source_data} />
+          <SourcesSection sources={detailView.source_data} />
         </div>
       )}
     </div>

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
@@ -390,10 +390,7 @@ function TechnicalImportRecord({ sourceRecord }) {
         </span>
       </button>
       {isOpen && (
-        <div
-          id={panelId}
-          className="space-y-3 border-t border-line px-4 py-3"
-        >
+        <div id={panelId} className="space-y-3 border-t border-line px-4 py-3">
           <FieldGrid>
             <FieldCard label="Record ID" value={sourceRecord.record_id} />
             <FieldCard label="Run ID" value={sourceRecord.run_id} />
@@ -436,9 +433,7 @@ function SourceRow({ source }) {
       </span>
     );
   } else if (isLoading) {
-    metaLine = (
-      <span className="text-ink-muted">Loading source details…</span>
-    );
+    metaLine = <span className="text-ink-muted">Loading source details…</span>;
   } else if (isError) {
     metaLine = (
       <span className="text-danger">Unable to load source details</span>
@@ -471,10 +466,7 @@ function SourceRow({ source }) {
       </div>
 
       {isOpen && (
-        <div
-          id={panelId}
-          className="mt-4 space-y-4 border-t border-line pt-4"
-        >
+        <div id={panelId} className="mt-4 space-y-4 border-t border-line pt-4">
           {isLoading && (
             <p className="text-sm text-ink-muted">Loading source details…</p>
           )}

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
@@ -236,7 +236,7 @@ describe("ResourceDetailPage", () => {
     ).toBeInTheDocument();
   });
 
-  it("shows source detail controls for each attached source", () => {
+  it("renders a Sources section with a row per attached source", () => {
     vi.mocked(useResourceDetail).mockReturnValue({
       ...defaultHookReturn,
       data: mockDetailView,
@@ -245,15 +245,15 @@ describe("ResourceDetailPage", () => {
     renderWithQueryClient(<ResourceDetailPage />);
 
     expect(
-      screen.getByRole("heading", { name: /source details/i }),
+      screen.getByRole("heading", { name: /^sources$/i, level: 2 }),
     ).toBeInTheDocument();
     expect(
-      screen.getByRole("button", { name: /show details/i }),
+      screen.getByRole("button", { name: /^view$/i }),
     ).toBeInTheDocument();
     expect(screen.getAllByText("Burgan Source").length).toBeGreaterThan(0);
   });
 
-  it("exposes disclosure accessibility attributes on the source detail toggle", async () => {
+  it("exposes disclosure accessibility attributes on the source row toggle", async () => {
     vi.mocked(useResourceDetail).mockReturnValue({
       ...defaultHookReturn,
       data: mockDetailView,
@@ -262,18 +262,20 @@ describe("ResourceDetailPage", () => {
 
     renderWithQueryClient(<ResourceDetailPage />);
 
-    const toggle = screen.getByRole("button", { name: /show details/i });
+    const toggle = screen.getByRole("button", { name: /^view$/i });
     expect(toggle).toHaveAttribute("aria-expanded", "false");
     const panelId = toggle.getAttribute("aria-controls");
     expect(panelId).toBeTruthy();
 
     await user.click(toggle);
 
-    expect(toggle).toHaveAttribute("aria-expanded", "true");
+    expect(
+      screen.getByRole("button", { name: /^hide$/i }),
+    ).toHaveAttribute("aria-expanded", "true");
     expect(document.getElementById(panelId)).toBeTruthy();
   });
 
-  it("renders raw source record details when a source detail panel is opened", async () => {
+  it("shows formatted producer and observed-at in the compact row once the source detail loads", () => {
     vi.mocked(useResourceDetail).mockReturnValue({
       ...defaultHookReturn,
       data: mockDetailView,
@@ -284,9 +286,41 @@ describe("ResourceDetailPage", () => {
         id: 11,
         source: "gem",
         name: "Burgan Source",
-        country: "Kuwait",
         source_record: {
           producer: "stitch-seed@0.1.0",
+          observed_at: "2026-05-13T12:00:00Z",
+          record_id: "abc",
+          run_id: "run-1",
+          payload: { name: "Burgan Source" },
+        },
+      },
+    });
+
+    renderWithQueryClient(<ResourceDetailPage />);
+
+    expect(
+      screen.getByText(/imported by stitch-seed@0\.1\.0/i),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/may 13, 2026/i)).toBeInTheDocument();
+    expect(screen.queryByText(/"name": "Burgan Source"/)).toBeNull();
+  });
+
+  it("reveals the raw payload only after the Technical import record disclosure is opened", async () => {
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView,
+    });
+    vi.mocked(useSourceDetail).mockReturnValue({
+      ...defaultSourceDetailHookReturn,
+      data: {
+        id: 11,
+        source: "gem",
+        name: "Burgan Source",
+        source_record: {
+          producer: "stitch-seed@0.1.0",
+          observed_at: "2026-05-13T12:00:00Z",
+          record_id: "abc",
+          run_id: "run-1",
           payload: { name: "Burgan Source" },
         },
       },
@@ -294,12 +328,19 @@ describe("ResourceDetailPage", () => {
     const user = userEvent.setup();
 
     renderWithQueryClient(<ResourceDetailPage />);
-    await user.click(screen.getByRole("button", { name: /show details/i }));
+    await user.click(screen.getByRole("button", { name: /^view$/i }));
 
-    expect(screen.getByText("stitch-seed@0.1.0")).toBeInTheDocument();
-    expect(
-      screen.getAllByText(/"name": "Burgan Source"/).length,
-    ).toBeGreaterThan(0);
+    const techToggle = screen.getByRole("button", {
+      name: /technical import record/i,
+    });
+    expect(techToggle).toBeInTheDocument();
+    expect(screen.queryByText(/"name": "Burgan Source"/)).toBeNull();
+
+    await user.click(techToggle);
+
+    expect(screen.getByText(/"name": "Burgan Source"/)).toBeInTheDocument();
+    expect(screen.getByText("abc")).toBeInTheDocument();
+    expect(screen.getByText("run-1")).toBeInTheDocument();
   });
 
   it("generates and renders an AI suggestion preview", async () => {

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
@@ -247,9 +247,7 @@ describe("ResourceDetailPage", () => {
     expect(
       screen.getByRole("heading", { name: /^sources$/i, level: 2 }),
     ).toBeInTheDocument();
-    expect(
-      screen.getByRole("button", { name: /^view$/i }),
-    ).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /^view$/i })).toBeInTheDocument();
     expect(screen.getAllByText("Burgan Source").length).toBeGreaterThan(0);
   });
 
@@ -269,9 +267,10 @@ describe("ResourceDetailPage", () => {
 
     await user.click(toggle);
 
-    expect(
-      screen.getByRole("button", { name: /^hide$/i }),
-    ).toHaveAttribute("aria-expanded", "true");
+    expect(screen.getByRole("button", { name: /^hide$/i })).toHaveAttribute(
+      "aria-expanded",
+      "true",
+    );
     expect(document.getElementById(panelId)).toBeTruthy();
   });
 


### PR DESCRIPTION
## Summary
  - Replaces the separate "Source Details" and "Source data" sections on the resource detail
   page with a single "Sources" section, per [STIT-478](https://…). Each source renders as a
   compact row showing source label, "Imported by {producer} · {observed date}", and a View
  action.
  - Clicking View reveals basic source fields formatted as record_id, run_id,
  and the raw payload JSON live behind a nested "Technical import record" disclosure so raw
  JSON is never visible by default.
  - Eager-fetches `/oil-gas-field-sources/{id}/detail` per row on mount (deduped by TanStack
   Query cache key) so producer + observed_at populate the row before any interaction. For 
  null-id sources (LLM-persisted suggestions awaiting merge), the View button is disabled.

  ## Acceptance criteria coverage
  - Only one source-related section ("Sources") appears on the resource detail page.
  - Raw JSON is not visible by default — it's two clicks away (View → Technical import 
  record).
  - Each row shows source label, producer, and observed date (with `—` fallback when 
  missing).
  - Clicking View reveals details for that source only.

  ## Test plan
  - [ ] `npm run test:run` — 157/157 passing locally, including 25 in 
  `ResourceDetailPage.test.jsx` (new tests cover the row meta line, the View/Hide toggle 
  aria, and the two-step raw-payload reveal).
  - [ ] Manual against mock data (`VITE_USE_MOCK_DATA=true npm run dev`): open a resource,
  verify single Sources section, rows show `—` for producer/date (mock data omits
  `source_record`), View expands inline, Technical import record stays collapsed.
  - [ ] Manual against local backend: producer + formatted date populate after the parallel 
  detail fetches resolve; raw payload only appears after opening the nested disclosure.
  - [ ] Keyboard / screen reader: Tab → View → Enter expands the row; `aria-expanded` 
  toggles correctly on both the outer and nested buttons.

  ## Notes
  - New row card uses `bg-panel` / `border-line` (matching the Identity/Production/AI 
  Suggestion sections) rather than the previous `bg-white` / `border-gray-dark/15` from 
  `SourceDetailCard`.
  - Assumes ≤ ~4 sources per resource (one per known source key). If that grows 
  significantly, we may want to revert to lazy-on-open per row. 

Mitigations if too many sources becomes a problem:
  1. Backend change (cleanest): add producer and observed_at (or the whole source_record
  summary) to OGFieldSourceView. Then useResourceDetail already carries everything the compact
  row needs, zero extra fetches.
  2. Bulk endpoint: GET /oil-gas-field-sources/details?ids=... returning N records in one
  request. One round-trip instead of N.
  3. Lazy-on-open with stub row: revert to fetching only when View is clicked, and show the row
  with just label + name + "View" (no producer/date until clicked). Violates the spec literally
  but is fine if N is large.

[STIT-478]: https://rmi1.atlassian.net/browse/STIT-478?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ