### PR TITLE
Feat/filter options (STIT-414)

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,51 @@
+## Resource Filter Options Endpoint
+
+### Summary
+Add a read-only endpoint at `GET /oil-gas-fields/filter-options?field=country` that returns the distinct coalesced resource values visible to the current user for one requested field. The query must use the same resource-side coalescing and permission scoping as `GET /oil-gas-fields/`, but it will not apply the rest of the current list filters in this PR.
+
+### Key Changes
+- Add a new endpoint under the existing `oil_gas_fields` router:
+  - `GET /oil-gas-fields/filter-options`
+  - Required query param: `field`
+- Define a small response model in the API entities layer.
+  - Default assumption: `{ "field": "country", "values": ["CAN", "USA"] }`
+  - Keep `values` sorted ascending and omit `null` / empty-string values.
+- Add a dedicated field-param type for this endpoint rather than reusing `OGFieldQueryParams`.
+  - Validate `field` against a whitelist of supported resource filter-option fields.
+  - Default assumption: support the coalesced scalar filter fields used by the table filters, not `q`, not list/JSON fields (`owners`, `operators`), and not raw-source-only fields.
+- Implement a new DB action on top of the existing coalesced resource CTE in `og_field_resource_actions.py`.
+  - Reuse `_build_licensed_resource_list_cte(...)` so results match resource visibility and source-priority coalescing.
+  - Do not apply `_build_final_conditions(...)` in this endpoint.
+  - Do still pass `licensed_sources(claims)` and the selected `source` set, so the result reflects the user-visible resource universe.
+- Keep this endpoint resource-based, not source-based.
+  - Distinct values come from the coalesced resource columns after permission scoping, never from raw source rows.
+
+### API / Behavior Details
+- Request:
+  - `GET /oil-gas-fields/filter-options?field=country`
+  - Optional `source` query params may still be accepted if convenient, since source selection is part of resource visibility.
+- Response:
+  - `field`: echoed requested field
+  - `values`: distinct visible values for that coalesced field
+- Validation:
+  - Unknown or unsupported `field` returns `422`.
+- Non-goal for this PR:
+  - No interaction with the rest of the active resource filters.
+  - This means the UI may later allow choosing a filter value that produces an empty result set; that is accepted for now.
+
+### Test Plan
+- Router unit tests:
+  - `GET /oil-gas-fields/filter-options?field=country` returns `200` and the expected response envelope.
+  - Invalid field such as `owners` returns `422`.
+  - Router passes claims-derived licensed sources into the DB action.
+- DB integration tests:
+  - Distinct values are computed from coalesced resource data, not individual source rows.
+  - Licensed-source restrictions remove values that only exist in unlicensed sources.
+  - Repointed / inactive-membership resources are excluded consistently with the main resource list.
+  - `null` and empty-string values are excluded.
+  - Results are sorted and deduplicated.
+
+### Assumptions
+- The endpoint should ignore current non-source resource filters in this PR, per your direction.
+- The response should be a simple object with `field` and `values`.
+- Supported `field` values should be limited to resource-table filter fields, not every `OilGasFieldBase` attribute.

--- a/deployments/api/src/stitch/api/db/og_field_resource_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_resource_actions.py
@@ -1,5 +1,5 @@
 from collections.abc import Collection, Sequence
-from typing import Any
+from typing import Any, get_args
 
 from fastapi import HTTPException
 from sqlalchemy import (
@@ -57,9 +57,7 @@ _LIST_SCALAR_FIELDS = tuple(
 )
 _LIST_DATA_FIELDS = (*_LIST_SCALAR_FIELDS, *_LIST_JSON_FIELDS)
 _PROVENANCE_SUFFIX = "__provenance_source"
-_FILTER_OPTION_FIELDS: frozenset[str] = frozenset(
-    FilterOptionField.__args__  # type: ignore[attr-defined]
-)
+_FILTER_OPTION_FIELDS: frozenset[str] = frozenset(get_args(FilterOptionField))
 
 
 def _priority_values() -> tuple[int, ...]:

--- a/deployments/api/src/stitch/api/db/og_field_resource_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_resource_actions.py
@@ -25,7 +25,11 @@ from stitch.api.db.errors import (
     ResourceNotFoundError,
 )
 from stitch.api.auth import CurrentUser
-from stitch.api.entities import OGFieldQueryParams
+from stitch.api.entities import (
+    FilterOptionField,
+    OGFieldFilterOptionsParams,
+    OGFieldQueryParams,
+)
 from stitch.api.db.og_field_source_actions import (
     attach_sources_to_resource,
     get_or_create_sources,
@@ -53,6 +57,9 @@ _LIST_SCALAR_FIELDS = tuple(
 )
 _LIST_DATA_FIELDS = (*_LIST_SCALAR_FIELDS, *_LIST_JSON_FIELDS)
 _PROVENANCE_SUFFIX = "__provenance_source"
+_FILTER_OPTION_FIELDS: frozenset[str] = frozenset(
+    FilterOptionField.__args__  # type: ignore[attr-defined]
+)
 
 
 def _priority_values() -> tuple[int, ...]:
@@ -87,6 +94,37 @@ async def query(
     rows = (await session.execute(page_stmt)).mappings().all()
 
     return [_list_item_from_row(row) for row in rows], total
+
+
+async def filter_options(
+    session: AsyncSession,
+    params: OGFieldFilterOptionsParams,
+    licensed_sources: Collection[OGSISrcKey] | None = None,
+) -> list[str]:
+    """Return distinct coalesced resource values for one filterable field."""
+    if params.field not in _FILTER_OPTION_FIELDS:
+        raise HTTPException(
+            status_code=422,
+            detail=f"field={params.field} is not supported for resource filter options.",
+        )
+
+    coalesced = _build_licensed_resource_list_cte(params, licensed_sources)
+    col = _resource_list_column(coalesced, params.field)
+    if col is None:
+        raise HTTPException(
+            status_code=422,
+            detail=f"field={params.field} is not supported for resource filter options.",
+        )
+
+    value_col = cast(col, String).label("value")
+    stmt = (
+        select(value_col)
+        .where(col.is_not(None), cast(col, String) != "")
+        .distinct()
+        .order_by(value_col)
+    )
+    values = await session.scalars(stmt)
+    return list(values.all())
 
 
 def _build_licensed_resource_list_cte(

--- a/deployments/api/src/stitch/api/entities.py
+++ b/deployments/api/src/stitch/api/entities.py
@@ -96,6 +96,19 @@ SortableField = Literal[
     "resource_id",
 ]
 
+FilterOptionField = Literal[
+    "name",
+    "name_local",
+    "basin",
+    "state_province",
+    "region",
+    "country",
+    "field_status",
+    "location_type",
+    "production_conventionality",
+    "primary_hydrocarbon_group",
+]
+
 
 class OGFieldFilterParams(BaseModel):
     q: str | None = None
@@ -119,6 +132,16 @@ class OGFieldSortParams(BaseModel):
 
 class OGFieldQueryParams(PaginationParams, OGFieldFilterParams, OGFieldSortParams):
     source: list[OGSISrcKey] = Field(default_factory=lambda: list(OGSI_SOURCE_DEFAULT))
+
+
+class OGFieldFilterOptionsParams(BaseModel):
+    field: FilterOptionField
+    source: list[OGSISrcKey] = Field(default_factory=lambda: list(OGSI_SOURCE_DEFAULT))
+
+
+class OGFieldFilterOptionsResponse(BaseModel):
+    field: FilterOptionField
+    values: list[str]
 
 
 class MergeCandidateStatus(StrEnum):

--- a/deployments/api/src/stitch/api/routers/oil_gas_fields.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_fields.py
@@ -4,6 +4,8 @@ from typing import Annotated
 from fastapi import APIRouter, HTTPException, Query
 
 from stitch.api.entities import (
+    OGFieldFilterOptionsParams,
+    OGFieldFilterOptionsResponse,
     MergeCandidateCreateRequest,
     MergeCandidateReviewRequest,
     MergeCandidateView,
@@ -64,6 +66,22 @@ async def get_all_resources(
         page=params.page,
         page_size=params.page_size,
     )
+
+
+@router.get("/filter-options", response_model=OGFieldFilterOptionsResponse)
+async def get_resource_filter_options(
+    *,
+    uow: UnitOfWorkDep,
+    _user: CurrentUser,
+    claims: Claims,
+    params: Annotated[OGFieldFilterOptionsParams, Query()],
+) -> OGFieldFilterOptionsResponse:
+    values = await resource_actions.filter_options(
+        session=uow.session,
+        params=params,
+        licensed_sources=licensed_sources(claims),
+    )
+    return OGFieldFilterOptionsResponse(field=params.field, values=values)
 
 
 @router.get("/merge-candidates", response_model=list[MergeCandidateView])

--- a/deployments/api/src/stitch/api/routers/oil_gas_fields.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_fields.py
@@ -96,8 +96,6 @@ async def get_resource_filter_options(
     response_model=list[MergeCandidateView],
     dependencies=[Depends(require_permissions(MERGE_CANDIDATE_READ))],
 )
-
-
 async def list_merge_candidates(
     *, uow: UnitOfWorkDep, _user: CurrentUser
 ) -> list[MergeCandidateView]:

--- a/deployments/api/tests/db/test_resource_actions.py
+++ b/deployments/api/tests/db/test_resource_actions.py
@@ -639,7 +639,10 @@ class TestResourceFilterOptionsAction:
         value_col = resource_actions.cast(col, resource_actions.String).label("value")
         stmt = (
             resource_actions.select(value_col)
-            .where(col.is_not(None), resource_actions.cast(col, resource_actions.String) != "")
+            .where(
+                col.is_not(None),
+                resource_actions.cast(col, resource_actions.String) != "",
+            )
             .distinct()
             .order_by(value_col)
         )
@@ -651,7 +654,10 @@ class TestResourceFilterOptionsAction:
             )
         )
 
-        assert "SELECT DISTINCT CAST(licensed_resource_list.basin AS VARCHAR) AS value" in sql
+        assert (
+            "SELECT DISTINCT CAST(licensed_resource_list.basin AS VARCHAR) AS value"
+            in sql
+        )
         assert "ORDER BY value" in sql
 
     @pytest.mark.anyio

--- a/deployments/api/tests/db/test_resource_actions.py
+++ b/deployments/api/tests/db/test_resource_actions.py
@@ -2,6 +2,8 @@
 
 import pytest
 from fastapi import HTTPException
+from sqlalchemy.dialects import postgresql
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from stitch.api.db import og_field_resource_actions as resource_actions
@@ -12,6 +14,7 @@ from stitch.api.db.model import (
     ResourceModel,
 )
 from stitch.api.entities import (
+    OGFieldFilterOptionsParams,
     OGFieldQueryParams,
     User,
 )
@@ -516,6 +519,140 @@ class TestResourceQueryAction:
         assert [item.id for item in items] == [resource_id]
         assert items[0].data.name == "LLM Name"
         assert items[0].provenance["name"] == "llm"
+
+
+class TestResourceFilterOptionsAction:
+    """Integration tests for resource_actions.filter_options()."""
+
+    @pytest.mark.anyio
+    async def test_returns_distinct_sorted_coalesced_values(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": None},
+            {"source": "gem", "country": "CAN"},
+        )
+        await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": "USA"},
+        )
+        await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": ""},
+        )
+        await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": None},
+        )
+
+        values = await resource_actions.filter_options(
+            seeded_integration_session,
+            OGFieldFilterOptionsParams(field="country"),
+        )
+
+        assert values == ["CAN", "USA"]
+
+    @pytest.mark.anyio
+    async def test_honors_licensed_sources_after_coalescing(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": None},
+            {"source": "gem", "country": "CAN"},
+        )
+        await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": "USA"},
+        )
+
+        values = await resource_actions.filter_options(
+            seeded_integration_session,
+            OGFieldFilterOptionsParams(field="country"),
+            licensed_sources=frozenset({"gem", "wm", "llm"}),
+        )
+
+        assert values == ["CAN"]
+
+    @pytest.mark.anyio
+    async def test_excludes_repointed_and_inactive_memberships(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        active_id = await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": "USA"},
+        )
+        repointed_to_id = await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": "BRA"},
+        )
+        inactive_id = await _create_resource_with_sources(
+            seeded_integration_session,
+            test_user,
+            {"source": "rmi", "country": "CAN"},
+        )
+
+        repointed_resource = await seeded_integration_session.get(
+            ResourceModel, repointed_to_id
+        )
+        assert repointed_resource is not None
+        repointed_resource.repointed_id = active_id
+
+        inactive_membership = await seeded_integration_session.scalar(
+            select(MembershipModel).where(MembershipModel.resource_id == inactive_id)
+        )
+        assert inactive_membership is not None
+        inactive_membership.status = MembershipStatus.INACTIVE
+        await seeded_integration_session.flush()
+
+        values = await resource_actions.filter_options(
+            seeded_integration_session,
+            OGFieldFilterOptionsParams(field="country"),
+        )
+
+        assert values == ["USA"]
+
+    def test_postgres_distinct_query_orders_by_selected_value_alias(self):
+        params = OGFieldFilterOptionsParams(field="basin")
+        coalesced = resource_actions._build_licensed_resource_list_cte(
+            params,
+            licensed_sources=frozenset({"gem", "wm", "rmi", "llm"}),
+        )
+        col = resource_actions._resource_list_column(coalesced, params.field)
+        assert col is not None
+
+        value_col = resource_actions.cast(col, resource_actions.String).label("value")
+        stmt = (
+            resource_actions.select(value_col)
+            .where(col.is_not(None), resource_actions.cast(col, resource_actions.String) != "")
+            .distinct()
+            .order_by(value_col)
+        )
+
+        sql = str(
+            stmt.compile(
+                dialect=postgresql.dialect(),
+                compile_kwargs={"literal_binds": True},
+            )
+        )
+
+        assert "SELECT DISTINCT CAST(licensed_resource_list.basin AS VARCHAR) AS value" in sql
+        assert "ORDER BY value" in sql
 
     @pytest.mark.anyio
     async def test_only_unlicensed_selected_sources_still_return_resource(

--- a/deployments/api/tests/routers/test_query_param_validation.py
+++ b/deployments/api/tests/routers/test_query_param_validation.py
@@ -61,6 +61,16 @@ class TestResourceRouterParamValidation:
         )
         assert resp.status_code == 422
 
+    @pytest.mark.anyio
+    async def test_invalid_filter_options_field_returns_422(
+        self, async_client: AsyncClient
+    ):
+        """filter-options field must be one of the supported coalesced scalar fields."""
+        resp = await async_client.get(
+            "/oil-gas-fields/filter-options", params={"field": "owners"}
+        )
+        assert resp.status_code == 422
+
 
 class TestSourceRouterParamValidation:
     """Verify FastAPI/Pydantic rejects invalid filter/sort params on GET /oil-gas-field-sources/."""

--- a/deployments/api/tests/routers/test_resources_unit.py
+++ b/deployments/api/tests/routers/test_resources_unit.py
@@ -257,8 +257,6 @@ class TestGetResourceFilterOptionsUnit:
         assert response.status_code == 200
         mock_repo.filter_options.assert_awaited_once()
         call_kwargs = mock_repo.filter_options.call_args.kwargs
-        assert call_kwargs["licensed_sources"] == frozenset(
-            {"rmi", "gem", "wm", "llm"}
-        )
+        assert call_kwargs["licensed_sources"] == frozenset({"rmi", "gem", "wm", "llm"})
         assert call_kwargs["params"].field == "country"
         assert call_kwargs["params"].source == ["gem", "wm"]

--- a/deployments/api/tests/routers/test_resources_unit.py
+++ b/deployments/api/tests/routers/test_resources_unit.py
@@ -214,3 +214,51 @@ class TestGetAllResourcesUnit:
         params = call_kwargs["params"]
         assert params.offset == 10
         assert params.limit == 10
+
+
+class TestGetResourceFilterOptionsUnit:
+    """Unit tests for GET /oil-gas-fields/filter-options endpoint."""
+
+    @pytest.mark.anyio
+    async def test_returns_filter_options(self, async_client, mock_uow):
+        async def override_get_uow():
+            yield mock_uow
+
+        app.dependency_overrides[get_uow] = override_get_uow
+
+        with patch("stitch.api.routers.oil_gas_fields.resource_actions") as mock_repo:
+            mock_repo.filter_options = AsyncMock(return_value=["CAN", "USA"])
+
+            response = await async_client.get(
+                "/oil-gas-fields/filter-options?field=country"
+            )
+
+        assert response.status_code == 200
+        assert response.json() == {"field": "country", "values": ["CAN", "USA"]}
+
+    @pytest.mark.anyio
+    async def test_passes_licensed_sources_and_source_filters(
+        self,
+        async_client,
+        mock_uow,
+    ):
+        async def override_get_uow():
+            yield mock_uow
+
+        app.dependency_overrides[get_uow] = override_get_uow
+
+        with patch("stitch.api.routers.oil_gas_fields.resource_actions") as mock_repo:
+            mock_repo.filter_options = AsyncMock(return_value=["CAN", "USA"])
+
+            response = await async_client.get(
+                "/oil-gas-fields/filter-options?field=country&source=gem&source=wm"
+            )
+
+        assert response.status_code == 200
+        mock_repo.filter_options.assert_awaited_once()
+        call_kwargs = mock_repo.filter_options.call_args.kwargs
+        assert call_kwargs["licensed_sources"] == frozenset(
+            {"rmi", "gem", "wm", "llm"}
+        )
+        assert call_kwargs["params"].field == "country"
+        assert call_kwargs["params"].source == ["gem", "wm"]

--- a/deployments/stitch-frontend/src/components/FilterBar.jsx
+++ b/deployments/stitch-frontend/src/components/FilterBar.jsx
@@ -1,30 +1,22 @@
-import { useMemo } from "react";
 import FilterDropdown from "./FilterDropdown";
 import { FILTER_FIELDS, EMPTY_FILTERS } from "../config/filters";
-import { getResourceField } from "../utils/resourceDisplay";
+import { useResourceFilterOptions } from "../hooks/useResources";
 
-// Compute sorted option list with static counts from the full dataset.
-function buildOptions(resources, field) {
-  const counts = {};
-  for (const r of resources) {
-    const val = getResourceField(r, field);
-    if (val != null) counts[val] = (counts[val] ?? 0) + 1;
-  }
-  return Object.entries(counts)
-    .map(([value, count]) => ({ value, count }))
-    .sort((a, b) => a.value.localeCompare(b.value));
+function FilterFieldDropdown({ endpoint, field, label, selected, onChange }) {
+  const { data } = useResourceFilterOptions(endpoint, field);
+  const options = (data?.values ?? []).map((value) => ({ value }));
+
+  return (
+    <FilterDropdown
+      label={label}
+      options={options}
+      selected={selected}
+      onChange={onChange}
+    />
+  );
 }
 
-export default function FilterBar({ resources, filters, onFiltersChange }) {
-  // Memoize per-field options so O(n) passes only re-run when `resources` changes,
-  // not on every filter interaction.
-  const optionsByField = useMemo(
-    () =>
-      Object.fromEntries(
-        FILTER_FIELDS.map(({ key }) => [key, buildOptions(resources, key)]),
-      ),
-    [resources],
-  );
+export default function FilterBar({ endpoint, filters, onFiltersChange }) {
   // Flatten active filters into chips: [{ field, label, value }, ...]
   const chips = FILTER_FIELDS.flatMap(({ key, label }) =>
     (filters[key] ?? []).map((value) => ({ field: key, label, value })),
@@ -46,10 +38,11 @@ export default function FilterBar({ resources, filters, onFiltersChange }) {
       {/* Dropdowns row */}
       <div className="flex flex-wrap gap-2">
         {FILTER_FIELDS.map(({ key, label }) => (
-          <FilterDropdown
+          <FilterFieldDropdown
             key={key}
+            endpoint={endpoint}
+            field={key}
             label={label}
-            options={optionsByField[key]}
             selected={filters[key] ?? []}
             onChange={(values) => handleDropdownChange(key, values)}
           />

--- a/deployments/stitch-frontend/src/components/FilterDropdown.jsx
+++ b/deployments/stitch-frontend/src/components/FilterDropdown.jsx
@@ -70,7 +70,9 @@ export default function FilterDropdown({ label, options, selected, onChange }) {
                       className="accent-primary"
                     />
                     <span className="flex-1 text-sm text-ink">{value}</span>
-                    <span className="text-xs text-ink-muted">{count}</span>
+                    {count != null && (
+                      <span className="text-xs text-ink-muted">{count}</span>
+                    )}
                   </label>
                 </li>
               ))}

--- a/deployments/stitch-frontend/src/components/ResourcesView.jsx
+++ b/deployments/stitch-frontend/src/components/ResourcesView.jsx
@@ -179,9 +179,9 @@ export default function ResourcesView({ className = "", endpoint }) {
           <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-ink-muted">
             Filters
           </p>
-          {resources.length > 0 && (
+          {data && (
             <FilterBar
-              resources={resources}
+              endpoint={endpoint}
               filters={filters}
               onFiltersChange={handleFiltersChange}
             />

--- a/deployments/stitch-frontend/src/components/ResourcesView.test.jsx
+++ b/deployments/stitch-frontend/src/components/ResourcesView.test.jsx
@@ -2,7 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, within, fireEvent } from "@testing-library/react";
 import { renderWithQueryClient } from "../test/utils";
 import ResourcesView from "./ResourcesView";
-import { useResources } from "../hooks/useResources";
+import {
+  useResourceFilterOptions,
+  useResources,
+} from "../hooks/useResources";
 import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE } from "../queries/resources";
 
 vi.mock("../hooks/useResources");
@@ -65,6 +68,20 @@ beforeEach(() => {
     ...defaultHookReturn,
     refetch: vi.fn(),
   });
+  vi.mocked(useResourceFilterOptions).mockImplementation((_endpoint, field) => ({
+    ...defaultHookReturn,
+    data: {
+      field,
+      values:
+        field === "region"
+          ? ["Middle East"]
+          : field === "basin"
+            ? ["Arabian", "Permian"]
+            : field === "state_province"
+              ? ["Kuwait"]
+              : ["Producing"],
+    },
+  }));
 });
 
 describe("ResourcesView", () => {
@@ -183,6 +200,17 @@ describe("ResourcesView", () => {
     renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);
 
     expect(screen.queryByTestId("filter-bar")).not.toBeInTheDocument();
+  });
+
+  it("shows filter bar when the current result set is empty", () => {
+    vi.mocked(useResources).mockReturnValue({
+      ...defaultHookReturn,
+      data: { ...mockResourceData, items: [], total_count: 0 },
+    });
+
+    renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);
+
+    expect(screen.getByTestId("filter-bar")).toBeInTheDocument();
   });
 
   describe("pagination", () => {
@@ -321,6 +349,32 @@ describe("ResourcesView", () => {
   });
 
   describe("filtering", () => {
+    it("loads dropdown options from filter-options queries", () => {
+      vi.mocked(useResources).mockReturnValue({
+        ...defaultHookReturn,
+        data: mockResourceData,
+      });
+
+      renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);
+
+      expect(useResourceFilterOptions).toHaveBeenCalledWith(
+        ENDPOINT,
+        "region",
+      );
+      expect(useResourceFilterOptions).toHaveBeenCalledWith(
+        ENDPOINT,
+        "state_province",
+      );
+      expect(useResourceFilterOptions).toHaveBeenCalledWith(
+        ENDPOINT,
+        "basin",
+      );
+      expect(useResourceFilterOptions).toHaveBeenCalledWith(
+        ENDPOINT,
+        "field_status",
+      );
+    });
+
     it("passes active filters to useResources", () => {
       vi.mocked(useResources).mockReturnValue({
         ...defaultHookReturn,

--- a/deployments/stitch-frontend/src/components/ResourcesView.test.jsx
+++ b/deployments/stitch-frontend/src/components/ResourcesView.test.jsx
@@ -2,10 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { screen, within, fireEvent } from "@testing-library/react";
 import { renderWithQueryClient } from "../test/utils";
 import ResourcesView from "./ResourcesView";
-import {
-  useResourceFilterOptions,
-  useResources,
-} from "../hooks/useResources";
+import { useResourceFilterOptions, useResources } from "../hooks/useResources";
 import { DEFAULT_PAGE_SIZE, DEFAULT_PAGE } from "../queries/resources";
 
 vi.mock("../hooks/useResources");
@@ -68,20 +65,22 @@ beforeEach(() => {
     ...defaultHookReturn,
     refetch: vi.fn(),
   });
-  vi.mocked(useResourceFilterOptions).mockImplementation((_endpoint, field) => ({
-    ...defaultHookReturn,
-    data: {
-      field,
-      values:
-        field === "region"
-          ? ["Middle East"]
-          : field === "basin"
-            ? ["Arabian", "Permian"]
-            : field === "state_province"
-              ? ["Kuwait"]
-              : ["Producing"],
-    },
-  }));
+  vi.mocked(useResourceFilterOptions).mockImplementation(
+    (_endpoint, field) => ({
+      ...defaultHookReturn,
+      data: {
+        field,
+        values:
+          field === "region"
+            ? ["Middle East"]
+            : field === "basin"
+              ? ["Arabian", "Permian"]
+              : field === "state_province"
+                ? ["Kuwait"]
+                : ["Producing"],
+      },
+    }),
+  );
 });
 
 describe("ResourcesView", () => {
@@ -357,18 +356,12 @@ describe("ResourcesView", () => {
 
       renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);
 
-      expect(useResourceFilterOptions).toHaveBeenCalledWith(
-        ENDPOINT,
-        "region",
-      );
+      expect(useResourceFilterOptions).toHaveBeenCalledWith(ENDPOINT, "region");
       expect(useResourceFilterOptions).toHaveBeenCalledWith(
         ENDPOINT,
         "state_province",
       );
-      expect(useResourceFilterOptions).toHaveBeenCalledWith(
-        ENDPOINT,
-        "basin",
-      );
+      expect(useResourceFilterOptions).toHaveBeenCalledWith(ENDPOINT, "basin");
       expect(useResourceFilterOptions).toHaveBeenCalledWith(
         ENDPOINT,
         "field_status",

--- a/deployments/stitch-frontend/src/hooks/useResources.js
+++ b/deployments/stitch-frontend/src/hooks/useResources.js
@@ -47,6 +47,18 @@ function useResourcesReal(
   });
 }
 
+function useResourceFilterOptionsReal(
+  endpoint = "resources",
+  field,
+  enabled = true,
+) {
+  const config = useConfig();
+  return useAuthenticatedQuery({
+    ...resourceQueries.filterOptions(config, endpoint, field),
+    enabled: enabled && Boolean(field),
+  });
+}
+
 function useResourceReal(endpoint = "resources", id, enabled = false) {
   const config = useConfig();
   return useAuthenticatedQuery({
@@ -185,6 +197,18 @@ function getMockResourcePage({
   };
 }
 
+function getMockFilterOptions(field) {
+  const values = Array.from(
+    new Set(
+      MOCK_RESOURCE_ITEMS.map((resource) => getResourceField(resource, field))
+        .filter((value) => value != null && value !== "")
+        .map(String),
+    ),
+  ).sort((a, b) => a.localeCompare(b));
+
+  return { field, values };
+}
+
 function useResourcesMock(
   endpoint = "resources",
   {
@@ -218,6 +242,18 @@ function useResourcesMock(
         }),
       ),
     enabled,
+  });
+}
+
+function useResourceFilterOptionsMock(
+  endpoint = "resources",
+  field,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: resourceKeys.filterOptions(endpoint, field),
+    queryFn: () => Promise.resolve(getMockFilterOptions(field)),
+    enabled: enabled && Boolean(field),
   });
 }
 
@@ -297,6 +333,9 @@ function useMergeCandidatePreviewReal(
 
 // Export one implementation based on the compile-time flag. Assign at module level
 export const useResources = USE_MOCK_DATA ? useResourcesMock : useResourcesReal;
+export const useResourceFilterOptions = USE_MOCK_DATA
+  ? useResourceFilterOptionsMock
+  : useResourceFilterOptionsReal;
 export const useResource = USE_MOCK_DATA ? useResourceMock : useResourceReal;
 export const useResourceDetail = USE_MOCK_DATA
   ? useResourceDetailMock

--- a/deployments/stitch-frontend/src/queries/api.js
+++ b/deployments/stitch-frontend/src/queries/api.js
@@ -21,6 +21,21 @@ export async function getResources(
   return await response.json();
 }
 
+export async function getResourceFilterOptions(
+  config,
+  fetcher,
+  endpoint = "resources",
+  field,
+) {
+  const params = new URLSearchParams({ field });
+  const url = `${config.apiBaseUrl}/${endpoint}/filter-options?${params}`;
+  const response = await fetcher(url);
+  if (!response.ok) {
+    throw new Error(`HTTP error! status: ${response.status}`);
+  }
+  return await response.json();
+}
+
 export async function getResource(config, id, fetcher, endpoint = "resources") {
   const url = `${config.apiBaseUrl}/${endpoint}/${id}`;
   const response = await fetcher(url);

--- a/deployments/stitch-frontend/src/queries/api.test.js
+++ b/deployments/stitch-frontend/src/queries/api.test.js
@@ -3,6 +3,7 @@ import {
   createLLMSuggestion,
   createMergeCandidate,
   createResource,
+  getResourceFilterOptions,
   getResources,
   getResource,
   reviewMergeCandidate,
@@ -124,6 +125,41 @@ describe("API Functions", () => {
       await expect(getResources(config, mockFetcher)).rejects.toThrow(
         "Network error",
       );
+    });
+  });
+
+  describe("getResourceFilterOptions", () => {
+    it("fetches and returns filter options successfully", async () => {
+      const mockOptions = { field: "basin", values: ["Arabian", "Permian"] };
+
+      mockFetcher.mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => mockOptions,
+      });
+
+      const result = await getResourceFilterOptions(
+        config,
+        mockFetcher,
+        "oil-gas-fields",
+        "basin",
+      );
+
+      expect(mockFetcher).toHaveBeenCalledWith(
+        "http://localhost:8000/api/v1/oil-gas-fields/filter-options?field=basin",
+      );
+      expect(result).toEqual(mockOptions);
+    });
+
+    it("throws error when filter options response is not ok", async () => {
+      mockFetcher.mockResolvedValueOnce({
+        ok: false,
+        status: 500,
+      });
+
+      await expect(
+        getResourceFilterOptions(config, mockFetcher, "oil-gas-fields", "basin"),
+      ).rejects.toThrow("HTTP error! status: 500");
     });
   });
 

--- a/deployments/stitch-frontend/src/queries/api.test.js
+++ b/deployments/stitch-frontend/src/queries/api.test.js
@@ -158,7 +158,12 @@ describe("API Functions", () => {
       });
 
       await expect(
-        getResourceFilterOptions(config, mockFetcher, "oil-gas-fields", "basin"),
+        getResourceFilterOptions(
+          config,
+          mockFetcher,
+          "oil-gas-fields",
+          "basin",
+        ),
       ).rejects.toThrow("HTTP error! status: 500");
     });
   });

--- a/deployments/stitch-frontend/src/queries/resources.js
+++ b/deployments/stitch-frontend/src/queries/resources.js
@@ -1,4 +1,5 @@
 import {
+  getResourceFilterOptions,
   getResource,
   getResources,
   getResourceDetail,
@@ -18,6 +19,11 @@ export const resourceKeys = {
   list: (endpoint = "resources", filters) => [
     ...resourceKeys.lists(endpoint),
     filters,
+  ],
+  filterOptions: (endpoint = "resources", field) => [
+    ...resourceKeys.all(endpoint),
+    "filter-options",
+    field,
   ],
   details: (endpoint = "resources") => [
     ...resourceKeys.all(endpoint),
@@ -76,6 +82,14 @@ export const resourceQueries = {
         sort_by,
         sort_order,
       }),
+    enabled: false,
+    staleTime: DEFAULT_STALE_TIME,
+  }),
+
+  filterOptions: (config, endpoint = "resources", field) => ({
+    queryKey: resourceKeys.filterOptions(endpoint, field),
+    queryFn: (fetcher) =>
+      getResourceFilterOptions(config, fetcher, endpoint, field),
     enabled: false,
     staleTime: DEFAULT_STALE_TIME,
   }),


### PR DESCRIPTION
Exposes an authenticated endpoint that lists distinct values for a field, as constructed using the user's permissions and standard coalescing rules (different users will see different result sets here), and update frontend to make use of it.

Eliminates behavior of filter dropdowns only showing values from the currently displayed page of PaginatedResponse

Supported by codex

Tested locally with auth, and in the PR environment: