### PR TITLE
don't include `Bearer ` in copied text

### DIFF
--- a/deployments/stitch-frontend/src/components/ColophonPanel.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.jsx
@@ -279,7 +279,7 @@ export default function ColophonPanel({ diagnosticsOpen = false }) {
     }
 
     try {
-      await navigator.clipboard.writeText(`Bearer ${accessToken}`);
+      await navigator.clipboard.writeText(accessToken);
       setTokenCopied(true);
       setTokenCopyError(false);
       window.setTimeout(() => setTokenCopied(false), 2000);
@@ -303,7 +303,7 @@ export default function ColophonPanel({ diagnosticsOpen = false }) {
               onClick={() => void handleCopyToken()}
               disabled={!accessToken}
               className="rounded-md border border-line bg-panel px-3 py-1.5 text-sm font-medium text-ink transition-colors hover:border-line-strong hover:bg-surface focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/30 focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-              title="Copy Bearer token for API tools"
+              title="Copy raw access token for API tools"
             >
               {tokenCopied
                 ? "Token copied!"

--- a/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
@@ -438,4 +438,24 @@ describe("ColophonPanel", () => {
     expect(copiedText).toContain("### Runtime Info ###");
     expect(copiedText).toContain("User Agent: VitestBrowser/1.0");
   });
+
+  it("copies the raw access token without a Bearer prefix", async () => {
+    const { default: ColophonPanel } = await import("./ColophonPanel");
+
+    renderWithQueryClient(<ColophonPanel diagnosticsOpen />);
+
+    await waitFor(() => {
+      expect(screen.getByText("stitch-api")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy token" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Token copied!" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(clipboardSpy).toHaveBeenCalledWith("test-access-token");
+  });
 });

--- a/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
+++ b/deployments/stitch-frontend/src/components/ColophonPanel.test.jsx
@@ -440,6 +440,19 @@ describe("ColophonPanel", () => {
 
     await waitFor(() => {
       expect(screen.getByText("stitch-api")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Copy token" }));
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: "Token copied!" }),
+      ).toBeInTheDocument();
+    });
+
+    expect(clipboardSpy).toHaveBeenCalledWith("test-access-token");
+  });
+
   it("requests the configured audience for displayed and copied tokens", async () => {
     const { default: ColophonPanel } = await import("./ColophonPanel");
 


### PR DESCRIPTION
Quality of life PR: Copy only the actual token, without `Bearer ` prefix, for easier pasting into other apps/envfiles