### PR TITLE
feat: add permissions strings and checks (STIT-422 & STIT-423)

### DIFF
--- a/packages/stitch-auth/src/stitch/auth/__init__.py
+++ b/packages/stitch-auth/src/stitch/auth/__init__.py
@@ -1,5 +1,11 @@
 from .claims import TokenClaims
-from .errors import AuthError, JWKSFetchError, TokenExpiredError, TokenValidationError
+from .errors import (
+    AuthError,
+    InsufficientPermissionsError,
+    JWKSFetchError,
+    TokenExpiredError,
+    TokenValidationError,
+)
 from .permissions import (
     ALL_PERMISSIONS,
     MERGE_CANDIDATE_CREATE,
@@ -16,6 +22,7 @@ from .permissions import (
     SOURCE_READ_RMI,
     SOURCE_READ_WM,
     SOURCE_WRITE,
+    check_permissions,
 )
 from .settings import OIDCSettings
 from .validator import JWTValidator
@@ -23,6 +30,7 @@ from .validator import JWTValidator
 __all__ = [
     "ALL_PERMISSIONS",
     "AuthError",
+    "InsufficientPermissionsError",
     "JWKSFetchError",
     "JWTValidator",
     "MERGE_CANDIDATE_CREATE",
@@ -43,4 +51,5 @@ __all__ = [
     "TokenClaims",
     "TokenExpiredError",
     "TokenValidationError",
+    "check_permissions",
 ]

--- a/packages/stitch-auth/src/stitch/auth/__init__.py
+++ b/packages/stitch-auth/src/stitch/auth/__init__.py
@@ -1,13 +1,45 @@
 from .claims import TokenClaims
 from .errors import AuthError, JWKSFetchError, TokenExpiredError, TokenValidationError
+from .permissions import (
+    ALL_PERMISSIONS,
+    MERGE_CANDIDATE_CREATE,
+    MERGE_CANDIDATE_READ,
+    MERGE_CANDIDATE_REVIEW,
+    RESOURCE_READ,
+    RESOURCE_WRITE,
+    SERVICE_ENTITY_LINKAGE_RUN,
+    SERVICE_LLM_SUGGEST,
+    SOURCE_READ_GEM,
+    SOURCE_READ_LLM,
+    SOURCE_READ_PERMISSIONS,
+    SOURCE_READ_PREFIX,
+    SOURCE_READ_RMI,
+    SOURCE_READ_WM,
+    SOURCE_WRITE,
+)
 from .settings import OIDCSettings
 from .validator import JWTValidator
 
 __all__ = [
+    "ALL_PERMISSIONS",
     "AuthError",
     "JWKSFetchError",
     "JWTValidator",
+    "MERGE_CANDIDATE_CREATE",
+    "MERGE_CANDIDATE_READ",
+    "MERGE_CANDIDATE_REVIEW",
     "OIDCSettings",
+    "RESOURCE_READ",
+    "RESOURCE_WRITE",
+    "SERVICE_ENTITY_LINKAGE_RUN",
+    "SERVICE_LLM_SUGGEST",
+    "SOURCE_READ_GEM",
+    "SOURCE_READ_LLM",
+    "SOURCE_READ_PERMISSIONS",
+    "SOURCE_READ_PREFIX",
+    "SOURCE_READ_RMI",
+    "SOURCE_READ_WM",
+    "SOURCE_WRITE",
     "TokenClaims",
     "TokenExpiredError",
     "TokenValidationError",

--- a/packages/stitch-auth/src/stitch/auth/errors.py
+++ b/packages/stitch-auth/src/stitch/auth/errors.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterable
+
+
 class AuthError(Exception):
     """Base for all auth errors. Consumers can catch broadly or narrowly."""
 
@@ -9,3 +12,34 @@ class TokenValidationError(AuthError): ...
 
 
 class JWKSFetchError(AuthError): ...
+
+
+class InsufficientPermissionsError(AuthError):
+    detail: str
+    granted: frozenset[str]
+    required: frozenset[str]
+    missing: frozenset[str]
+
+    def __init__(
+        self,
+        granted: Iterable[str],
+        required: Iterable[str],
+        missing: Iterable[str] | None = None,
+        detail: str | None = None,
+    ):
+        self.granted = frozenset(granted)
+        self.required = frozenset(required)
+        self.missing = (
+            frozenset(missing)
+            if missing is not None
+            else self.required.difference(self.granted)
+        )
+        self.detail = detail or _permission_detail(self.missing)
+        super().__init__(self.detail)
+
+
+def _permission_detail(missing: Iterable[str]) -> str:
+    missing_text = ", ".join(sorted(missing))
+    if not missing_text:
+        return "Missing required permission(s)"
+    return f"Missing required permission(s): {missing_text}"

--- a/packages/stitch-auth/src/stitch/auth/permissions.py
+++ b/packages/stitch-auth/src/stitch/auth/permissions.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Collection, Iterable
-from typing import TypeAlias
+from collections.abc import Callable, Collection, Iterable
+from typing import Literal, NoReturn, TypeAlias
+
+from .errors import InsufficientPermissionsError
 
 logger = logging.getLogger(__name__)
 
@@ -109,3 +111,52 @@ def has_any_permission(
     candidates: Iterable[str],
 ) -> bool:
     return any(permission in granted for permission in candidates)
+
+
+def check_permissions(
+    granted: Iterable[str],
+    required: Iterable[str],
+    check: Literal["all", "any"] = "all",
+    exc_handler: Callable[[InsufficientPermissionsError], NoReturn] | None = None,
+) -> None:
+    """Verify that granted permissions satisfy required permissions.
+
+    Args:
+        granted: Permissions granted to the caller.
+        required: Permissions required for the protected operation.
+        check: Whether all required permissions or any required permission must be
+            granted.
+        exc_handler: Optional callback for mapping permission failures to a
+            caller-specific exception. This callback should raise an exception.
+
+    Raises:
+        ValueError: If check is not "all" or "any".
+        InsufficientPermissionsError: If the required permissions are not
+            satisfied and exc_handler does not raise its own exception.
+    """
+    if check not in {"all", "any"}:
+        msg = f"unsupported permission check mode: {check!r}"
+        raise ValueError(msg)
+
+    granted_set = frozenset(granted)
+    required_set = frozenset(required)
+    if not required_set:
+        return None
+
+    if check == "all":
+        missing = required_set.difference(granted_set)
+        if not missing:
+            return None
+    else:
+        missing = required_set.difference(granted_set)
+        if missing != required_set:
+            return None
+
+    exc = InsufficientPermissionsError(
+        granted=granted_set,
+        required=required_set,
+        missing=missing,
+    )
+    if exc_handler is not None:
+        exc_handler(exc)
+    raise exc

--- a/packages/stitch-auth/src/stitch/auth/permissions.py
+++ b/packages/stitch-auth/src/stitch/auth/permissions.py
@@ -1,0 +1,111 @@
+"""Shared Stitch permission constants and exact-match helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Collection, Iterable
+from typing import TypeAlias
+
+logger = logging.getLogger(__name__)
+
+Permission: TypeAlias = str
+
+RESOURCE_READ: Permission = "resource:read"
+RESOURCE_WRITE: Permission = "resource:write"
+
+SOURCE_READ_PREFIX = "source:read:"
+SOURCE_READ_RMI: Permission = f"{SOURCE_READ_PREFIX}rmi"
+SOURCE_READ_GEM: Permission = f"{SOURCE_READ_PREFIX}gem"
+SOURCE_READ_WM: Permission = f"{SOURCE_READ_PREFIX}wm"
+SOURCE_READ_LLM: Permission = f"{SOURCE_READ_PREFIX}llm"
+SOURCE_READ_PERMISSIONS: frozenset[Permission] = frozenset(
+    {
+        SOURCE_READ_RMI,
+        SOURCE_READ_GEM,
+        SOURCE_READ_WM,
+        SOURCE_READ_LLM,
+    }
+)
+SOURCE_WRITE: Permission = "source:write"
+
+MERGE_CANDIDATE_READ: Permission = "merge-candidate:read"
+MERGE_CANDIDATE_CREATE: Permission = "merge-candidate:create"
+MERGE_CANDIDATE_REVIEW: Permission = "merge-candidate:review"
+
+SERVICE_ENTITY_LINKAGE_RUN: Permission = "service:entity-linkage:run"
+SERVICE_LLM_SUGGEST: Permission = "service:llm:suggest"
+
+ALL_PERMISSIONS: frozenset[Permission] = frozenset(
+    {
+        RESOURCE_READ,
+        RESOURCE_WRITE,
+        *SOURCE_READ_PERMISSIONS,
+        SOURCE_WRITE,
+        MERGE_CANDIDATE_READ,
+        MERGE_CANDIDATE_CREATE,
+        MERGE_CANDIDATE_REVIEW,
+        SERVICE_ENTITY_LINKAGE_RUN,
+        SERVICE_LLM_SUGGEST,
+    }
+)
+
+
+def source_read_permission(source: str) -> Permission:
+    return f"{SOURCE_READ_PREFIX}{source}"
+
+
+def source_from_read_permission(
+    permission: str,
+    *,
+    valid_sources: Collection[str],
+) -> str | None:
+    if not permission.startswith(SOURCE_READ_PREFIX):
+        return None
+
+    source = permission[len(SOURCE_READ_PREFIX) :]
+    if not source or ":" in source:
+        return None
+    if source not in valid_sources:
+        logger.warning("ignoring unknown source in permission: %r", permission)
+        return None
+    return source
+
+
+def source_read_sources(
+    permissions: Iterable[str],
+    *,
+    valid_sources: Collection[str],
+) -> frozenset[str]:
+    sources = {
+        source
+        for permission in permissions
+        if (
+            source := source_from_read_permission(
+                permission,
+                valid_sources=valid_sources,
+            )
+        )
+        is not None
+    }
+    return frozenset(sources)
+
+
+def missing_permissions(
+    granted: Collection[str],
+    required: Iterable[str],
+) -> frozenset[str]:
+    return frozenset(permission for permission in required if permission not in granted)
+
+
+def has_all_permissions(
+    granted: Collection[str],
+    required: Iterable[str],
+) -> bool:
+    return not missing_permissions(granted, required)
+
+
+def has_any_permission(
+    granted: Collection[str],
+    candidates: Iterable[str],
+) -> bool:
+    return any(permission in granted for permission in candidates)

--- a/packages/stitch-auth/tests/test_claims_unit.py
+++ b/packages/stitch-auth/tests/test_claims_unit.py
@@ -4,6 +4,7 @@ import pytest
 
 from pydantic import ValidationError
 from stitch.auth.claims import TokenClaims
+from stitch.auth.permissions import RESOURCE_READ, SOURCE_READ_WM
 
 
 class TestTokenClaimsConstruction:
@@ -69,12 +70,10 @@ class TestTokenClaimsPermissions:
     def test_permissions_accepts_list_and_coerces_to_frozenset(self):
         claims = TokenClaims(
             sub="auth0|abc",
-            permissions=["resource:read:public", "resource:read:licensed:wm"],
+            permissions=[RESOURCE_READ, SOURCE_READ_WM],
         )
 
-        assert claims.permissions == frozenset(
-            {"resource:read:public", "resource:read:licensed:wm"}
-        )
+        assert claims.permissions == frozenset({RESOURCE_READ, SOURCE_READ_WM})
         assert isinstance(claims.permissions, frozenset)
 
     def test_permissions_accepts_frozenset_directly(self):

--- a/packages/stitch-auth/tests/test_permissions.py
+++ b/packages/stitch-auth/tests/test_permissions.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+from stitch.auth.errors import InsufficientPermissionsError
 from stitch.auth.permissions import (
     ALL_PERMISSIONS,
     MERGE_CANDIDATE_CREATE,
@@ -10,6 +12,7 @@ from stitch.auth.permissions import (
     SOURCE_READ_PERMISSIONS,
     SOURCE_READ_RMI,
     SOURCE_WRITE,
+    check_permissions,
     has_all_permissions,
     has_any_permission,
     missing_permissions,
@@ -17,6 +20,8 @@ from stitch.auth.permissions import (
     source_read_permission,
     source_read_sources,
 )
+
+VALID_SOURCES = {"rmi", "gem"}
 
 
 def test_all_permissions_contains_defined_route_permissions():
@@ -58,26 +63,50 @@ def test_source_read_permission_formats_source():
 
 
 def test_source_from_read_permission_parses_known_source():
-    assert source_from_read_permission(SOURCE_READ_RMI) == "rmi"
+    assert (
+        source_from_read_permission(SOURCE_READ_RMI, valid_sources=VALID_SOURCES)
+        == "rmi"
+    )
 
 
 def test_source_from_read_permission_ignores_non_source_read_permission():
-    assert source_from_read_permission(RESOURCE_READ) is None
+    assert (
+        source_from_read_permission(RESOURCE_READ, valid_sources=VALID_SOURCES) is None
+    )
 
 
 def test_source_from_read_permission_ignores_malformed_source():
-    assert source_from_read_permission("source:read:") is None
-    assert source_from_read_permission("source:read:rmi:extra") is None
+    assert (
+        source_from_read_permission("source:read:", valid_sources=VALID_SOURCES)
+        is None
+    )
+    assert (
+        source_from_read_permission("source:read:rmi:", valid_sources=VALID_SOURCES)
+        is None
+    )
+    assert (
+        source_from_read_permission(
+            "source:read:rmi:extra",
+            valid_sources=VALID_SOURCES,
+        )
+        is None
+    )
 
 
 def test_source_from_read_permission_ignores_unknown_source(caplog):
     with caplog.at_level(logging.WARNING, logger="stitch.auth.permissions"):
-        assert source_from_read_permission("source:read:bogus") is None
+        assert (
+            source_from_read_permission(
+                "source:read:bogus",
+                valid_sources=VALID_SOURCES,
+            )
+            is None
+        )
 
     assert any("source:read:bogus" in rec.message for rec in caplog.records)
 
 
-def test_source_read_sources_dedupes_and_ignores_unknown():
+def test_source_read_sources_dedupes_and_filters_with_explicit_valid_sources():
     assert source_read_sources(
         [
             SOURCE_READ_RMI,
@@ -85,7 +114,8 @@ def test_source_read_sources_dedupes_and_ignores_unknown():
             SOURCE_READ_RMI,
             "source:read:bogus",
             RESOURCE_READ,
-        ]
+        ],
+        valid_sources=VALID_SOURCES,
     ) == frozenset({"rmi", "gem"})
 
 
@@ -94,3 +124,121 @@ def test_source_read_sources_accepts_explicit_valid_sources():
         [SOURCE_READ_RMI, SOURCE_READ_GEM],
         valid_sources={"gem"},
     ) == frozenset({"gem"})
+
+
+def test_check_permissions_all_succeeds_when_all_required_are_granted():
+    assert (
+        check_permissions(
+            {RESOURCE_READ, RESOURCE_WRITE},
+            [RESOURCE_READ, RESOURCE_WRITE],
+        )
+        is None
+    )
+
+
+def test_check_permissions_all_raises_with_structured_error():
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        check_permissions({RESOURCE_READ}, [RESOURCE_READ, RESOURCE_WRITE])
+
+    exc = exc_info.value
+    assert exc.granted == frozenset({RESOURCE_READ})
+    assert exc.required == frozenset({RESOURCE_READ, RESOURCE_WRITE})
+    assert exc.missing == frozenset({RESOURCE_WRITE})
+    assert exc.detail == "Missing required permission(s): resource:write"
+    assert str(exc) == exc.detail
+
+
+def test_check_permissions_any_succeeds_when_any_candidate_is_granted():
+    assert (
+        check_permissions(
+            {RESOURCE_READ},
+            [SOURCE_READ_RMI, RESOURCE_READ],
+            check="any",
+        )
+        is None
+    )
+
+
+def test_check_permissions_any_raises_when_no_candidates_are_granted():
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        check_permissions(
+            {SOURCE_READ_RMI},
+            [RESOURCE_READ, RESOURCE_WRITE],
+            check="any",
+        )
+
+    exc = exc_info.value
+    assert exc.granted == frozenset({SOURCE_READ_RMI})
+    assert exc.required == frozenset({RESOURCE_READ, RESOURCE_WRITE})
+    assert exc.missing == frozenset({RESOURCE_READ, RESOURCE_WRITE})
+    assert exc.detail == (
+        "Missing required permission(s): resource:read, resource:write"
+    )
+
+
+@pytest.mark.parametrize("check", ["all", "any"])
+def test_check_permissions_empty_required_succeeds(check):
+    assert check_permissions({RESOURCE_READ}, [], check=check) is None
+
+
+def test_check_permissions_invalid_check_raises_value_error():
+    with pytest.raises(ValueError, match="unsupported permission check mode"):
+        check_permissions({RESOURCE_READ}, [RESOURCE_READ], check="some")
+
+
+def test_check_permissions_iterator_inputs_preserve_error_payloads():
+    granted = iter([RESOURCE_READ])
+    required = iter([RESOURCE_READ, RESOURCE_WRITE])
+
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        check_permissions(granted, required)
+
+    exc = exc_info.value
+    assert exc.granted == frozenset({RESOURCE_READ})
+    assert exc.required == frozenset({RESOURCE_READ, RESOURCE_WRITE})
+    assert exc.missing == frozenset({RESOURCE_WRITE})
+
+
+def test_check_permissions_raising_exc_handler_gets_structured_error():
+    seen: list[InsufficientPermissionsError] = []
+
+    def raise_forbidden(exc: InsufficientPermissionsError):
+        seen.append(exc)
+        raise RuntimeError("forbidden")
+
+    with pytest.raises(RuntimeError, match="forbidden"):
+        check_permissions(
+            {RESOURCE_READ},
+            [RESOURCE_WRITE],
+            exc_handler=raise_forbidden,
+        )
+
+    assert len(seen) == 1
+    assert seen[0].missing == frozenset({RESOURCE_WRITE})
+
+
+def test_check_permissions_returning_exc_handler_still_raises_original_error():
+    seen: list[InsufficientPermissionsError] = []
+
+    def returns_unexpectedly(exc: InsufficientPermissionsError):
+        seen.append(exc)
+
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        check_permissions(
+            {RESOURCE_READ},
+            [RESOURCE_WRITE],
+            exc_handler=returns_unexpectedly,
+        )
+
+    assert seen == [exc_info.value]
+    assert exc_info.value.missing == frozenset({RESOURCE_WRITE})
+
+
+def test_top_level_exports_permission_helper_and_error():
+    from stitch.auth import (
+        InsufficientPermissionsError as exported_error,
+        check_permissions as exported_check_permissions,
+    )
+
+    assert exported_check_permissions is check_permissions
+    assert exported_error is InsufficientPermissionsError

--- a/packages/stitch-auth/tests/test_permissions.py
+++ b/packages/stitch-auth/tests/test_permissions.py
@@ -77,8 +77,7 @@ def test_source_from_read_permission_ignores_non_source_read_permission():
 
 def test_source_from_read_permission_ignores_malformed_source():
     assert (
-        source_from_read_permission("source:read:", valid_sources=VALID_SOURCES)
-        is None
+        source_from_read_permission("source:read:", valid_sources=VALID_SOURCES) is None
     )
     assert (
         source_from_read_permission("source:read:rmi:", valid_sources=VALID_SOURCES)

--- a/packages/stitch-auth/tests/test_permissions.py
+++ b/packages/stitch-auth/tests/test_permissions.py
@@ -1,0 +1,96 @@
+import logging
+
+from stitch.auth.permissions import (
+    ALL_PERMISSIONS,
+    MERGE_CANDIDATE_CREATE,
+    RESOURCE_READ,
+    RESOURCE_WRITE,
+    SERVICE_LLM_SUGGEST,
+    SOURCE_READ_GEM,
+    SOURCE_READ_PERMISSIONS,
+    SOURCE_READ_RMI,
+    SOURCE_WRITE,
+    has_all_permissions,
+    has_any_permission,
+    missing_permissions,
+    source_from_read_permission,
+    source_read_permission,
+    source_read_sources,
+)
+
+
+def test_all_permissions_contains_defined_route_permissions():
+    assert {
+        RESOURCE_READ,
+        RESOURCE_WRITE,
+        SOURCE_WRITE,
+        MERGE_CANDIDATE_CREATE,
+        SERVICE_LLM_SUGGEST,
+        *SOURCE_READ_PERMISSIONS,
+    }.issubset(ALL_PERMISSIONS)
+
+
+def test_missing_permissions_uses_exact_matching():
+    granted = {RESOURCE_READ, SOURCE_READ_RMI}
+
+    assert missing_permissions(granted, [RESOURCE_READ, RESOURCE_WRITE]) == frozenset(
+        {RESOURCE_WRITE}
+    )
+    assert missing_permissions(granted, ["resource"]) == frozenset({"resource"})
+
+
+def test_has_all_permissions_uses_exact_matching():
+    granted = {RESOURCE_READ, RESOURCE_WRITE}
+
+    assert has_all_permissions(granted, [RESOURCE_READ, RESOURCE_WRITE])
+    assert not has_all_permissions(granted, [RESOURCE_READ, "resource"])
+
+
+def test_has_any_permission_uses_exact_matching():
+    granted = {RESOURCE_READ}
+
+    assert has_any_permission(granted, [SOURCE_READ_RMI, RESOURCE_READ])
+    assert not has_any_permission(granted, [SOURCE_READ_RMI, "resource"])
+
+
+def test_source_read_permission_formats_source():
+    assert source_read_permission("gem") == SOURCE_READ_GEM
+
+
+def test_source_from_read_permission_parses_known_source():
+    assert source_from_read_permission(SOURCE_READ_RMI) == "rmi"
+
+
+def test_source_from_read_permission_ignores_non_source_read_permission():
+    assert source_from_read_permission(RESOURCE_READ) is None
+
+
+def test_source_from_read_permission_ignores_malformed_source():
+    assert source_from_read_permission("source:read:") is None
+    assert source_from_read_permission("source:read:rmi:extra") is None
+
+
+def test_source_from_read_permission_ignores_unknown_source(caplog):
+    with caplog.at_level(logging.WARNING, logger="stitch.auth.permissions"):
+        assert source_from_read_permission("source:read:bogus") is None
+
+    assert any("source:read:bogus" in rec.message for rec in caplog.records)
+
+
+def test_source_read_sources_dedupes_and_ignores_unknown():
+    assert source_read_sources(
+        [
+            SOURCE_READ_RMI,
+            SOURCE_READ_GEM,
+            SOURCE_READ_RMI,
+            "source:read:bogus",
+            RESOURCE_READ,
+        ]
+    ) == frozenset({"rmi", "gem"})
+
+
+def test_source_read_sources_accepts_explicit_valid_sources():
+    assert source_read_sources(
+        [SOURCE_READ_RMI, SOURCE_READ_GEM],
+        valid_sources={"gem"},
+    ) == frozenset({"gem"})

--- a/packages/stitch-auth/tests/test_validator_unit.py
+++ b/packages/stitch-auth/tests/test_validator_unit.py
@@ -5,6 +5,7 @@ import time
 import jwt as pyjwt
 import pytest
 
+from stitch.auth.permissions import RESOURCE_READ, SOURCE_READ_WM
 from stitch.auth.errors import JWKSFetchError, TokenExpiredError, TokenValidationError
 from stitch.auth.validator import JWTValidator
 
@@ -225,8 +226,8 @@ class TestJWTValidatorPermissions:
         token = token_factory(
             extra_claims={
                 "permissions": [
-                    "resource:read:public",
-                    "resource:read:licensed:wm",
+                    RESOURCE_READ,
+                    SOURCE_READ_WM,
                 ],
             },
         )
@@ -234,9 +235,7 @@ class TestJWTValidatorPermissions:
 
         claims = validator.validate(token)
 
-        assert claims.permissions == frozenset(
-            {"resource:read:public", "resource:read:licensed:wm"}
-        )
+        assert claims.permissions == frozenset({RESOURCE_READ, SOURCE_READ_WM})
         assert isinstance(claims.permissions, frozenset)
 
     def test_permissions_empty_when_claim_absent(
@@ -294,7 +293,7 @@ class TestJWTValidatorPermissions:
     ):
         token = token_factory(
             extra_claims={
-                "permissions": "resource:read:public resource:read:licensed:wm",
+                "permissions": "resource:read source:read:wm",
             },
         )
         validator = JWTValidator(oidc_settings)


### PR DESCRIPTION
Adds the updated permissions strings to `stitch-auth` since this is shared between all our deployments.

Provides `check_permissions` which can be used/called within a deployment.