### PR TITLE
feat: integrate auth permissions (STIT-422 & STIT-423)

### DIFF
--- a/deployments/api/src/stitch/api/auth.py
+++ b/deployments/api/src/stitch/api/auth.py
@@ -1,17 +1,21 @@
 import asyncio
 import logging
 from functools import lru_cache
-from typing import Annotated, get_args
+from typing import Annotated
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-from starlette.status import HTTP_401_UNAUTHORIZED
+from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 
 from stitch.auth import JWTValidator, OIDCSettings, TokenClaims
 from stitch.auth.errors import AuthError, JWKSFetchError
-from stitch.ogsi.model.types import OGSISrcKey
+from stitch.auth.permissions import (
+    ALL_PERMISSIONS,
+    has_any_permission,
+    missing_permissions,
+)
 
 from stitch.api.db.config import SessionFactoryDep
 from stitch.api.db.model.user import User as UserModel
@@ -35,9 +39,7 @@ _DEV_CLAIMS = TokenClaims(
     sub="dev|local-placeholder",
     email="dev@example.com",
     name="Dev User",
-    permissions=frozenset(
-        f"resource:read:licensed:{src}" for src in get_args(OGSISrcKey)
-    ),
+    permissions=ALL_PERMISSIONS,
     raw={},
 )
 
@@ -111,12 +113,40 @@ async def get_token_claims(
 
     if not claims.permissions:
         logger.warning(
-            "authenticated token has no permissions; user will see null-shell data"
+            "authenticated token has no permissions; protected routes will reject it"
         )
     return claims
 
 
 Claims = Annotated[TokenClaims, Depends(get_token_claims)]
+
+
+def require_permissions(*required_permissions: str):
+    async def dependency(claims: Claims) -> None:
+        missing = missing_permissions(claims.permissions, required_permissions)
+        if missing:
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail=(
+                    f"Missing required permission(s): {', '.join(sorted(missing))}"
+                ),
+            )
+
+    return dependency
+
+
+def require_any_permission(*candidate_permissions: str):
+    async def dependency(claims: Claims) -> None:
+        if not has_any_permission(claims.permissions, candidate_permissions):
+            raise HTTPException(
+                status_code=HTTP_403_FORBIDDEN,
+                detail=(
+                    "Missing at least one required permission: "
+                    f"{', '.join(sorted(candidate_permissions))}"
+                ),
+            )
+
+    return dependency
 
 
 async def get_current_user(claims: Claims, session_factory: SessionFactoryDep) -> User:

--- a/deployments/api/src/stitch/api/auth.py
+++ b/deployments/api/src/stitch/api/auth.py
@@ -1,7 +1,7 @@
 import asyncio
 import logging
 from functools import lru_cache
-from typing import Annotated
+from typing import Annotated, Literal, NoReturn
 
 from fastapi import Depends, HTTPException, Request
 from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
@@ -9,12 +9,15 @@ from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
 from starlette.status import HTTP_401_UNAUTHORIZED, HTTP_403_FORBIDDEN
 
-from stitch.auth import JWTValidator, OIDCSettings, TokenClaims
-from stitch.auth.errors import AuthError, JWKSFetchError
-from stitch.auth.permissions import (
+from stitch.auth import (
     ALL_PERMISSIONS,
-    has_any_permission,
-    missing_permissions,
+    AuthError,
+    InsufficientPermissionsError,
+    JWKSFetchError,
+    JWTValidator,
+    OIDCSettings,
+    TokenClaims,
+    check_permissions,
 )
 
 from stitch.api.db.config import SessionFactoryDep
@@ -121,30 +124,20 @@ async def get_token_claims(
 Claims = Annotated[TokenClaims, Depends(get_token_claims)]
 
 
-def require_permissions(*required_permissions: str):
+def _permission_exception_handler(exc: InsufficientPermissionsError) -> NoReturn:
+    raise HTTPException(status_code=HTTP_403_FORBIDDEN, detail=exc.detail)
+
+
+def require_permissions(
+    *required_permissions: str, check: Literal["all", "any"] = "all"
+):
     async def dependency(claims: Claims) -> None:
-        missing = missing_permissions(claims.permissions, required_permissions)
-        if missing:
-            raise HTTPException(
-                status_code=HTTP_403_FORBIDDEN,
-                detail=(
-                    f"Missing required permission(s): {', '.join(sorted(missing))}"
-                ),
-            )
-
-    return dependency
-
-
-def require_any_permission(*candidate_permissions: str):
-    async def dependency(claims: Claims) -> None:
-        if not has_any_permission(claims.permissions, candidate_permissions):
-            raise HTTPException(
-                status_code=HTTP_403_FORBIDDEN,
-                detail=(
-                    "Missing at least one required permission: "
-                    f"{', '.join(sorted(candidate_permissions))}"
-                ),
-            )
+        check_permissions(
+            granted=claims.permissions,
+            required=required_permissions,
+            check=check,
+            exc_handler=_permission_exception_handler,
+        )
 
     return dependency
 

--- a/deployments/api/src/stitch/api/permissions/__init__.py
+++ b/deployments/api/src/stitch/api/permissions/__init__.py
@@ -1,31 +1,20 @@
-"""Auth0 permission claim parsing.
+"""OGSI-aware permission helpers for API data redaction."""
 
-All knowledge of permission-string grammar lives here. Callers receive a
-typed `frozenset[OGSISrcKey]`; new permission shapes are added as new
-free functions in this module without touching the rest of the API.
-"""
-
-import logging
 from typing import cast, get_args
 
 from stitch.auth import TokenClaims
+from stitch.auth.permissions import source_read_sources
 from stitch.ogsi.model.types import OGSISrcKey
 
-logger = logging.getLogger(__name__)
-
-_LICENSED_PREFIX = "resource:read:licensed:"
 _VALID_SOURCES: frozenset[str] = frozenset(get_args(OGSISrcKey))
 
 
 def licensed_sources(claims: TokenClaims) -> frozenset[OGSISrcKey]:
     """Return the set of OGSI sources the caller is licensed to read."""
-    out: set[OGSISrcKey] = set()
-    for perm in claims.permissions:
-        if not perm.startswith(_LICENSED_PREFIX):
-            continue
-        candidate = perm[len(_LICENSED_PREFIX) :]
-        if candidate in _VALID_SOURCES:
-            out.add(cast(OGSISrcKey, candidate))
-        else:
-            logger.warning("ignoring unknown source in permission: %r", perm)
-    return frozenset(out)
+    return frozenset(
+        cast(OGSISrcKey, source)
+        for source in source_read_sources(
+            claims.permissions,
+            valid_sources=_VALID_SOURCES,
+        )
+    )

--- a/deployments/api/src/stitch/api/routers/oil_gas_field_sources.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_field_sources.py
@@ -2,10 +2,16 @@ from __future__ import annotations
 
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from stitch.auth.permissions import SOURCE_READ_PERMISSIONS, SOURCE_WRITE
 from stitch.ogsi.model import OGFieldSource, OGFieldSourceView
 
-from stitch.api.auth import Claims, CurrentUser
+from stitch.api.auth import (
+    Claims,
+    CurrentUser,
+    require_any_permission,
+    require_permissions,
+)
 from stitch.api.db import og_field_source_actions
 from stitch.api.db.config import UnitOfWorkDep
 from stitch.api.db.errors import SourceNotFoundError
@@ -18,7 +24,11 @@ from stitch.api.permissions import licensed_sources
 router = APIRouter(prefix="/oil-gas-field-sources", tags=["oil_gas_field_sources"])
 
 
-@router.post("/", response_model=OGFieldSourceView)
+@router.post(
+    "/",
+    response_model=OGFieldSourceView,
+    dependencies=[Depends(require_permissions(SOURCE_WRITE))],
+)
 async def create_oil_gas_field_source(
     source: OGFieldSource,
     uow: UnitOfWorkDep,
@@ -41,7 +51,10 @@ async def create_oil_gas_field_source(
     )
 
 
-@router.get("/")
+@router.get(
+    "/",
+    dependencies=[Depends(require_any_permission(*SOURCE_READ_PERMISSIONS))],
+)
 async def query_oil_gas_field_sources(
     uow: UnitOfWorkDep,
     user: CurrentUser,
@@ -61,7 +74,11 @@ async def query_oil_gas_field_sources(
     )
 
 
-@router.get("/{id}", response_model=OGFieldSourceView)
+@router.get(
+    "/{id}",
+    response_model=OGFieldSourceView,
+    dependencies=[Depends(require_any_permission(*SOURCE_READ_PERMISSIONS))],
+)
 async def get_oil_gas_field(
     id: int, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims
 ) -> OGFieldSourceView:
@@ -75,7 +92,10 @@ async def get_oil_gas_field(
         raise HTTPException(status_code=404, detail=str(exc))
 
 
-@router.get("/{id}/detail")
+@router.get(
+    "/{id}/detail",
+    dependencies=[Depends(require_any_permission(*SOURCE_READ_PERMISSIONS))],
+)
 async def get_oil_gas_field_detail(
     id: int, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims
 ) -> OGFieldSource:

--- a/deployments/api/src/stitch/api/routers/oil_gas_field_sources.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_field_sources.py
@@ -9,7 +9,6 @@ from stitch.ogsi.model import OGFieldSource, OGFieldSourceView
 from stitch.api.auth import (
     Claims,
     CurrentUser,
-    require_any_permission,
     require_permissions,
 )
 from stitch.api.db import og_field_source_actions
@@ -53,7 +52,7 @@ async def create_oil_gas_field_source(
 
 @router.get(
     "/",
-    dependencies=[Depends(require_any_permission(*SOURCE_READ_PERMISSIONS))],
+    dependencies=[Depends(require_permissions(*SOURCE_READ_PERMISSIONS, check="any"))],
 )
 async def query_oil_gas_field_sources(
     uow: UnitOfWorkDep,
@@ -77,7 +76,7 @@ async def query_oil_gas_field_sources(
 @router.get(
     "/{id}",
     response_model=OGFieldSourceView,
-    dependencies=[Depends(require_any_permission(*SOURCE_READ_PERMISSIONS))],
+    dependencies=[Depends(require_permissions(*SOURCE_READ_PERMISSIONS, check="any"))],
 )
 async def get_oil_gas_field(
     id: int, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims
@@ -94,7 +93,7 @@ async def get_oil_gas_field(
 
 @router.get(
     "/{id}/detail",
-    dependencies=[Depends(require_any_permission(*SOURCE_READ_PERMISSIONS))],
+    dependencies=[Depends(require_permissions(*SOURCE_READ_PERMISSIONS, check="any"))],
 )
 async def get_oil_gas_field_detail(
     id: int, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims

--- a/deployments/api/src/stitch/api/routers/oil_gas_fields.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_fields.py
@@ -1,7 +1,14 @@
 import logging
 from typing import Annotated
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, Depends, HTTPException, Query
+from stitch.auth.permissions import (
+    MERGE_CANDIDATE_CREATE,
+    MERGE_CANDIDATE_READ,
+    MERGE_CANDIDATE_REVIEW,
+    RESOURCE_READ,
+    RESOURCE_WRITE,
+)
 
 from stitch.api.entities import (
     MergeCandidateCreateRequest,
@@ -20,7 +27,7 @@ from stitch.api.db.errors import (
     ResourceNotFoundError,
     ResourceIntegrityError,
 )
-from stitch.api.auth import Claims, CurrentUser
+from stitch.api.auth import Claims, CurrentUser, require_permissions
 from stitch.api.db.utils import (
     resource_to_view,
     resource_to_detail_view,
@@ -45,7 +52,7 @@ router = APIRouter(
 )
 
 
-@router.get("/")
+@router.get("/", dependencies=[Depends(require_permissions(RESOURCE_READ))])
 async def get_all_resources(
     *,
     uow: UnitOfWorkDep,
@@ -66,14 +73,22 @@ async def get_all_resources(
     )
 
 
-@router.get("/merge-candidates", response_model=list[MergeCandidateView])
+@router.get(
+    "/merge-candidates",
+    response_model=list[MergeCandidateView],
+    dependencies=[Depends(require_permissions(MERGE_CANDIDATE_READ))],
+)
 async def list_merge_candidates(
     *, uow: UnitOfWorkDep, _user: CurrentUser
 ) -> list[MergeCandidateView]:
     return await merge_candidate_actions.list_merge_candidates(session=uow.session)
 
 
-@router.get("/merge-candidates/{id}", response_model=MergeCandidateView)
+@router.get(
+    "/merge-candidates/{id}",
+    response_model=MergeCandidateView,
+    dependencies=[Depends(require_permissions(MERGE_CANDIDATE_READ))],
+)
 async def get_merge_candidate(
     *, uow: UnitOfWorkDep, _user: CurrentUser, id: int
 ) -> MergeCandidateView:
@@ -86,7 +101,11 @@ async def get_merge_candidate(
         raise HTTPException(status_code=404, detail=str(exc))
 
 
-@router.get("/merge-candidates/{id}/preview", response_model=OGFieldMergePreviewView)
+@router.get(
+    "/merge-candidates/{id}/preview",
+    response_model=OGFieldMergePreviewView,
+    dependencies=[Depends(require_permissions(MERGE_CANDIDATE_READ))],
+)
 async def preview_merge_candidate(
     *,
     uow: UnitOfWorkDep,
@@ -112,7 +131,11 @@ async def preview_merge_candidate(
         )
 
 
-@router.post("/merge-candidates", response_model=MergeCandidateView)
+@router.post(
+    "/merge-candidates",
+    response_model=MergeCandidateView,
+    dependencies=[Depends(require_permissions(MERGE_CANDIDATE_CREATE))],
+)
 async def create_merge_candidate(
     *,
     uow: UnitOfWorkDep,
@@ -149,7 +172,11 @@ async def create_merge_candidate(
         )
 
 
-@router.post("/merge-candidates/{id}/approve", response_model=MergeCandidateView)
+@router.post(
+    "/merge-candidates/{id}/approve",
+    response_model=MergeCandidateView,
+    dependencies=[Depends(require_permissions(MERGE_CANDIDATE_REVIEW))],
+)
 async def approve_merge_candidate(
     *,
     uow: UnitOfWorkDep,
@@ -178,7 +205,11 @@ async def approve_merge_candidate(
         )
 
 
-@router.post("/merge-candidates/{id}/deny", response_model=MergeCandidateView)
+@router.post(
+    "/merge-candidates/{id}/deny",
+    response_model=MergeCandidateView,
+    dependencies=[Depends(require_permissions(MERGE_CANDIDATE_REVIEW))],
+)
 async def deny_merge_candidate(
     *,
     uow: UnitOfWorkDep,
@@ -207,7 +238,11 @@ async def deny_merge_candidate(
         )
 
 
-@router.get("/{id}", response_model=OGFieldView)
+@router.get(
+    "/{id}",
+    response_model=OGFieldView,
+    dependencies=[Depends(require_permissions(RESOURCE_READ))],
+)
 async def get_resource(
     *, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims, id: int
 ) -> OGFieldView:
@@ -217,7 +252,11 @@ async def get_resource(
     return resource_to_view(resource=res)
 
 
-@router.get("/{id}/detail", response_model=OGFieldDetailView)
+@router.get(
+    "/{id}/detail",
+    response_model=OGFieldDetailView,
+    dependencies=[Depends(require_permissions(RESOURCE_READ))],
+)
 async def get_resource_detail(
     *, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims, id: int
 ) -> OGFieldDetailView:
@@ -227,7 +266,11 @@ async def get_resource_detail(
     return resource_to_detail_view(resource=res)
 
 
-@router.post("/", response_model=OGFieldResourceView)
+@router.post(
+    "/",
+    response_model=OGFieldResourceView,
+    dependencies=[Depends(require_permissions(RESOURCE_WRITE))],
+)
 async def create_resource(
     *, uow: UnitOfWorkDep, user: CurrentUser, resource_in: OGFieldResource
 ) -> OGFieldResourceView:

--- a/deployments/api/tests/conftest.py
+++ b/deployments/api/tests/conftest.py
@@ -2,7 +2,6 @@
 
 from collections.abc import AsyncIterator
 from functools import partial
-from typing import get_args
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -11,7 +10,7 @@ from polyfactory.pytest_plugin import register_fixture
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from stitch.auth import TokenClaims
-from stitch.ogsi.model.types import OGSISrcKey
+from stitch.auth.permissions import ALL_PERMISSIONS
 
 from stitch.api.db.config import UnitOfWork, get_uow
 from stitch.api.db.model import (
@@ -29,9 +28,7 @@ _ALL_LICENSED_CLAIMS = TokenClaims(
     sub="test|user-1",
     email="test@test.com",
     name="Test User",
-    permissions=frozenset(
-        f"resource:read:licensed:{src}" for src in get_args(OGSISrcKey)
-    ),
+    permissions=ALL_PERMISSIONS,
 )
 
 

--- a/deployments/api/tests/permissions/test_licensed_sources.py
+++ b/deployments/api/tests/permissions/test_licensed_sources.py
@@ -1,7 +1,5 @@
 """Tests for stitch.api.permissions.licensed_sources."""
 
-import logging
-
 from stitch.auth import TokenClaims
 
 from stitch.api.permissions import licensed_sources
@@ -16,14 +14,14 @@ def test_empty_permissions_returns_empty_frozenset():
 
 
 def test_single_valid_source():
-    assert licensed_sources(_claims("resource:read:licensed:rmi")) == frozenset({"rmi"})
+    assert licensed_sources(_claims("source:read:rmi")) == frozenset({"rmi"})
 
 
 def test_multiple_valid_sources_deduped():
     claims = _claims(
-        "resource:read:licensed:rmi",
-        "resource:read:licensed:gem",
-        "resource:read:licensed:rmi",
+        "source:read:rmi",
+        "source:read:gem",
+        "source:read:rmi",
     )
     assert licensed_sources(claims) == frozenset({"rmi", "gem"})
 
@@ -31,32 +29,29 @@ def test_multiple_valid_sources_deduped():
 def test_malformed_permission_strings_ignored():
     claims = _claims(
         "no-prefix",
-        "resource:read:licensed:",  # empty source segment
-        "resource:read:licensed:rmi:extra",  # trailing segment is not a valid source
+        "source:read:",  # empty source segment
+        "source:read:rmi:extra",  # trailing segment is not a valid source
     )
     assert licensed_sources(claims) == frozenset()
 
 
-def test_unknown_source_value_ignored_with_debug_log(caplog):
-    with caplog.at_level(logging.DEBUG, logger="stitch.api.permissions"):
-        result = licensed_sources(_claims("resource:read:licensed:bogus"))
-    assert result == frozenset()
-    assert any("bogus" in rec.message for rec in caplog.records)
+def test_unknown_source_value_ignored():
+    assert licensed_sources(_claims("source:read:bogus")) == frozenset()
 
 
 def test_mixed_valid_and_unknown_only_keeps_valid():
     claims = _claims(
-        "resource:read:licensed:rmi",
-        "resource:read:licensed:bogus",
-        "resource:read:licensed:wm",
+        "source:read:rmi",
+        "source:read:bogus",
+        "source:read:wm",
     )
     assert licensed_sources(claims) == frozenset({"rmi", "wm"})
 
 
 def test_non_licensed_prefixes_ignored():
     claims = _claims(
-        "resource:write:licensed:rmi",
+        "source:write:rmi",
         "admin",
-        "resource:read:licensed:gem",
+        "source:read:gem",
     )
     assert licensed_sources(claims) == frozenset({"gem"})

--- a/deployments/api/tests/routers/test_licensed_sources_routes.py
+++ b/deployments/api/tests/routers/test_licensed_sources_routes.py
@@ -7,6 +7,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
 from stitch.auth import TokenClaims
+from stitch.auth.permissions import RESOURCE_READ, SOURCE_READ_GEM
 
 from stitch.api.auth import get_current_user, get_token_claims
 from stitch.api.db.config import UnitOfWork, get_uow
@@ -27,7 +28,16 @@ def _gem_only_claims() -> TokenClaims:
         sub="test|user-1",
         email="test@test.com",
         name="Test User",
-        permissions=frozenset({"resource:read:licensed:gem"}),
+        permissions=frozenset({RESOURCE_READ, SOURCE_READ_GEM}),
+    )
+
+
+def _resource_only_claims() -> TokenClaims:
+    return TokenClaims(
+        sub="test|user-1",
+        email="test@test.com",
+        name="Test User",
+        permissions=frozenset({RESOURCE_READ}),
     )
 
 
@@ -51,6 +61,38 @@ async def gem_only_client(
 
     def override_get_token_claims() -> TokenClaims:
         return _gem_only_claims()
+
+    app.dependency_overrides[get_uow] = override_get_uow
+    app.dependency_overrides[get_current_user] = override_get_current_user
+    app.dependency_overrides[get_token_claims] = override_get_token_claims
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app),
+        base_url="http://test/api/v1",
+    ) as ac:
+        yield ac
+
+
+@pytest.fixture
+async def resource_only_client(
+    integration_session_factory: async_sessionmaker[AsyncSession],
+    test_user: User,
+    test_user_model: UserModel,
+) -> AsyncIterator[AsyncClient]:
+    """Client with resource read but no source read grants."""
+    async with integration_session_factory() as session:
+        session.add(test_user_model)
+        await session.commit()
+
+    async def override_get_uow() -> AsyncIterator[UnitOfWork]:
+        async with UnitOfWork(integration_session_factory) as uow:
+            yield uow
+
+    def override_get_current_user() -> User:
+        return test_user
+
+    def override_get_token_claims() -> TokenClaims:
+        return _resource_only_claims()
 
     app.dependency_overrides[get_uow] = override_get_uow
     app.dependency_overrides[get_current_user] = override_get_current_user
@@ -111,6 +153,30 @@ async def _source_id_for(
 
 
 class TestOilGasFieldsLicensedSources:
+    @pytest.mark.anyio
+    async def test_list_with_no_source_grants_returns_redacted_resource_shell(
+        self,
+        resource_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        resource_id = await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+        )
+
+        response = await resource_only_client.get("/oil-gas-fields/")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["total_count"] == 1
+        item = data["items"][0]
+        assert item["id"] == resource_id
+        assert item["data"]["name"] is None
+        assert item["data"]["country"] is None
+        assert item["provenance"]["name"] is None
+
     @pytest.mark.anyio
     async def test_list_returns_only_licensed_data(
         self,
@@ -218,6 +284,24 @@ class TestOilGasFieldsLicensedSources:
 
 
 class TestOilGasFieldSourcesLicensedSources:
+    @pytest.mark.anyio
+    async def test_list_with_no_source_grants_returns_403(
+        self,
+        resource_only_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        test_user: User,
+    ):
+        await _seed_resource_with_sources(
+            integration_session_factory,
+            test_user,
+            {"source": "rmi", "name": "RMI Name", "country": "USA"},
+        )
+
+        response = await resource_only_client.get("/oil-gas-field-sources/")
+
+        assert response.status_code == 403
+        assert "source:read:" in response.json()["detail"]
+
     @pytest.mark.anyio
     async def test_list_drops_unlicensed_rows(
         self,

--- a/deployments/api/tests/routers/test_route_permissions.py
+++ b/deployments/api/tests/routers/test_route_permissions.py
@@ -1,0 +1,119 @@
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from httpx import AsyncClient
+
+from stitch.auth import TokenClaims
+from stitch.auth.permissions import (
+    MERGE_CANDIDATE_CREATE,
+    MERGE_CANDIDATE_READ,
+    MERGE_CANDIDATE_REVIEW,
+    RESOURCE_READ,
+    RESOURCE_WRITE,
+    SOURCE_READ_GEM,
+    SOURCE_WRITE,
+)
+
+from stitch.api.auth import get_token_claims
+from stitch.api.db.config import get_uow
+from stitch.api.main import app
+
+
+def _claims(*permissions: str) -> TokenClaims:
+    return TokenClaims(sub="test|user-1", permissions=frozenset(permissions))
+
+
+def _uow_override(mock_uow):
+    async def override_uow():
+        yield mock_uow
+
+    return override_uow
+
+
+def _source_payload() -> dict:
+    return {
+        "source": "gem",
+        "name": "Alpha",
+        "country": "USA",
+        "source_record": {
+            "observed_at": "2026-01-01T00:00:00Z",
+            "producer": "test",
+            "payload": {},
+        },
+    }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    ("method", "path", "permissions", "missing_permission", "json_body"),
+    [
+        ("get", "/oil-gas-fields/", (), RESOURCE_READ, None),
+        (
+            "post",
+            "/oil-gas-fields/",
+            (RESOURCE_READ,),
+            RESOURCE_WRITE,
+            {"source_data": []},
+        ),
+        (
+            "get",
+            "/oil-gas-fields/merge-candidates",
+            (RESOURCE_READ,),
+            MERGE_CANDIDATE_READ,
+            None,
+        ),
+        (
+            "post",
+            "/oil-gas-fields/merge-candidates",
+            (MERGE_CANDIDATE_READ,),
+            MERGE_CANDIDATE_CREATE,
+            {"resource_ids": [1, 2]},
+        ),
+        (
+            "post",
+            "/oil-gas-fields/merge-candidates/1/approve",
+            (MERGE_CANDIDATE_READ,),
+            MERGE_CANDIDATE_REVIEW,
+            {},
+        ),
+        (
+            "post",
+            "/oil-gas-field-sources/",
+            (SOURCE_READ_GEM,),
+            SOURCE_WRITE,
+            _source_payload(),
+        ),
+    ],
+)
+async def test_route_returns_403_when_required_permission_missing(
+    async_client: AsyncClient,
+    mock_uow,
+    method: str,
+    path: str,
+    permissions: tuple[str, ...],
+    missing_permission: str,
+    json_body: dict | None,
+):
+    app.dependency_overrides[get_token_claims] = lambda: _claims(*permissions)
+    app.dependency_overrides[get_uow] = _uow_override(mock_uow)
+
+    response = await async_client.request(method, path, json=json_body)
+
+    assert response.status_code == 403
+    assert missing_permission in response.json()["detail"]
+
+
+@pytest.mark.anyio
+async def test_merge_candidate_read_permission_allows_list_route(
+    async_client: AsyncClient,
+    mock_uow,
+):
+    app.dependency_overrides[get_token_claims] = lambda: _claims(MERGE_CANDIDATE_READ)
+    app.dependency_overrides[get_uow] = _uow_override(mock_uow)
+
+    with patch("stitch.api.routers.oil_gas_fields.merge_candidate_actions") as actions:
+        actions.list_merge_candidates = AsyncMock(return_value=[])
+        response = await async_client.get("/oil-gas-fields/merge-candidates")
+
+    assert response.status_code == 200
+    assert response.json() == []

--- a/deployments/api/tests/test_auth_unit.py
+++ b/deployments/api/tests/test_auth_unit.py
@@ -3,15 +3,20 @@
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
+from fastapi import HTTPException
 from starlette.testclient import TestClient
 
-from stitch.api.auth import get_token_claims, validate_auth_config_at_startup
+from stitch.api.auth import (
+    get_token_claims,
+    require_permissions,
+    validate_auth_config_at_startup,
+)
 from stitch.api.db.config import get_uow
 from stitch.api.entities import User
 from stitch.api.main import app
 from stitch.api.settings import Settings
 from stitch.auth import TokenClaims
-from stitch.auth.permissions import RESOURCE_READ, SOURCE_READ_WM
+from stitch.auth.permissions import RESOURCE_READ, RESOURCE_WRITE, SOURCE_READ_WM
 from stitch.auth.settings import OIDCSettings
 
 
@@ -140,6 +145,70 @@ class TestGetTokenClaims:
 
             assert response.status_code == 401
             assert response.json()["detail"] == "Invalid Authorization header format"
+
+
+class TestRequirePermissions:
+    """Unit tests for the API permission dependency wrapper."""
+
+    @pytest.mark.anyio
+    async def test_default_check_requires_all_permissions(self):
+        dependency = require_permissions(RESOURCE_READ, RESOURCE_WRITE)
+        claims = TokenClaims(
+            sub="auth0|permission-user",
+            permissions=frozenset({RESOURCE_READ, RESOURCE_WRITE}),
+        )
+
+        assert await dependency(claims) is None
+
+    @pytest.mark.anyio
+    async def test_default_check_raises_403_for_missing_permission(self):
+        dependency = require_permissions(RESOURCE_READ, RESOURCE_WRITE)
+        claims = TokenClaims(
+            sub="auth0|permission-user",
+            permissions=frozenset({RESOURCE_READ}),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await dependency(claims)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == (
+            "Missing required permission(s): resource:write"
+        )
+
+    @pytest.mark.anyio
+    async def test_any_check_accepts_one_candidate_permission(self):
+        dependency = require_permissions(
+            RESOURCE_WRITE,
+            SOURCE_READ_WM,
+            check="any",
+        )
+        claims = TokenClaims(
+            sub="auth0|permission-user",
+            permissions=frozenset({SOURCE_READ_WM}),
+        )
+
+        assert await dependency(claims) is None
+
+    @pytest.mark.anyio
+    async def test_any_check_raises_403_when_no_candidates_match(self):
+        dependency = require_permissions(
+            RESOURCE_WRITE,
+            SOURCE_READ_WM,
+            check="any",
+        )
+        claims = TokenClaims(
+            sub="auth0|permission-user",
+            permissions=frozenset({RESOURCE_READ}),
+        )
+
+        with pytest.raises(HTTPException) as exc_info:
+            await dependency(claims)
+
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail == (
+            "Missing required permission(s): resource:write, source:read:wm"
+        )
 
 
 class TestAuthMeEndpoint:

--- a/deployments/api/tests/test_auth_unit.py
+++ b/deployments/api/tests/test_auth_unit.py
@@ -11,6 +11,7 @@ from stitch.api.entities import User
 from stitch.api.main import app
 from stitch.api.settings import Settings
 from stitch.auth import TokenClaims
+from stitch.auth.permissions import RESOURCE_READ, SOURCE_READ_WM
 from stitch.auth.settings import OIDCSettings
 
 
@@ -151,10 +152,8 @@ class TestAuthMeEndpoint:
             sub="auth0|claims-user",
             email="claims@example.com",
             name="Claims User",
-            permissions=frozenset(
-                {"resource:read:licensed:wm", "resource:read:public"}
-            ),
-            raw={"permissions": ["resource:read:public", "resource:read:licensed:wm"]},
+            permissions=frozenset({RESOURCE_READ, SOURCE_READ_WM}),
+            raw={"permissions": [RESOURCE_READ, SOURCE_READ_WM]},
         )
         user = User(
             id=42,
@@ -200,13 +199,13 @@ class TestAuthMeEndpoint:
                 "email": "claims@example.com",
                 "name": "Claims User",
                 "permissions": [
-                    "resource:read:licensed:wm",
-                    "resource:read:public",
+                    "resource:read",
+                    "source:read:wm",
                 ],
                 "raw": {
                     "permissions": [
-                        "resource:read:public",
-                        "resource:read:licensed:wm",
+                        "resource:read",
+                        "source:read:wm",
                     ]
                 },
             },
@@ -219,8 +218,8 @@ class TestAuthMeEndpoint:
             sub="auth0|claims-only",
             email=None,
             name=None,
-            permissions=frozenset({"resource:read:public"}),
-            raw={"permissions": ["resource:read:public"]},
+            permissions=frozenset({RESOURCE_READ}),
+            raw={"permissions": [RESOURCE_READ]},
         )
 
         def override_get_token_claims() -> TokenClaims:
@@ -253,7 +252,7 @@ class TestAuthMeEndpoint:
                 "sub": "auth0|claims-only",
                 "email": None,
                 "name": None,
-                "permissions": ["resource:read:public"],
-                "raw": {"permissions": ["resource:read:public"]},
+                "permissions": ["resource:read"],
+                "raw": {"permissions": ["resource:read"]},
             },
         }

--- a/packages/stitch-auth/src/stitch/auth/__init__.py
+++ b/packages/stitch-auth/src/stitch/auth/__init__.py
@@ -1,5 +1,11 @@
 from .claims import TokenClaims
-from .errors import AuthError, JWKSFetchError, TokenExpiredError, TokenValidationError
+from .errors import (
+    AuthError,
+    InsufficientPermissionsError,
+    JWKSFetchError,
+    TokenExpiredError,
+    TokenValidationError,
+)
 from .permissions import (
     ALL_PERMISSIONS,
     MERGE_CANDIDATE_CREATE,
@@ -16,6 +22,7 @@ from .permissions import (
     SOURCE_READ_RMI,
     SOURCE_READ_WM,
     SOURCE_WRITE,
+    check_permissions,
 )
 from .settings import OIDCSettings
 from .validator import JWTValidator
@@ -23,6 +30,7 @@ from .validator import JWTValidator
 __all__ = [
     "ALL_PERMISSIONS",
     "AuthError",
+    "InsufficientPermissionsError",
     "JWKSFetchError",
     "JWTValidator",
     "MERGE_CANDIDATE_CREATE",
@@ -43,4 +51,5 @@ __all__ = [
     "TokenClaims",
     "TokenExpiredError",
     "TokenValidationError",
+    "check_permissions",
 ]

--- a/packages/stitch-auth/src/stitch/auth/__init__.py
+++ b/packages/stitch-auth/src/stitch/auth/__init__.py
@@ -1,13 +1,45 @@
 from .claims import TokenClaims
 from .errors import AuthError, JWKSFetchError, TokenExpiredError, TokenValidationError
+from .permissions import (
+    ALL_PERMISSIONS,
+    MERGE_CANDIDATE_CREATE,
+    MERGE_CANDIDATE_READ,
+    MERGE_CANDIDATE_REVIEW,
+    RESOURCE_READ,
+    RESOURCE_WRITE,
+    SERVICE_ENTITY_LINKAGE_RUN,
+    SERVICE_LLM_SUGGEST,
+    SOURCE_READ_GEM,
+    SOURCE_READ_LLM,
+    SOURCE_READ_PERMISSIONS,
+    SOURCE_READ_PREFIX,
+    SOURCE_READ_RMI,
+    SOURCE_READ_WM,
+    SOURCE_WRITE,
+)
 from .settings import OIDCSettings
 from .validator import JWTValidator
 
 __all__ = [
+    "ALL_PERMISSIONS",
     "AuthError",
     "JWKSFetchError",
     "JWTValidator",
+    "MERGE_CANDIDATE_CREATE",
+    "MERGE_CANDIDATE_READ",
+    "MERGE_CANDIDATE_REVIEW",
     "OIDCSettings",
+    "RESOURCE_READ",
+    "RESOURCE_WRITE",
+    "SERVICE_ENTITY_LINKAGE_RUN",
+    "SERVICE_LLM_SUGGEST",
+    "SOURCE_READ_GEM",
+    "SOURCE_READ_LLM",
+    "SOURCE_READ_PERMISSIONS",
+    "SOURCE_READ_PREFIX",
+    "SOURCE_READ_RMI",
+    "SOURCE_READ_WM",
+    "SOURCE_WRITE",
     "TokenClaims",
     "TokenExpiredError",
     "TokenValidationError",

--- a/packages/stitch-auth/src/stitch/auth/errors.py
+++ b/packages/stitch-auth/src/stitch/auth/errors.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterable
+
+
 class AuthError(Exception):
     """Base for all auth errors. Consumers can catch broadly or narrowly."""
 
@@ -9,3 +12,34 @@ class TokenValidationError(AuthError): ...
 
 
 class JWKSFetchError(AuthError): ...
+
+
+class InsufficientPermissionsError(AuthError):
+    detail: str
+    granted: frozenset[str]
+    required: frozenset[str]
+    missing: frozenset[str]
+
+    def __init__(
+        self,
+        granted: Iterable[str],
+        required: Iterable[str],
+        missing: Iterable[str] | None = None,
+        detail: str | None = None,
+    ):
+        self.granted = frozenset(granted)
+        self.required = frozenset(required)
+        self.missing = (
+            frozenset(missing)
+            if missing is not None
+            else self.required.difference(self.granted)
+        )
+        self.detail = detail or _permission_detail(self.missing)
+        super().__init__(self.detail)
+
+
+def _permission_detail(missing: Iterable[str]) -> str:
+    missing_text = ", ".join(sorted(missing))
+    if not missing_text:
+        return "Missing required permission(s)"
+    return f"Missing required permission(s): {missing_text}"

--- a/packages/stitch-auth/src/stitch/auth/permissions.py
+++ b/packages/stitch-auth/src/stitch/auth/permissions.py
@@ -3,8 +3,10 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Collection, Iterable
-from typing import TypeAlias
+from collections.abc import Callable, Collection, Iterable
+from typing import Literal, NoReturn, TypeAlias
+
+from .errors import InsufficientPermissionsError
 
 logger = logging.getLogger(__name__)
 
@@ -109,3 +111,52 @@ def has_any_permission(
     candidates: Iterable[str],
 ) -> bool:
     return any(permission in granted for permission in candidates)
+
+
+def check_permissions(
+    granted: Iterable[str],
+    required: Iterable[str],
+    check: Literal["all", "any"] = "all",
+    exc_handler: Callable[[InsufficientPermissionsError], NoReturn] | None = None,
+) -> None:
+    """Verify that granted permissions satisfy required permissions.
+
+    Args:
+        granted: Permissions granted to the caller.
+        required: Permissions required for the protected operation.
+        check: Whether all required permissions or any required permission must be
+            granted.
+        exc_handler: Optional callback for mapping permission failures to a
+            caller-specific exception. This callback should raise an exception.
+
+    Raises:
+        ValueError: If check is not "all" or "any".
+        InsufficientPermissionsError: If the required permissions are not
+            satisfied and exc_handler does not raise its own exception.
+    """
+    if check not in {"all", "any"}:
+        msg = f"unsupported permission check mode: {check!r}"
+        raise ValueError(msg)
+
+    granted_set = frozenset(granted)
+    required_set = frozenset(required)
+    if not required_set:
+        return None
+
+    if check == "all":
+        missing = required_set.difference(granted_set)
+        if not missing:
+            return None
+    else:
+        missing = required_set.difference(granted_set)
+        if missing != required_set:
+            return None
+
+    exc = InsufficientPermissionsError(
+        granted=granted_set,
+        required=required_set,
+        missing=missing,
+    )
+    if exc_handler is not None:
+        exc_handler(exc)
+    raise exc

--- a/packages/stitch-auth/src/stitch/auth/permissions.py
+++ b/packages/stitch-auth/src/stitch/auth/permissions.py
@@ -1,0 +1,111 @@
+"""Shared Stitch permission constants and exact-match helpers."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Collection, Iterable
+from typing import TypeAlias
+
+logger = logging.getLogger(__name__)
+
+Permission: TypeAlias = str
+
+RESOURCE_READ: Permission = "resource:read"
+RESOURCE_WRITE: Permission = "resource:write"
+
+SOURCE_READ_PREFIX = "source:read:"
+SOURCE_READ_RMI: Permission = f"{SOURCE_READ_PREFIX}rmi"
+SOURCE_READ_GEM: Permission = f"{SOURCE_READ_PREFIX}gem"
+SOURCE_READ_WM: Permission = f"{SOURCE_READ_PREFIX}wm"
+SOURCE_READ_LLM: Permission = f"{SOURCE_READ_PREFIX}llm"
+SOURCE_READ_PERMISSIONS: frozenset[Permission] = frozenset(
+    {
+        SOURCE_READ_RMI,
+        SOURCE_READ_GEM,
+        SOURCE_READ_WM,
+        SOURCE_READ_LLM,
+    }
+)
+SOURCE_WRITE: Permission = "source:write"
+
+MERGE_CANDIDATE_READ: Permission = "merge-candidate:read"
+MERGE_CANDIDATE_CREATE: Permission = "merge-candidate:create"
+MERGE_CANDIDATE_REVIEW: Permission = "merge-candidate:review"
+
+SERVICE_ENTITY_LINKAGE_RUN: Permission = "service:entity-linkage:run"
+SERVICE_LLM_SUGGEST: Permission = "service:llm:suggest"
+
+ALL_PERMISSIONS: frozenset[Permission] = frozenset(
+    {
+        RESOURCE_READ,
+        RESOURCE_WRITE,
+        *SOURCE_READ_PERMISSIONS,
+        SOURCE_WRITE,
+        MERGE_CANDIDATE_READ,
+        MERGE_CANDIDATE_CREATE,
+        MERGE_CANDIDATE_REVIEW,
+        SERVICE_ENTITY_LINKAGE_RUN,
+        SERVICE_LLM_SUGGEST,
+    }
+)
+
+
+def source_read_permission(source: str) -> Permission:
+    return f"{SOURCE_READ_PREFIX}{source}"
+
+
+def source_from_read_permission(
+    permission: str,
+    *,
+    valid_sources: Collection[str],
+) -> str | None:
+    if not permission.startswith(SOURCE_READ_PREFIX):
+        return None
+
+    source = permission[len(SOURCE_READ_PREFIX) :]
+    if not source or ":" in source:
+        return None
+    if source not in valid_sources:
+        logger.warning("ignoring unknown source in permission: %r", permission)
+        return None
+    return source
+
+
+def source_read_sources(
+    permissions: Iterable[str],
+    *,
+    valid_sources: Collection[str],
+) -> frozenset[str]:
+    sources = {
+        source
+        for permission in permissions
+        if (
+            source := source_from_read_permission(
+                permission,
+                valid_sources=valid_sources,
+            )
+        )
+        is not None
+    }
+    return frozenset(sources)
+
+
+def missing_permissions(
+    granted: Collection[str],
+    required: Iterable[str],
+) -> frozenset[str]:
+    return frozenset(permission for permission in required if permission not in granted)
+
+
+def has_all_permissions(
+    granted: Collection[str],
+    required: Iterable[str],
+) -> bool:
+    return not missing_permissions(granted, required)
+
+
+def has_any_permission(
+    granted: Collection[str],
+    candidates: Iterable[str],
+) -> bool:
+    return any(permission in granted for permission in candidates)

--- a/packages/stitch-auth/tests/test_claims_unit.py
+++ b/packages/stitch-auth/tests/test_claims_unit.py
@@ -4,6 +4,7 @@ import pytest
 
 from pydantic import ValidationError
 from stitch.auth.claims import TokenClaims
+from stitch.auth.permissions import RESOURCE_READ, SOURCE_READ_WM
 
 
 class TestTokenClaimsConstruction:
@@ -69,12 +70,10 @@ class TestTokenClaimsPermissions:
     def test_permissions_accepts_list_and_coerces_to_frozenset(self):
         claims = TokenClaims(
             sub="auth0|abc",
-            permissions=["resource:read:public", "resource:read:licensed:wm"],
+            permissions=[RESOURCE_READ, SOURCE_READ_WM],
         )
 
-        assert claims.permissions == frozenset(
-            {"resource:read:public", "resource:read:licensed:wm"}
-        )
+        assert claims.permissions == frozenset({RESOURCE_READ, SOURCE_READ_WM})
         assert isinstance(claims.permissions, frozenset)
 
     def test_permissions_accepts_frozenset_directly(self):

--- a/packages/stitch-auth/tests/test_permissions.py
+++ b/packages/stitch-auth/tests/test_permissions.py
@@ -1,5 +1,7 @@
 import logging
 
+import pytest
+from stitch.auth.errors import InsufficientPermissionsError
 from stitch.auth.permissions import (
     ALL_PERMISSIONS,
     MERGE_CANDIDATE_CREATE,
@@ -10,6 +12,7 @@ from stitch.auth.permissions import (
     SOURCE_READ_PERMISSIONS,
     SOURCE_READ_RMI,
     SOURCE_WRITE,
+    check_permissions,
     has_all_permissions,
     has_any_permission,
     missing_permissions,
@@ -17,6 +20,8 @@ from stitch.auth.permissions import (
     source_read_permission,
     source_read_sources,
 )
+
+VALID_SOURCES = {"rmi", "gem"}
 
 
 def test_all_permissions_contains_defined_route_permissions():
@@ -58,26 +63,50 @@ def test_source_read_permission_formats_source():
 
 
 def test_source_from_read_permission_parses_known_source():
-    assert source_from_read_permission(SOURCE_READ_RMI) == "rmi"
+    assert (
+        source_from_read_permission(SOURCE_READ_RMI, valid_sources=VALID_SOURCES)
+        == "rmi"
+    )
 
 
 def test_source_from_read_permission_ignores_non_source_read_permission():
-    assert source_from_read_permission(RESOURCE_READ) is None
+    assert (
+        source_from_read_permission(RESOURCE_READ, valid_sources=VALID_SOURCES) is None
+    )
 
 
 def test_source_from_read_permission_ignores_malformed_source():
-    assert source_from_read_permission("source:read:") is None
-    assert source_from_read_permission("source:read:rmi:extra") is None
+    assert (
+        source_from_read_permission("source:read:", valid_sources=VALID_SOURCES)
+        is None
+    )
+    assert (
+        source_from_read_permission("source:read:rmi:", valid_sources=VALID_SOURCES)
+        is None
+    )
+    assert (
+        source_from_read_permission(
+            "source:read:rmi:extra",
+            valid_sources=VALID_SOURCES,
+        )
+        is None
+    )
 
 
 def test_source_from_read_permission_ignores_unknown_source(caplog):
     with caplog.at_level(logging.WARNING, logger="stitch.auth.permissions"):
-        assert source_from_read_permission("source:read:bogus") is None
+        assert (
+            source_from_read_permission(
+                "source:read:bogus",
+                valid_sources=VALID_SOURCES,
+            )
+            is None
+        )
 
     assert any("source:read:bogus" in rec.message for rec in caplog.records)
 
 
-def test_source_read_sources_dedupes_and_ignores_unknown():
+def test_source_read_sources_dedupes_and_filters_with_explicit_valid_sources():
     assert source_read_sources(
         [
             SOURCE_READ_RMI,
@@ -85,7 +114,8 @@ def test_source_read_sources_dedupes_and_ignores_unknown():
             SOURCE_READ_RMI,
             "source:read:bogus",
             RESOURCE_READ,
-        ]
+        ],
+        valid_sources=VALID_SOURCES,
     ) == frozenset({"rmi", "gem"})
 
 
@@ -94,3 +124,121 @@ def test_source_read_sources_accepts_explicit_valid_sources():
         [SOURCE_READ_RMI, SOURCE_READ_GEM],
         valid_sources={"gem"},
     ) == frozenset({"gem"})
+
+
+def test_check_permissions_all_succeeds_when_all_required_are_granted():
+    assert (
+        check_permissions(
+            {RESOURCE_READ, RESOURCE_WRITE},
+            [RESOURCE_READ, RESOURCE_WRITE],
+        )
+        is None
+    )
+
+
+def test_check_permissions_all_raises_with_structured_error():
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        check_permissions({RESOURCE_READ}, [RESOURCE_READ, RESOURCE_WRITE])
+
+    exc = exc_info.value
+    assert exc.granted == frozenset({RESOURCE_READ})
+    assert exc.required == frozenset({RESOURCE_READ, RESOURCE_WRITE})
+    assert exc.missing == frozenset({RESOURCE_WRITE})
+    assert exc.detail == "Missing required permission(s): resource:write"
+    assert str(exc) == exc.detail
+
+
+def test_check_permissions_any_succeeds_when_any_candidate_is_granted():
+    assert (
+        check_permissions(
+            {RESOURCE_READ},
+            [SOURCE_READ_RMI, RESOURCE_READ],
+            check="any",
+        )
+        is None
+    )
+
+
+def test_check_permissions_any_raises_when_no_candidates_are_granted():
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        check_permissions(
+            {SOURCE_READ_RMI},
+            [RESOURCE_READ, RESOURCE_WRITE],
+            check="any",
+        )
+
+    exc = exc_info.value
+    assert exc.granted == frozenset({SOURCE_READ_RMI})
+    assert exc.required == frozenset({RESOURCE_READ, RESOURCE_WRITE})
+    assert exc.missing == frozenset({RESOURCE_READ, RESOURCE_WRITE})
+    assert exc.detail == (
+        "Missing required permission(s): resource:read, resource:write"
+    )
+
+
+@pytest.mark.parametrize("check", ["all", "any"])
+def test_check_permissions_empty_required_succeeds(check):
+    assert check_permissions({RESOURCE_READ}, [], check=check) is None
+
+
+def test_check_permissions_invalid_check_raises_value_error():
+    with pytest.raises(ValueError, match="unsupported permission check mode"):
+        check_permissions({RESOURCE_READ}, [RESOURCE_READ], check="some")
+
+
+def test_check_permissions_iterator_inputs_preserve_error_payloads():
+    granted = iter([RESOURCE_READ])
+    required = iter([RESOURCE_READ, RESOURCE_WRITE])
+
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        check_permissions(granted, required)
+
+    exc = exc_info.value
+    assert exc.granted == frozenset({RESOURCE_READ})
+    assert exc.required == frozenset({RESOURCE_READ, RESOURCE_WRITE})
+    assert exc.missing == frozenset({RESOURCE_WRITE})
+
+
+def test_check_permissions_raising_exc_handler_gets_structured_error():
+    seen: list[InsufficientPermissionsError] = []
+
+    def raise_forbidden(exc: InsufficientPermissionsError):
+        seen.append(exc)
+        raise RuntimeError("forbidden")
+
+    with pytest.raises(RuntimeError, match="forbidden"):
+        check_permissions(
+            {RESOURCE_READ},
+            [RESOURCE_WRITE],
+            exc_handler=raise_forbidden,
+        )
+
+    assert len(seen) == 1
+    assert seen[0].missing == frozenset({RESOURCE_WRITE})
+
+
+def test_check_permissions_returning_exc_handler_still_raises_original_error():
+    seen: list[InsufficientPermissionsError] = []
+
+    def returns_unexpectedly(exc: InsufficientPermissionsError):
+        seen.append(exc)
+
+    with pytest.raises(InsufficientPermissionsError) as exc_info:
+        check_permissions(
+            {RESOURCE_READ},
+            [RESOURCE_WRITE],
+            exc_handler=returns_unexpectedly,
+        )
+
+    assert seen == [exc_info.value]
+    assert exc_info.value.missing == frozenset({RESOURCE_WRITE})
+
+
+def test_top_level_exports_permission_helper_and_error():
+    from stitch.auth import (
+        InsufficientPermissionsError as exported_error,
+        check_permissions as exported_check_permissions,
+    )
+
+    assert exported_check_permissions is check_permissions
+    assert exported_error is InsufficientPermissionsError

--- a/packages/stitch-auth/tests/test_permissions.py
+++ b/packages/stitch-auth/tests/test_permissions.py
@@ -77,8 +77,7 @@ def test_source_from_read_permission_ignores_non_source_read_permission():
 
 def test_source_from_read_permission_ignores_malformed_source():
     assert (
-        source_from_read_permission("source:read:", valid_sources=VALID_SOURCES)
-        is None
+        source_from_read_permission("source:read:", valid_sources=VALID_SOURCES) is None
     )
     assert (
         source_from_read_permission("source:read:rmi:", valid_sources=VALID_SOURCES)

--- a/packages/stitch-auth/tests/test_permissions.py
+++ b/packages/stitch-auth/tests/test_permissions.py
@@ -1,0 +1,96 @@
+import logging
+
+from stitch.auth.permissions import (
+    ALL_PERMISSIONS,
+    MERGE_CANDIDATE_CREATE,
+    RESOURCE_READ,
+    RESOURCE_WRITE,
+    SERVICE_LLM_SUGGEST,
+    SOURCE_READ_GEM,
+    SOURCE_READ_PERMISSIONS,
+    SOURCE_READ_RMI,
+    SOURCE_WRITE,
+    has_all_permissions,
+    has_any_permission,
+    missing_permissions,
+    source_from_read_permission,
+    source_read_permission,
+    source_read_sources,
+)
+
+
+def test_all_permissions_contains_defined_route_permissions():
+    assert {
+        RESOURCE_READ,
+        RESOURCE_WRITE,
+        SOURCE_WRITE,
+        MERGE_CANDIDATE_CREATE,
+        SERVICE_LLM_SUGGEST,
+        *SOURCE_READ_PERMISSIONS,
+    }.issubset(ALL_PERMISSIONS)
+
+
+def test_missing_permissions_uses_exact_matching():
+    granted = {RESOURCE_READ, SOURCE_READ_RMI}
+
+    assert missing_permissions(granted, [RESOURCE_READ, RESOURCE_WRITE]) == frozenset(
+        {RESOURCE_WRITE}
+    )
+    assert missing_permissions(granted, ["resource"]) == frozenset({"resource"})
+
+
+def test_has_all_permissions_uses_exact_matching():
+    granted = {RESOURCE_READ, RESOURCE_WRITE}
+
+    assert has_all_permissions(granted, [RESOURCE_READ, RESOURCE_WRITE])
+    assert not has_all_permissions(granted, [RESOURCE_READ, "resource"])
+
+
+def test_has_any_permission_uses_exact_matching():
+    granted = {RESOURCE_READ}
+
+    assert has_any_permission(granted, [SOURCE_READ_RMI, RESOURCE_READ])
+    assert not has_any_permission(granted, [SOURCE_READ_RMI, "resource"])
+
+
+def test_source_read_permission_formats_source():
+    assert source_read_permission("gem") == SOURCE_READ_GEM
+
+
+def test_source_from_read_permission_parses_known_source():
+    assert source_from_read_permission(SOURCE_READ_RMI) == "rmi"
+
+
+def test_source_from_read_permission_ignores_non_source_read_permission():
+    assert source_from_read_permission(RESOURCE_READ) is None
+
+
+def test_source_from_read_permission_ignores_malformed_source():
+    assert source_from_read_permission("source:read:") is None
+    assert source_from_read_permission("source:read:rmi:extra") is None
+
+
+def test_source_from_read_permission_ignores_unknown_source(caplog):
+    with caplog.at_level(logging.WARNING, logger="stitch.auth.permissions"):
+        assert source_from_read_permission("source:read:bogus") is None
+
+    assert any("source:read:bogus" in rec.message for rec in caplog.records)
+
+
+def test_source_read_sources_dedupes_and_ignores_unknown():
+    assert source_read_sources(
+        [
+            SOURCE_READ_RMI,
+            SOURCE_READ_GEM,
+            SOURCE_READ_RMI,
+            "source:read:bogus",
+            RESOURCE_READ,
+        ]
+    ) == frozenset({"rmi", "gem"})
+
+
+def test_source_read_sources_accepts_explicit_valid_sources():
+    assert source_read_sources(
+        [SOURCE_READ_RMI, SOURCE_READ_GEM],
+        valid_sources={"gem"},
+    ) == frozenset({"gem"})

--- a/packages/stitch-auth/tests/test_validator_unit.py
+++ b/packages/stitch-auth/tests/test_validator_unit.py
@@ -5,6 +5,7 @@ import time
 import jwt as pyjwt
 import pytest
 
+from stitch.auth.permissions import RESOURCE_READ, SOURCE_READ_WM
 from stitch.auth.errors import JWKSFetchError, TokenExpiredError, TokenValidationError
 from stitch.auth.validator import JWTValidator
 
@@ -225,8 +226,8 @@ class TestJWTValidatorPermissions:
         token = token_factory(
             extra_claims={
                 "permissions": [
-                    "resource:read:public",
-                    "resource:read:licensed:wm",
+                    RESOURCE_READ,
+                    SOURCE_READ_WM,
                 ],
             },
         )
@@ -234,9 +235,7 @@ class TestJWTValidatorPermissions:
 
         claims = validator.validate(token)
 
-        assert claims.permissions == frozenset(
-            {"resource:read:public", "resource:read:licensed:wm"}
-        )
+        assert claims.permissions == frozenset({RESOURCE_READ, SOURCE_READ_WM})
         assert isinstance(claims.permissions, frozenset)
 
     def test_permissions_empty_when_claim_absent(
@@ -294,7 +293,7 @@ class TestJWTValidatorPermissions:
     ):
         token = token_factory(
             extra_claims={
-                "permissions": "resource:read:public resource:read:licensed:wm",
+                "permissions": "resource:read source:read:wm",
             },
         )
         validator = JWTValidator(oidc_settings)


### PR DESCRIPTION
Small permissions wiring pass for STIT-422/423.

- adds shared stitch-auth permission strings + guard
- wires API routes through require_permissions(...), including source-read check="any"
- keeps source licensing backed by the shared parser