### PR TITLE
Fix for Syntax error

### DIFF
--- a/packages/stitch-models/src/stitch/models/__init__.py
+++ b/packages/stitch-models/src/stitch/models/__init__.py
@@ -83,10 +83,7 @@ class Resource[TResId: IdType, TSrc: Source](BaseModel):
         return self
 
 
-class Resource_[
-    TResId: IdType,
-    TPayload: SourcePayload,
-](BaseModel):
+class Resource_[TResId: IdType, TPayload: SourcePayload](BaseModel):
     id: TResId | None = None
     source_data: TPayload
     repointed_to: TResId | None = Field(default=None)


### PR DESCRIPTION
To fix this without changing functionality, correct the generic class header for `Resource_` so it is valid Python syntax while preserving the same type parameters and inheritance.

Best fix in this file:
- In `packages/stitch-models/src/stitch/models/__init__.py`, replace the malformed multi-line class declaration starting at `class Resource_[` and ending at `](BaseModel):` with a valid generic class declaration:
  - `class Resource_[TResId: IdType, TPayload: SourcePayload](BaseModel):`
- Keep all class fields, validators, and behavior unchanged.

No new imports, helper methods, or dependency changes are required.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._