### PR TITLE
Feat/etl (STIT-475)

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -27,6 +27,16 @@ on:
         description: "Base stitch-llm URL to inject into runtime config"
         required: true
         type: string
+      etl-gem-url:
+        description: "Base ETL GEM URL to inject into runtime config (empty when not deployed)"
+        required: false
+        default: ''
+        type: string
+      etl-woodmac-url:
+        description: "Base ETL WoodMac URL to inject into runtime config (empty when not deployed)"
+        required: false
+        default: ''
+        type: string
       auth0-domain:
         description: "Auth0 domain"
         required: true
@@ -118,6 +128,8 @@ jobs:
             "apiUrl": "${{ inputs.api-url }}",
             "entityLinkageUrl": "${{ inputs.entity-linkage-url }}",
             "stitchLlmUrl": "${{ inputs.stitch-llm-url }}",
+            "etlGemUrl": "${{ inputs.etl-gem-url }}",
+            "etlWoodmacUrl": "${{ inputs.etl-woodmac-url }}",
             "auth0Domain": "${{ inputs.auth0-domain }}",
             "auth0ClientId": "${{ inputs.auth0-client-id }}",
             "auth0Audience": "${{ inputs.auth0-audience }}",

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -347,7 +347,7 @@ jobs:
       registry-password: ${{ secrets.GHCR_ETL_PULL_TOKEN }}
     with:
       deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
-      full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-gem:${{ vars.ETL_GEM_IMAGE_TAG || 'pr-9' }}
+      full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-gem:${{ vars.ETL_GEM_IMAGE_TAG || 'main' }}
       container-app-name: ${{ format('{0}-etl-gem', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
       registry-username: ${{ needs.lane-config-validate.outputs.ghcr-etl-pull-username }}
@@ -384,7 +384,7 @@ jobs:
       registry-password: ${{ secrets.GHCR_ETL_PULL_TOKEN }}
     with:
       deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
-      full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-woodmac:${{ vars.ETL_WOODMAC_IMAGE_TAG || 'pr-9' }}
+      full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-woodmac:${{ vars.ETL_WOODMAC_IMAGE_TAG || 'main' }}
       container-app-name: ${{ format('{0}-etl-woodmac', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
       registry-username: ${{ needs.lane-config-validate.outputs.ghcr-etl-pull-username }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -332,13 +332,13 @@ jobs:
       azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       stitch-client-bearer-token: ${{ secrets.STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN }}
-      registry-username: ${{ secrets.GHCR_ETL_PULL_USERNAME }}
       registry-password: ${{ secrets.GHCR_ETL_PULL_TOKEN }}
     with:
       deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
       full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-gem:${{ vars.ETL_GEM_IMAGE_TAG || 'pr-9' }}
       container-app-name: ${{ format('{0}-etl-gem', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
+      registry-username: ${{ vars.GHCR_ETL_PULL_USERNAME }}
       environment-variables: >-
         LOG_LEVEL=info
         AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}
@@ -362,13 +362,13 @@ jobs:
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       stitch-client-bearer-token: ${{ secrets.STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN }}
       woodmac-api-key: ${{ secrets.WOODMAC_API_KEY }}
-      registry-username: ${{ secrets.GHCR_ETL_PULL_USERNAME }}
       registry-password: ${{ secrets.GHCR_ETL_PULL_TOKEN }}
     with:
       deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
       full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-woodmac:${{ vars.ETL_WOODMAC_IMAGE_TAG || 'pr-9' }}
       container-app-name: ${{ format('{0}-etl-woodmac', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
+      registry-username: ${{ vars.GHCR_ETL_PULL_USERNAME }}
       environment-variables: >-
         LOG_LEVEL=info
         AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -351,6 +351,7 @@ jobs:
         AUTH_AUDIENCE=${{ needs.lane-config-validate.outputs.auth-audience }}
         AUTH_JWKS_URI=${{ needs.lane-config-validate.outputs.auth-jwks-uri }}
         API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
+        ETL_GEM_FRONTEND_ORIGIN_URL=${{ needs.lane-config-validate.outputs.frontend-origin-url }}
         GEM_FILE_DIR=/mnt/data
       deployment-label: etl-gem
 
@@ -381,6 +382,7 @@ jobs:
         AUTH_AUDIENCE=${{ needs.lane-config-validate.outputs.auth-audience }}
         AUTH_JWKS_URI=${{ needs.lane-config-validate.outputs.auth-jwks-uri }}
         API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
+        ETL_WOODMAC_FRONTEND_ORIGIN_URL=${{ needs.lane-config-validate.outputs.frontend-origin-url }}
         WOODMAC_DATA_DIR=/tmp/woodmac
       deployment-label: etl-woodmac
 

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -342,6 +342,9 @@ jobs:
       container-app-name: ${{ format('{0}-etl-gem', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
       registry-username: ${{ needs.lane-config-validate.outputs.ghcr-etl-pull-username }}
+      # Single job at a time + in-memory /status state: keep exactly one replica.
+      min-replicas: "1"
+      max-replicas: "1"
       environment-variables: >-
         LOG_LEVEL=info
         AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}
@@ -373,6 +376,9 @@ jobs:
       container-app-name: ${{ format('{0}-etl-woodmac', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
       registry-username: ${{ needs.lane-config-validate.outputs.ghcr-etl-pull-username }}
+      # Single job at a time + in-memory /status state: keep exactly one replica.
+      min-replicas: "1"
+      max-replicas: "1"
       environment-variables: >-
         LOG_LEVEL=info
         AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -27,6 +27,7 @@ jobs:
       stitch-llm-azure-openai-base-url: ${{ steps.export-auth.outputs.stitch-llm-azure-openai-base-url }}
       stitch-llm-azure-openai-model: ${{ steps.export-auth.outputs.stitch-llm-azure-openai-model }}
       stitch-llm-azure-openai-timeout-seconds: ${{ steps.export-auth.outputs.stitch-llm-azure-openai-timeout-seconds }}
+      ghcr-etl-pull-username: ${{ steps.export-auth.outputs.ghcr-etl-pull-username }}
     env:
       FRONTEND_PRODUCTION_URL: ${{ vars.FRONTEND_PRODUCTION_URL }}
       FRONTEND_PREVIEW_URL_TEMPLATE: ${{ vars.FRONTEND_PREVIEW_URL_TEMPLATE }}
@@ -40,6 +41,7 @@ jobs:
       STITCH_LLM_AZURE_OPENAI_BASE_URL: ${{ vars.STITCH_LLM_AZURE_OPENAI_BASE_URL }}
       STITCH_LLM_AZURE_OPENAI_MODEL: ${{ vars.STITCH_LLM_AZURE_OPENAI_MODEL }}
       STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS: ${{ vars.STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS }}
+      GHCR_ETL_PULL_USERNAME: ${{ vars.GHCR_ETL_PULL_USERNAME }}
       STITCH_APP_PASSWORD: ${{ secrets.STITCH_APP_PASSWORD }}
       STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN: ${{ secrets.STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN }}
       STITCH_CLIENT_LLM_BEARER_TOKEN: ${{ secrets.STITCH_CLIENT_LLM_BEARER_TOKEN }}
@@ -123,6 +125,7 @@ jobs:
           echo "stitch-llm-azure-openai-base-url=${STITCH_LLM_AZURE_OPENAI_BASE_URL}" >> "$GITHUB_OUTPUT"
           echo "stitch-llm-azure-openai-model=${STITCH_LLM_AZURE_OPENAI_MODEL}" >> "$GITHUB_OUTPUT"
           echo "stitch-llm-azure-openai-timeout-seconds=${STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS:-30}" >> "$GITHUB_OUTPUT"
+          echo "ghcr-etl-pull-username=${GHCR_ETL_PULL_USERNAME:-}" >> "$GITHUB_OUTPUT"
 
   build-frontend:
     name: "Build frontend"
@@ -338,7 +341,7 @@ jobs:
       full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-gem:${{ vars.ETL_GEM_IMAGE_TAG || 'pr-9' }}
       container-app-name: ${{ format('{0}-etl-gem', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
-      registry-username: ${{ vars.GHCR_ETL_PULL_USERNAME }}
+      registry-username: ${{ needs.lane-config-validate.outputs.ghcr-etl-pull-username }}
       environment-variables: >-
         LOG_LEVEL=info
         AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}
@@ -368,7 +371,7 @@ jobs:
       full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-woodmac:${{ vars.ETL_WOODMAC_IMAGE_TAG || 'pr-9' }}
       container-app-name: ${{ format('{0}-etl-woodmac', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
-      registry-username: ${{ vars.GHCR_ETL_PULL_USERNAME }}
+      registry-username: ${{ needs.lane-config-validate.outputs.ghcr-etl-pull-username }}
       environment-variables: >-
         LOG_LEVEL=info
         AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -28,6 +28,7 @@ jobs:
       stitch-llm-azure-openai-model: ${{ steps.export-auth.outputs.stitch-llm-azure-openai-model }}
       stitch-llm-azure-openai-timeout-seconds: ${{ steps.export-auth.outputs.stitch-llm-azure-openai-timeout-seconds }}
       ghcr-etl-pull-username: ${{ steps.export-auth.outputs.ghcr-etl-pull-username }}
+      etl-storage-name: ${{ steps.export-auth.outputs.etl-storage-name }}
     env:
       FRONTEND_PRODUCTION_URL: ${{ vars.FRONTEND_PRODUCTION_URL }}
       FRONTEND_PREVIEW_URL_TEMPLATE: ${{ vars.FRONTEND_PREVIEW_URL_TEMPLATE }}
@@ -42,6 +43,7 @@ jobs:
       STITCH_LLM_AZURE_OPENAI_MODEL: ${{ vars.STITCH_LLM_AZURE_OPENAI_MODEL }}
       STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS: ${{ vars.STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS }}
       GHCR_ETL_PULL_USERNAME: ${{ vars.GHCR_ETL_PULL_USERNAME }}
+      ETL_STORAGE_NAME: ${{ vars.ETL_STORAGE_NAME }}
       STITCH_APP_PASSWORD: ${{ secrets.STITCH_APP_PASSWORD }}
       STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN: ${{ secrets.STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN }}
       STITCH_CLIENT_LLM_BEARER_TOKEN: ${{ secrets.STITCH_CLIENT_LLM_BEARER_TOKEN }}
@@ -126,6 +128,7 @@ jobs:
           echo "stitch-llm-azure-openai-model=${STITCH_LLM_AZURE_OPENAI_MODEL}" >> "$GITHUB_OUTPUT"
           echo "stitch-llm-azure-openai-timeout-seconds=${STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS:-30}" >> "$GITHUB_OUTPUT"
           echo "ghcr-etl-pull-username=${GHCR_ETL_PULL_USERNAME:-}" >> "$GITHUB_OUTPUT"
+          echo "etl-storage-name=${ETL_STORAGE_NAME:-}" >> "$GITHUB_OUTPUT"
 
   build-frontend:
     name: "Build frontend"
@@ -361,8 +364,11 @@ jobs:
         AUTH_JWKS_URI=${{ needs.lane-config-validate.outputs.auth-jwks-uri }}
         API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
         ETL_GEM_FRONTEND_ORIGIN_URL=${{ needs.lane-config-validate.outputs.frontend-origin-url }}
-        GEM_FILE_DIR=/mnt/data
+        GEM_FILE_DIR=/mnt/data/gem
       deployment-label: etl-gem
+      # Mount the lane's Azure Files share; GEM reads its xlsx from the gem/ subdir.
+      storage-name: ${{ needs.lane-config-validate.outputs.etl-storage-name }}
+      storage-mount-path: /mnt/data
 
   deploy-etl-woodmac:
     name: "Deploy ETL WoodMac"
@@ -395,8 +401,11 @@ jobs:
         AUTH_JWKS_URI=${{ needs.lane-config-validate.outputs.auth-jwks-uri }}
         API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
         ETL_WOODMAC_FRONTEND_ORIGIN_URL=${{ needs.lane-config-validate.outputs.frontend-origin-url }}
-        WOODMAC_DATA_DIR=/tmp/woodmac
+        WOODMAC_DATA_DIR=/mnt/data/woodmac
       deployment-label: etl-woodmac
+      # Mount the lane's Azure Files share; WoodMac caches under the woodmac/ subdir.
+      storage-name: ${{ needs.lane-config-validate.outputs.etl-storage-name }}
+      storage-mount-path: /mnt/data
 
   run-seed:
     name: "Run seed"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -171,6 +171,9 @@ jobs:
 
   build-seed-docker-image:
     name: "Build and publish Seed"
+    # Seed only runs in development; non-development lanes are populated by the
+    # ETL pipelines instead (one or the other, never both).
+    if: ${{ needs.resolve-context.outputs.deployment-lane == 'development' }}
     needs: [resolve-context]
     uses: ./.github/workflows/build-and-push-Docker-image.yml
     secrets: inherit
@@ -353,7 +356,8 @@ jobs:
 
   run-seed:
     name: "Run seed"
-    if: ${{ needs.deploy-db.outputs.database-created == 'true' }}
+    # Seed only runs in development; non-development lanes use the ETL pipelines.
+    if: ${{ needs.resolve-context.outputs.deployment-lane == 'development' && needs.deploy-db.outputs.database-created == 'true' }}
     needs: [resolve-context, build-seed-docker-image, deploy-db, deploy-api]
     uses: ./.github/workflows/run-seed.yml
     secrets:

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -270,6 +270,8 @@ jobs:
         POSTGRES_USER=${{ needs.deploy-db.outputs.postgres-user }}
         PGSSLMODE=${{ needs.deploy-db.outputs.postgres-sslmode }}
       deployment-label: api
+      # Keep staging / dress-rehearsal always-on; development scales to zero.
+      min-replicas: ${{ needs.resolve-context.outputs.deployment-lane != 'development' && '1' || '' }}
 
   deploy-entity-linkage:
     name: "Deploy entity linkage"
@@ -295,6 +297,8 @@ jobs:
         ENTITY_LINKAGE_API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
         ENTITY_LINKAGE_FRONTEND_ORIGIN_URL=${{ needs.lane-config-validate.outputs.frontend-origin-url }}
       deployment-label: entity-linkage
+      # Keep staging / dress-rehearsal always-on; development scales to zero.
+      min-replicas: ${{ needs.resolve-context.outputs.deployment-lane != 'development' && '1' || '' }}
 
   deploy-stitch-llm:
     name: "Deploy stitch-llm"
@@ -324,6 +328,8 @@ jobs:
         STITCH_LLM_AZURE_OPENAI_MODEL=${{ needs.lane-config-validate.outputs.stitch-llm-azure-openai-model }}
         STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS=${{ needs.lane-config-validate.outputs.stitch-llm-azure-openai-timeout-seconds }}
       deployment-label: stitch-llm
+      # Keep staging / dress-rehearsal always-on; development scales to zero.
+      min-replicas: ${{ needs.resolve-context.outputs.deployment-lane != 'development' && '1' || '' }}
 
   deploy-etl-gem:
     name: "Deploy ETL GEM"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -292,6 +292,65 @@ jobs:
         STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS=${{ needs.lane-config-validate.outputs.stitch-llm-azure-openai-timeout-seconds }}
       deployment-label: stitch-llm
 
+  deploy-etl-gem:
+    name: "Deploy ETL GEM"
+    if: ${{ needs.resolve-context.outputs.deployment-lane != 'development' }}
+    needs: [resolve-context, lane-config-validate, deploy-api]
+    uses: ./.github/workflows/deploy-container.yml
+    secrets:
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      stitch-client-bearer-token: ${{ secrets.STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN }}
+      registry-username: ${{ secrets.GHCR_ETL_PULL_USERNAME }}
+      registry-password: ${{ secrets.GHCR_ETL_PULL_TOKEN }}
+    with:
+      deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
+      full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-gem:${{ vars.ETL_GEM_IMAGE_TAG || 'pr-9' }}
+      container-app-name: ${{ format('{0}-etl-gem', needs.resolve-context.outputs.deployment-name) }}
+      registry-server: ghcr.io
+      environment-variables: >-
+        LOG_LEVEL=info
+        AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}
+        DEPLOYMENT_LANE=${{ needs.resolve-context.outputs.deployment-lane }}
+        DEPLOYMENT_NAME=${{ needs.resolve-context.outputs.deployment-name }}
+        AUTH_ISSUER=${{ needs.lane-config-validate.outputs.auth-issuer }}
+        AUTH_AUDIENCE=${{ needs.lane-config-validate.outputs.auth-audience }}
+        AUTH_JWKS_URI=${{ needs.lane-config-validate.outputs.auth-jwks-uri }}
+        API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
+        GEM_FILE_DIR=/mnt/data
+      deployment-label: etl-gem
+
+  deploy-etl-woodmac:
+    name: "Deploy ETL WoodMac"
+    if: ${{ needs.resolve-context.outputs.deployment-lane != 'development' }}
+    needs: [resolve-context, lane-config-validate, deploy-api]
+    uses: ./.github/workflows/deploy-container.yml
+    secrets:
+      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
+      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      stitch-client-bearer-token: ${{ secrets.STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN }}
+      woodmac-api-key: ${{ secrets.WOODMAC_API_KEY }}
+      registry-username: ${{ secrets.GHCR_ETL_PULL_USERNAME }}
+      registry-password: ${{ secrets.GHCR_ETL_PULL_TOKEN }}
+    with:
+      deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
+      full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-woodmac:${{ vars.ETL_WOODMAC_IMAGE_TAG || 'pr-9' }}
+      container-app-name: ${{ format('{0}-etl-woodmac', needs.resolve-context.outputs.deployment-name) }}
+      registry-server: ghcr.io
+      environment-variables: >-
+        LOG_LEVEL=info
+        AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}
+        DEPLOYMENT_LANE=${{ needs.resolve-context.outputs.deployment-lane }}
+        DEPLOYMENT_NAME=${{ needs.resolve-context.outputs.deployment-name }}
+        AUTH_ISSUER=${{ needs.lane-config-validate.outputs.auth-issuer }}
+        AUTH_AUDIENCE=${{ needs.lane-config-validate.outputs.auth-audience }}
+        AUTH_JWKS_URI=${{ needs.lane-config-validate.outputs.auth-jwks-uri }}
+        API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
+        WOODMAC_DATA_DIR=/tmp/woodmac
+      deployment-label: etl-woodmac
+
   run-seed:
     name: "Run seed"
     if: ${{ needs.deploy-db.outputs.database-created == 'true' }}
@@ -306,7 +365,10 @@ jobs:
 
   deploy-frontend:
     name: "Deploy frontend"
-    needs: [resolve-context, lane-config-validate, build-frontend, deploy-api, deploy-entity-linkage, deploy-stitch-llm]
+    # ETL deploys are skipped in the development lane; gate on no-failure rather
+    # than all-success so the frontend still deploys when they are skipped.
+    if: ${{ !failure() && !cancelled() }}
+    needs: [resolve-context, lane-config-validate, build-frontend, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl-gem, deploy-etl-woodmac]
     uses: ./.github/workflows/azure-static-web-apps.yml
     secrets:
       azure-static-web-apps-deploy-token: ${{ secrets.AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN }}
@@ -317,6 +379,8 @@ jobs:
       api-url: ${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
       entity-linkage-url: ${{ format('{0}/api/v1', needs.deploy-entity-linkage.outputs.container-app-url) }}
       stitch-llm-url: ${{ format('{0}/api/v1', needs.deploy-stitch-llm.outputs.container-app-url) }}
+      etl-gem-url: ${{ needs.deploy-etl-gem.result == 'success' && format('{0}/api/v1', needs.deploy-etl-gem.outputs.container-app-url) || '' }}
+      etl-woodmac-url: ${{ needs.deploy-etl-woodmac.result == 'success' && format('{0}/api/v1', needs.deploy-etl-woodmac.outputs.container-app-url) || '' }}
       auth0-domain: ${{ needs.lane-config-validate.outputs.auth0-domain }}
       auth0-client-id: ${{ needs.lane-config-validate.outputs.auth0-client-id }}
       auth0-audience: ${{ needs.lane-config-validate.outputs.auth0-audience }}
@@ -326,4 +390,4 @@ jobs:
     if: ${{ always() && github.event_name == 'pull_request' }}
     uses: ./.github/workflows/comment-pr-summary.yml
     secrets: inherit
-    needs: [resolve-context, build-api-docker-image, build-entity-linkage-docker-image, build-stitch-llm-docker-image, build-seed-docker-image, deploy-db, run-db-migrations, deploy-api, deploy-entity-linkage, deploy-stitch-llm, run-seed, deploy-frontend]
+    needs: [resolve-context, build-api-docker-image, build-entity-linkage-docker-image, build-stitch-llm-docker-image, build-seed-docker-image, deploy-db, run-db-migrations, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl-gem, deploy-etl-woodmac, run-seed, deploy-frontend]

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -38,6 +38,16 @@ on:
         required: false
         default: ""
         type: string
+      min-replicas:
+        description: "Optional. If set, reassert the Container App min replica count after deploy. Use to pin single-replica apps (set min and max to 1)."
+        required: false
+        default: ""
+        type: string
+      max-replicas:
+        description: "Optional. If set, reassert the Container App max replica count after deploy."
+        required: false
+        default: ""
+        type: string
     secrets:
       azure-client-id:
         required: true
@@ -150,6 +160,26 @@ jobs:
           registryUrl: ${{ inputs.registry-server }}
           registryUsername: ${{ inputs.registry-username }}
           registryPassword: ${{ secrets.registry-password }}
+
+      - name: Pin replica scaling
+        # `az containerapp up` (the deploy action) does not reliably preserve
+        # scale settings, so reassert them after every deploy when requested.
+        # Single-job apps (the ETLs) pass min=max=1 to avoid multiple replicas.
+        if: ${{ inputs.min-replicas != '' || inputs.max-replicas != '' }}
+        shell: bash
+        env:
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+          MIN_REPLICAS: ${{ inputs.min-replicas }}
+          MAX_REPLICAS: ${{ inputs.max-replicas }}
+        run: |
+          set -euo pipefail
+          args=()
+          [ -n "${MIN_REPLICAS}" ] && args+=(--min-replicas "${MIN_REPLICAS}")
+          [ -n "${MAX_REPLICAS}" ] && args+=(--max-replicas "${MAX_REPLICAS}")
+          az containerapp update \
+            --name "${{ inputs.container-app-name }}" \
+            --resource-group "${AZURE_RESOURCE_GROUP}" \
+            "${args[@]}"
 
       - name: Export application URL
         id: export-app-url

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -48,6 +48,16 @@ on:
         required: false
         default: ""
         type: string
+      storage-name:
+        description: "Optional. Name of an Azure Files storage already registered on the Container Apps environment. When set, it is mounted into the app after deploy."
+        required: false
+        default: ""
+        type: string
+      storage-mount-path:
+        description: "Container path to mount the Azure Files storage at (e.g. /mnt/data). Required when storage-name is set."
+        required: false
+        default: ""
+        type: string
     secrets:
       azure-client-id:
         required: true
@@ -180,6 +190,44 @@ jobs:
             --name "${{ inputs.container-app-name }}" \
             --resource-group "${AZURE_RESOURCE_GROUP}" \
             "${args[@]}"
+
+      - name: Mount Azure Files volume
+        # The deploy action cannot mount volumes, so attach the (already
+        # environment-registered) Azure Files storage afterward by reading the
+        # current app spec, injecting a volume + volumeMount, and re-applying.
+        # show -> mutate -> update --yaml is the documented pattern and preserves
+        # everything the action just set (image, env vars, scale, registry).
+        if: ${{ inputs.storage-name != '' }}
+        shell: bash
+        env:
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+          STORAGE_NAME: ${{ inputs.storage-name }}
+          MOUNT_PATH: ${{ inputs.storage-mount-path }}
+        run: |
+          set -euo pipefail
+          : "${MOUNT_PATH:?storage-name is set but storage-mount-path is empty}"
+
+          az containerapp show \
+            --name "${{ inputs.container-app-name }}" \
+            --resource-group "${AZURE_RESOURCE_GROUP}" \
+            --output json > /tmp/app.json
+
+          jq \
+            --arg sn "${STORAGE_NAME}" \
+            --arg mp "${MOUNT_PATH}" \
+            'del(.systemData)
+             | .properties.template.volumes = [
+                 {name: "data", storageType: "AzureFile", storageName: $sn}
+               ]
+             | .properties.template.containers |= map(
+                 .volumeMounts = [{volumeName: "data", mountPath: $mp}]
+               )' \
+            /tmp/app.json > /tmp/app.yaml
+
+          az containerapp update \
+            --name "${{ inputs.container-app-name }}" \
+            --resource-group "${AZURE_RESOURCE_GROUP}" \
+            --yaml /tmp/app.yaml
 
       - name: Export application URL
         id: export-app-url

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -28,6 +28,11 @@ on:
         required: false
         default: ""
         type: string
+      registry-server:
+        description: "Container image registry server (e.g. ghcr.io). Set to configure pull credentials on the Container App; required for private/internal images."
+        required: false
+        default: ""
+        type: string
     secrets:
       azure-client-id:
         required: true
@@ -40,6 +45,12 @@ on:
       stitch-client-bearer-token:
         required: false
       stitch-llm-azure-openai-api-key:
+        required: false
+      woodmac-api-key:
+        required: false
+      registry-username:
+        required: false
+      registry-password:
         required: false
     outputs:
       container-app-url:
@@ -88,6 +99,7 @@ jobs:
           STITCH_APP_PASSWORD: ${{ secrets.stitch-app-password }}
           STITCH_CLIENT_BEARER_TOKEN: ${{ secrets.stitch-client-bearer-token }}
           STITCH_LLM_AZURE_OPENAI_API_KEY: ${{ secrets.stitch-llm-azure-openai-api-key }}
+          WOODMAC_API_KEY: ${{ secrets.woodmac-api-key }}
         run: |
           set -euo pipefail
           envvars='${{ inputs.environment-variables }}'
@@ -99,6 +111,9 @@ jobs:
           fi
           if [ -n "${STITCH_LLM_AZURE_OPENAI_API_KEY:-}" ]; then
             envvars="$envvars STITCH_LLM_AZURE_OPENAI_API_KEY=${STITCH_LLM_AZURE_OPENAI_API_KEY}"
+          fi
+          if [ -n "${WOODMAC_API_KEY:-}" ]; then
+            envvars="$envvars WOODMAC_API_KEY=${WOODMAC_API_KEY}"
           fi
           echo "environment-variables<<EOF" >> "$GITHUB_OUTPUT"
           echo "$envvars" >> "$GITHUB_OUTPUT"
@@ -114,6 +129,12 @@ jobs:
           targetPort: ${{ inputs.target-port }}
           environmentVariables: ${{ steps.envvars.outputs.environment-variables }}
           ingress: "external"
+          # Registry pull credentials are only configured when registry-server is
+          # set (e.g. for cross-repo private/internal GHCR images). Existing
+          # callers omit these and the action leaves registry config untouched.
+          registryUrl: ${{ inputs.registry-server }}
+          registryUsername: ${{ secrets.registry-username }}
+          registryPassword: ${{ secrets.registry-password }}
 
       - name: Export application URL
         id: export-app-url

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -104,6 +104,8 @@ jobs:
           REGISTRY_SERVER: ${{ inputs.registry-server }}
           REGISTRY_USERNAME: ${{ inputs.registry-username }}
           REGISTRY_PASSWORD: ${{ secrets.registry-password }}
+          STORAGE_NAME: ${{ inputs.storage-name }}
+          MOUNT_PATH: ${{ inputs.storage-mount-path }}
         run: |
           set -euo pipefail
           : "${AZURE_RESOURCE_GROUP:?Missing required variable AZURE_RESOURCE_GROUP}"
@@ -116,6 +118,20 @@ jobs:
           if [ -n "${REGISTRY_SERVER:-}" ]; then
             : "${REGISTRY_USERNAME:?registry-server is set but the registry-username variable is empty}"
             : "${REGISTRY_PASSWORD:?registry-server is set but the registry-password secret is empty}"
+          fi
+
+          # storage-name and storage-mount-path must be set together. Callers that
+          # need durable storage (the ETL apps) hardcode the mount path, so an
+          # empty storage-name means a missing/typo'd ETL_STORAGE_NAME variable.
+          # Without this check the mount step below silently skips and the app
+          # deploys with no durable storage. Fail fast on either-without-the-other.
+          if [ -n "${STORAGE_NAME:-}" ] && [ -z "${MOUNT_PATH:-}" ]; then
+            echo "::error::storage-name is set but storage-mount-path is empty" >&2
+            exit 1
+          fi
+          if [ -n "${MOUNT_PATH:-}" ] && [ -z "${STORAGE_NAME:-}" ]; then
+            echo "::error::storage-mount-path is set but storage-name is empty (check the lane's ETL_STORAGE_NAME variable)" >&2
+            exit 1
           fi
 
       - name: Azure login

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -33,6 +33,11 @@ on:
         required: false
         default: ""
         type: string
+      registry-username:
+        description: "Username for the image registry. Not sensitive (the token is the secret), so pass it as a variable."
+        required: false
+        default: ""
+        type: string
     secrets:
       azure-client-id:
         required: true
@@ -47,8 +52,6 @@ on:
       stitch-llm-azure-openai-api-key:
         required: false
       woodmac-api-key:
-        required: false
-      registry-username:
         required: false
       registry-password:
         required: false
@@ -78,10 +81,22 @@ jobs:
         env:
           AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           AZURE_CONTAINER_APP_ENVIRONMENT: ${{ vars.AZURE_CONTAINER_APP_ENVIRONMENT }}
+          REGISTRY_SERVER: ${{ inputs.registry-server }}
+          REGISTRY_USERNAME: ${{ inputs.registry-username }}
+          REGISTRY_PASSWORD: ${{ secrets.registry-password }}
         run: |
           set -euo pipefail
           : "${AZURE_RESOURCE_GROUP:?Missing required variable AZURE_RESOURCE_GROUP}"
           : "${AZURE_CONTAINER_APP_ENVIRONMENT:?Missing required variable AZURE_CONTAINER_APP_ENVIRONMENT}"
+
+          # If a registry server is configured (e.g. for private/internal GHCR
+          # images), the pull credentials must accompany it. Fail fast with a
+          # clear message rather than letting `az containerapp up` return an
+          # opaque "UNAUTHORIZED: authentication required".
+          if [ -n "${REGISTRY_SERVER:-}" ]; then
+            : "${REGISTRY_USERNAME:?registry-server is set but the registry-username variable is empty}"
+            : "${REGISTRY_PASSWORD:?registry-server is set but the registry-password secret is empty}"
+          fi
 
       - name: Azure login
         uses: azure/login@v3
@@ -133,7 +148,7 @@ jobs:
           # set (e.g. for cross-repo private/internal GHCR images). Existing
           # callers omit these and the action leaves registry config untouched.
           registryUrl: ${{ inputs.registry-server }}
-          registryUsername: ${{ secrets.registry-username }}
+          registryUsername: ${{ inputs.registry-username }}
           registryPassword: ${{ secrets.registry-password }}
 
       - name: Export application URL

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -33,6 +33,30 @@ It then handles deployments for:
 * the API Container App, assuming an existing Container Apps environment
 * the entity-linkage Container App in the same environment
 * the stitch-llm Container App in the same environment
+* the ETL Container Apps (`etl-gem`, `etl-woodmac`) in the same environment,
+  on non-`development` lanes only (see below)
+
+### ETL pipelines (temporary POC wiring)
+
+The `etl-gem` and `etl-woodmac` Container Apps are deployed from pre-built images
+published by the separate `stitch-etl-poc` repository
+(`ghcr.io/rmi/stitch-etl-poc-etl-{gem,woodmac}`). This pipeline does **not** build
+them; it only deploys the tag named by the `ETL_GEM_IMAGE_TAG` /
+`ETL_WOODMAC_IMAGE_TAG` variables (defaulting to `pr-9`).
+
+Seed and ETL are mutually exclusive per lane:
+
+* `development`: `seed` builds and runs; ETL deploys are skipped.
+* `staging` / `dress-rehearsal`: ETL deploys run; `seed` is skipped.
+
+Because the ETL images live in another repo's GHCR, the Container App needs
+stored pull credentials. The ephemeral `GITHUB_TOKEN` cannot be used (it expires
+and the app re-pulls on every restart), so a long-lived classic PAT with
+`read:packages` is required — GHCR does not support fine-grained tokens. These
+are supplied to `deploy-container.yml` via the `registry-server` /
+`registry-username` inputs and the `registry-password` secret. The frontend
+receives each ETL Container App URL (empty when not deployed) and renders the ETL
+control page.
 
 Reusable workflows now select lane-specific configuration from GitHub
 Environments and are expected to fail loudly when required values are absent.
@@ -128,6 +152,13 @@ named:
 * `STITCH_LLM_AZURE_OPENAI_BASE_URL` (example: `https://stitch-foundry-dev.openai.azure.com/openai/v1`)
 * `STITCH_LLM_AZURE_OPENAI_MODEL` (example: `gpt-5.1-chat`)
 * `STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS` (example: `30`)
+* `GHCR_ETL_PULL_USERNAME` (example: `your-github-username`) — registry username
+  for pulling the ETL images; not sensitive, so it is a variable. Only needed on
+  `staging` / `dress-rehearsal`.
+* `ETL_GEM_IMAGE_TAG` (example: `pr-9`) — optional; ETL GEM image tag to deploy,
+  defaults to `pr-9`. Only used on `staging` / `dress-rehearsal`.
+* `ETL_WOODMAC_IMAGE_TAG` (example: `pr-9`) — optional; ETL WoodMac image tag to
+  deploy, defaults to `pr-9`. Only used on `staging` / `dress-rehearsal`.
   * NOTE: `FRONTEND_PREVIEW_URL_TEMPLATE` must contain the literal `{name}` placeholder.
 For `dress-rehearsal`, the workflow uses `FRONTEND_PRODUCTION_URL` directly. For pull requests, it replaces `{name}` with the raw PR number so PR #106 resolves to `https://witty-mushroom-017a3dc1e-106.westus2.1.azurestaticapps.net`. For other preview deployments, it replaces `{name}` with `deployment_name`.
 
@@ -140,6 +171,11 @@ For `dress-rehearsal`, the workflow uses `FRONTEND_PRODUCTION_URL` directly. For
 * `STITCH_CLIENT_LLM_BEARER_TOKEN`
 * `STITCH_LLM_AZURE_OPENAI_API_KEY`
 * `AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN`
+* `WOODMAC_API_KEY` — WoodMac API key for the `etl-woodmac` Container App. Only
+  needed on `staging` / `dress-rehearsal`.
+* `GHCR_ETL_PULL_TOKEN` — classic PAT with `read:packages` used to pull the ETL
+  images from the `stitch-etl-poc` GHCR. Only needed on `staging` /
+  `dress-rehearsal`.
 
 Current validation behavior:
 
@@ -160,3 +196,7 @@ Current validation behavior:
   * If any of `STITCH_LLM_AZURE_OPENAI_BASE_URL`, `STITCH_LLM_AZURE_OPENAI_MODEL`, or `STITCH_LLM_AZURE_OPENAI_API_KEY` are set, all three must be set
 * DB migrations validate `STITCH_MIGRATOR_PASSWORD`
 * frontend deploy validates `AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN`
+* container deploy validates that, when `registry-server` is set, both
+  `registry-username` (variable) and `registry-password` (secret) are present —
+  so a missing ETL pull credential fails fast instead of surfacing as an opaque
+  registry `UNAUTHORIZED` from `az containerapp up`

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -58,6 +58,87 @@ are supplied to `deploy-container.yml` via the `registry-server` /
 receives each ETL Container App URL (empty when not deployed) and renders the ETL
 control page.
 
+CORS: each ETL app allows exactly one browser origin, set at deploy time via
+`ETL_GEM_FRONTEND_ORIGIN_URL` / `ETL_WOODMAC_FRONTEND_ORIGIN_URL` (sourced from
+the lane's computed `frontend-origin-url`). Unset, they default to
+`http://localhost:3000`, so a missing value shows up as a browser CORS
+("No 'Access-Control-Allow-Origin' header") failure, not a server error.
+
+#### ETL durable storage (Azure Files — manual setup, not yet wired)
+
+The ETL apps need persistent storage that the current deploy path does not yet
+provide: `etl-gem` reads a read-only reference spreadsheet (`GEM_FILE_DIR`,
+`/mnt/data`) and `etl-woodmac` keeps a read-write cache (`WOODMAC_DATA_DIR`,
+currently the ephemeral `/tmp/woodmac`, lost on every restart/revision). The plan
+is one **SMB Azure Files** share per lane, mounted into both apps (gem read-only,
+woodmac read-write). `azure/container-apps-deploy-action@v1` cannot mount volumes,
+so wiring this in CI requires graduating the ETL jobs to an `az containerapp
+update --yaml` step — tracked separately. The Azure-side prerequisites below are
+manual and must exist **before** that CI work lands.
+
+These prerequisites are done in the **Azure Portal** (web UI) — no `az` required.
+SMB Azure Files registration and mounting are fully supported in the Portal; only
+NFS forces the CLI/YAML route, which is another reason to use SMB. Do this per
+lane (`staging`, `dress-rehearsal`), in that lane's resource group and Container
+Apps environment.
+
+1. **Create a storage account + file share.** Create a Storage account (Standard
+   LRS, StorageV2) or reuse one, then under **File shares** add a share named
+   `etl-data`.
+
+2. **Upload the data into the share.** In the share's **Browse** view, create a
+   `gem/` folder and upload the GEM reference spreadsheet
+   (`Global-Oil-and-Gas-Extraction-Tracker-*.xlsx`); add any woodmac seed files
+   similarly. The data is intentionally **not** baked into the image.
+
+3. **Register the share on the Container Apps environment.** Open the Container
+   Apps **Environment** → **Settings → Volume mounts → Add** → choose **SMB**, and
+   enter the storage account name, account key, share name (`etl-data`), and
+   access mode. This registration lives on the *environment* and persists across
+   app deploys. (Container Apps does not support managed-identity access to Azure
+   Files, so the account key is required regardless of Portal vs. CLI.)
+
+   To get the account key: go to the **storage account** → **Security +
+   networking → Access keys** → **Show** under `key1` and copy the **Key** value
+   (either `key1` or `key2` works). This is the same key recorded as the
+   `ETL_STORAGE_ACCOUNT_KEY` secret in step 4. Treat it as a secret — it grants
+   full access to the storage account; rotate via the same blade if exposed.
+
+4. **Record the names for the future CI wiring** as environment-scoped GitHub
+   config: variables `ETL_STORAGE_NAME` (e.g. `etl-data`) and
+   `ETL_STORAGE_SHARE_NAME`, and — if the YAML deploy authenticates with the key
+   rather than the pre-registered env storage — secret `ETL_STORAGE_ACCOUNT_KEY`.
+
+The per-app **volume mount** (attaching the registered storage to a container at
+a path) can also be added in the Portal by editing the app and creating a new
+revision — but **do not rely on that for a stable setup**: our deploys run through
+`azure/container-apps-deploy-action@v1` (`az containerapp up`), which re-applies
+the container spec and will drop a hand-added mount on the next pipeline run. A
+Portal mount is fine for a one-off smoke test; for durability the mount must live
+in the deploy path (the YAML step in the follow-up task). Steps 1–3 above are
+safe to do in the Portal now because they persist independently of app deploys.
+
+Equivalent CLI, for reference (registration is the key step):
+
+```bash
+az containerapp env storage set \
+  --name <AZURE_CONTAINER_APP_ENVIRONMENT> \
+  --resource-group <AZURE_RESOURCE_GROUP> \
+  --storage-name etl-data \
+  --azure-file-account-name <storageacct> \
+  --azure-file-account-key <key> \
+  --azure-file-share-name etl-data \
+  --access-mode ReadWrite
+```
+
+See the Microsoft docs for the full Portal walkthrough:
+<https://learn.microsoft.com/en-us/azure/container-apps/storage-mounts-azure-files>.
+
+Once mounted, the apps should also be pinned to **min = max = 1 replica**: they
+hold job state in memory (the `/status` endpoint) and run one job at a time, so a
+second replica would both fragment status responses and create a concurrent
+writer on the shared share.
+
 Reusable workflows now select lane-specific configuration from GitHub
 Environments and are expected to fail loudly when required values are absent.
 

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -80,11 +80,17 @@ These prerequisites are done in the **Azure Portal** (web UI) — no `az` requir
 SMB Azure Files registration and mounting are fully supported in the Portal; only
 NFS forces the CLI/YAML route, which is another reason to use SMB. Do this per
 lane (`staging`, `dress-rehearsal`), in that lane's resource group and Container
-Apps environment.
+Apps environment. Each lane gets its own storage account / share / environment
+storage name — the table tracks the concrete values:
+
+| Lane | Storage account | File share | Env storage (mount) name |
+|---|---|---|---|
+| `staging` | `stitchstaging` | `etl-staging` | `etl-staging` |
+| `dress-rehearsal` | _(tbd)_ | _(tbd)_ | _(tbd)_ |
 
 1. **Create a storage account + file share.** Create a Storage account (Standard
-   LRS, StorageV2) or reuse one, then under **File shares** add a share named
-   `etl-data`.
+   LRS, StorageV2) or reuse one, then under **File shares** add a share (for
+   `staging`: account `stitchstaging`, share `etl-staging`).
 
 2. **Upload the data into the share.** In the share's **Browse** view, create a
    `gem/` folder and upload the GEM reference spreadsheet
@@ -93,10 +99,11 @@ Apps environment.
 
 3. **Register the share on the Container Apps environment.** Open the Container
    Apps **Environment** → **Settings → Volume mounts → Add** → choose **SMB**, and
-   enter the storage account name, account key, share name (`etl-data`), and
-   access mode. This registration lives on the *environment* and persists across
-   app deploys. (Container Apps does not support managed-identity access to Azure
-   Files, so the account key is required regardless of Portal vs. CLI.)
+   enter the storage account name, account key, share name (`etl-staging` for
+   staging), and access mode; name the environment storage to match (`etl-staging`).
+   This registration lives on the *environment* and persists across app deploys.
+   (Container Apps does not support managed-identity access to Azure Files, so the
+   account key is required regardless of Portal vs. CLI.)
 
    To get the account key: go to the **storage account** → **Security +
    networking → Access keys** → **Show** under `key1` and copy the **Key** value
@@ -105,9 +112,10 @@ Apps environment.
    full access to the storage account; rotate via the same blade if exposed.
 
 4. **Record the names for the future CI wiring** as environment-scoped GitHub
-   config: variables `ETL_STORAGE_NAME` (e.g. `etl-data`) and
-   `ETL_STORAGE_SHARE_NAME`, and — if the YAML deploy authenticates with the key
-   rather than the pre-registered env storage — secret `ETL_STORAGE_ACCOUNT_KEY`.
+   config: variables `ETL_STORAGE_NAME` (the env storage name, e.g. `etl-staging`)
+   and `ETL_STORAGE_SHARE_NAME` (e.g. `etl-staging`), and — if the YAML deploy
+   authenticates with the key rather than the pre-registered env storage — secret
+   `ETL_STORAGE_ACCOUNT_KEY`.
 
 The per-app **volume mount** (attaching the registered storage to a container at
 a path) can also be added in the Portal by editing the app and creating a new
@@ -121,23 +129,36 @@ safe to do in the Portal now because they persist independently of app deploys.
 Equivalent CLI, for reference (registration is the key step):
 
 ```bash
+# staging values shown
 az containerapp env storage set \
   --name <AZURE_CONTAINER_APP_ENVIRONMENT> \
   --resource-group <AZURE_RESOURCE_GROUP> \
-  --storage-name etl-data \
-  --azure-file-account-name <storageacct> \
+  --storage-name etl-staging \
+  --azure-file-account-name stitchstaging \
   --azure-file-account-key <key> \
-  --azure-file-share-name etl-data \
+  --azure-file-share-name etl-staging \
   --access-mode ReadWrite
 ```
 
 See the Microsoft docs for the full Portal walkthrough:
 <https://learn.microsoft.com/en-us/azure/container-apps/storage-mounts-azure-files>.
 
-Once mounted, the apps should also be pinned to **min = max = 1 replica**: they
-hold job state in memory (the `/status` endpoint) and run one job at a time, so a
-second replica would both fragment status responses and create a concurrent
-writer on the shared share.
+#### ETL replica pinning (wired in CI)
+
+The ETL apps must run a **single replica**: they hold job state in memory (the
+`/status` endpoint) and run one job at a time, so a second replica would fragment
+status responses and (once the share is mounted) create a concurrent writer.
+
+This is **enforced on every deploy**, not as a one-time manual setting. The
+`azure/container-apps-deploy-action@v1` step (`az containerapp up`) does not
+reliably preserve scale settings, so a value set by hand in the Portal can be
+reset on the next pipeline run. Instead, `deploy-container.yml` takes optional
+`min-replicas` / `max-replicas` inputs and, when either is set, runs a post-deploy
+`az containerapp update --min-replicas … --max-replicas …` to reassert them. The
+ETL jobs pass `min-replicas: "1"` and `max-replicas: "1"`, so the pin is
+self-healing — no manual Portal step needed, and it survives every redeploy. Other
+deploys (api, entity-linkage, stitch-llm) omit these inputs and keep their default
+scaling.
 
 Reusable workflows now select lane-specific configuration from GitHub
 Environments and are expected to fail loudly when required values are absent.

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -156,9 +156,31 @@ reset on the next pipeline run. Instead, `deploy-container.yml` takes optional
 `min-replicas` / `max-replicas` inputs and, when either is set, runs a post-deploy
 `az containerapp update --min-replicas … --max-replicas …` to reassert them. The
 ETL jobs pass `min-replicas: "1"` and `max-replicas: "1"`, so the pin is
-self-healing — no manual Portal step needed, and it survives every redeploy. Other
-deploys (api, entity-linkage, stitch-llm) omit these inputs and keep their default
-scaling.
+self-healing — no manual Portal step needed, and it survives every redeploy.
+
+#### Keeping staging / dress-rehearsal awake (scale-to-zero policy)
+
+By default a Container App scales to zero (`min-replicas: 0`) when idle, so the
+first request after a quiet period pays a cold-start. That is fine for
+`development` (keeps costs down when nobody is using it) but undesirable for
+`staging` / `dress-rehearsal`, which we want responsive.
+
+The always-on services — `api`, `entity-linkage`, `stitch-llm` — therefore pass a
+**lane-conditional** `min-replicas` through the same mechanism:
+
+```yaml
+min-replicas: ${{ needs.resolve-context.outputs.deployment-lane != 'development' && '1' || '' }}
+```
+
+So on `staging` / `dress-rehearsal` they reassert `min-replicas: 1` (always one
+warm replica, `max` left at the default so they can still scale out), and on
+`development` the input is empty, the post-deploy step is skipped, and they keep
+the default scale-to-zero. The ETL apps are always-on on those lanes too, since
+they pin `min = max = 1` and only deploy on non-`development` lanes.
+
+This only affects the Container Apps. The frontend is an Azure Static Web App
+(always served, no hibernation), and the PostgreSQL flexible server's
+pause behavior, if any, is a separate server-level setting not managed here.
 
 Reusable workflows now select lane-specific configuration from GitHub
 Environments and are expected to fail loudly when required values are absent.

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -64,26 +64,32 @@ the lane's computed `frontend-origin-url`). Unset, they default to
 `http://localhost:3000`, so a missing value shows up as a browser CORS
 ("No 'Access-Control-Allow-Origin' header") failure, not a server error.
 
-#### ETL durable storage (Azure Files — manual setup, not yet wired)
+#### ETL durable storage (Azure Files — wired in CI; storage prerequisites manual)
 
-The ETL apps need persistent storage that the current deploy path does not yet
-provide: `etl-gem` reads a read-only reference spreadsheet (`GEM_FILE_DIR`,
-`/mnt/data`) and `etl-woodmac` keeps a read-write cache (`WOODMAC_DATA_DIR`,
-currently the ephemeral `/tmp/woodmac`, lost on every restart/revision). The plan
-is one **SMB Azure Files** share per lane, mounted into both apps (gem read-only,
-woodmac read-write). `azure/container-apps-deploy-action@v1` cannot mount volumes,
-so wiring this in CI requires graduating the ETL jobs to an `az containerapp
-update --yaml` step — tracked separately. The Azure-side prerequisites below are
-manual and must exist **before** that CI work lands.
+The ETL apps mount a persistent **SMB Azure Files** share so their data survives
+restarts/revisions: `etl-gem` reads its reference spreadsheet from
+`GEM_FILE_DIR=/mnt/data/gem` and `etl-woodmac` keeps its cache at
+`WOODMAC_DATA_DIR=/mnt/data/woodmac`. One share per lane is mounted into both apps
+at `/mnt/data`, with each app using its own subfolder (`gem/`, `woodmac/`).
 
-These prerequisites are done in the **Azure Portal** (web UI) — no `az` required.
-SMB Azure Files registration and mounting are fully supported in the Portal; only
-NFS forces the CLI/YAML route, which is another reason to use SMB. Do this per
-lane (`staging`, `dress-rehearsal`), in that lane's resource group and Container
-Apps environment. Each lane gets its own storage account / share / environment
-storage name — the table tracks the concrete values:
+The **per-app mount is applied automatically by the pipeline** —
+`azure/container-apps-deploy-action@v1` can't mount volumes, so
+`deploy-container.yml` takes optional `storage-name` / `storage-mount-path` inputs
+and, after the deploy, reads the app spec (`az containerapp show`), injects the
+volume + volumeMount with `jq`, and re-applies it (`az containerapp update
+--yaml`). The ETL jobs pass `storage-name` (from the lane's `ETL_STORAGE_NAME`
+variable, routed via `lane-config-validate` because env-scoped variables aren't
+visible to reusable-workflow callers) and `storage-mount-path: /mnt/data`. Because
+it runs every deploy, **do not configure the mount by hand in the Portal** — the
+pipeline reasserts it and a manual mount would just be overwritten.
 
-| Lane | Storage account | File share | Env storage (mount) name |
+What *is* manual is the storage itself. Do the steps below in the **Azure Portal**
+(no `az` needed; SMB registration and mounting are fully Portal-supported — only
+NFS forces CLI/YAML) per lane (`staging`, `dress-rehearsal`), in that lane's
+resource group and Container Apps environment. Each lane gets its own storage
+account / share / environment-storage name:
+
+| Lane | Storage account | File share | Env storage name (`ETL_STORAGE_NAME`) |
 |---|---|---|---|
 | `staging` | `stitchstaging` | `etl-staging` | `etl-staging` |
 | `dress-rehearsal` | _(tbd)_ | _(tbd)_ | _(tbd)_ |
@@ -92,41 +98,35 @@ storage name — the table tracks the concrete values:
    LRS, StorageV2) or reuse one, then under **File shares** add a share (for
    `staging`: account `stitchstaging`, share `etl-staging`).
 
-2. **Upload the data into the share.** In the share's **Browse** view, create a
-   `gem/` folder and upload the GEM reference spreadsheet
-   (`Global-Oil-and-Gas-Extraction-Tracker-*.xlsx`); add any woodmac seed files
-   similarly. The data is intentionally **not** baked into the image.
+2. **Create the subfolders and upload data.** In the share's **Browse** view,
+   create a `gem/` folder and upload the GEM reference spreadsheet
+   (`Global-Oil-and-Gas-Extraction-Tracker-*.xlsx`) into it, and create a
+   `woodmac/` folder for the cache (and any woodmac seed files). These match
+   `GEM_FILE_DIR=/mnt/data/gem` and `WOODMAC_DATA_DIR=/mnt/data/woodmac`. The data
+   is intentionally **not** baked into the image.
 
 3. **Register the share on the Container Apps environment.** Open the Container
    Apps **Environment** → **Settings → Volume mounts → Add** → choose **SMB**, and
    enter the storage account name, account key, share name (`etl-staging` for
-   staging), and access mode; name the environment storage to match (`etl-staging`).
-   This registration lives on the *environment* and persists across app deploys.
+   staging), and access mode `ReadWrite`; name the environment storage to match
+   (`etl-staging`) — this exact name is what `ETL_STORAGE_NAME` must hold. The
+   registration lives on the *environment* and persists across app deploys.
    (Container Apps does not support managed-identity access to Azure Files, so the
    account key is required regardless of Portal vs. CLI.)
 
    To get the account key: go to the **storage account** → **Security +
    networking → Access keys** → **Show** under `key1` and copy the **Key** value
-   (either `key1` or `key2` works). This is the same key recorded as the
-   `ETL_STORAGE_ACCOUNT_KEY` secret in step 4. Treat it as a secret — it grants
-   full access to the storage account; rotate via the same blade if exposed.
+   (either `key1` or `key2` works). Treat it as a secret — it grants full access to
+   the storage account; rotate via the same blade if exposed. It is only used here
+   for the manual registration; the pipeline does **not** need it as a GitHub
+   secret (it references the share by the registered env-storage name).
 
-4. **Record the names for the future CI wiring** as environment-scoped GitHub
-   config: variables `ETL_STORAGE_NAME` (the env storage name, e.g. `etl-staging`)
-   and `ETL_STORAGE_SHARE_NAME` (e.g. `etl-staging`), and — if the YAML deploy
-   authenticates with the key rather than the pre-registered env storage — secret
-   `ETL_STORAGE_ACCOUNT_KEY`.
+4. **Set the `ETL_STORAGE_NAME` environment variable** (GitHub Environment →
+   Variables) to the env-storage name from step 3, e.g. `etl-staging`. This is the
+   one piece of GitHub config the CI wiring consumes; the share name and account
+   key are used only during the manual registration above.
 
-The per-app **volume mount** (attaching the registered storage to a container at
-a path) can also be added in the Portal by editing the app and creating a new
-revision — but **do not rely on that for a stable setup**: our deploys run through
-`azure/container-apps-deploy-action@v1` (`az containerapp up`), which re-applies
-the container spec and will drop a hand-added mount on the next pipeline run. A
-Portal mount is fine for a one-off smoke test; for durability the mount must live
-in the deploy path (the YAML step in the follow-up task). Steps 1–3 above are
-safe to do in the Portal now because they persist independently of app deploys.
-
-Equivalent CLI, for reference (registration is the key step):
+Equivalent CLI for step 3, for reference:
 
 ```bash
 # staging values shown
@@ -279,6 +279,10 @@ named:
 * `GHCR_ETL_PULL_USERNAME` (example: `your-github-username`) — registry username
   for pulling the ETL images; not sensitive, so it is a variable. Only needed on
   `staging` / `dress-rehearsal`.
+* `ETL_STORAGE_NAME` (example: `etl-staging`) — the Azure Files env-storage name
+  registered on the Container Apps environment; mounted into both ETL apps at
+  `/mnt/data`. Only needed on `staging` / `dress-rehearsal` (see ETL durable
+  storage above).
 * `ETL_GEM_IMAGE_TAG` (example: `pr-9`) — optional; ETL GEM image tag to deploy,
   defaults to `pr-9`. Only used on `staging` / `dress-rehearsal`.
 * `ETL_WOODMAC_IMAGE_TAG` (example: `pr-9`) — optional; ETL WoodMac image tag to

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -92,7 +92,7 @@ account / share / environment-storage name:
 | Lane | Storage account | File share | Env storage name (`ETL_STORAGE_NAME`) |
 |---|---|---|---|
 | `staging` | `stitchstaging` | `etl-staging` | `etl-staging` |
-| `dress-rehearsal` | _(tbd)_ | _(tbd)_ | _(tbd)_ |
+| `dress-rehearsal` | `stitchstaging` | `etl-dress-rehearsal` | `etl-dress-rehearsal` |
 
 1. **Create a storage account + file share.** Create a Storage account (Standard
    LRS, StorageV2) or reuse one, then under **File shares** add a share (for

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -42,7 +42,7 @@ The `etl-gem` and `etl-woodmac` Container Apps are deployed from pre-built image
 published by the separate `stitch-etl-poc` repository
 (`ghcr.io/rmi/stitch-etl-poc-etl-{gem,woodmac}`). This pipeline does **not** build
 them; it only deploys the tag named by the `ETL_GEM_IMAGE_TAG` /
-`ETL_WOODMAC_IMAGE_TAG` variables (defaulting to `pr-9`).
+`ETL_WOODMAC_IMAGE_TAG` variables (defaulting to `main`).
 
 Seed and ETL are mutually exclusive per lane:
 
@@ -283,10 +283,10 @@ named:
   registered on the Container Apps environment; mounted into both ETL apps at
   `/mnt/data`. Only needed on `staging` / `dress-rehearsal` (see ETL durable
   storage above).
-* `ETL_GEM_IMAGE_TAG` (example: `pr-9`) — optional; ETL GEM image tag to deploy,
-  defaults to `pr-9`. Only used on `staging` / `dress-rehearsal`.
-* `ETL_WOODMAC_IMAGE_TAG` (example: `pr-9`) — optional; ETL WoodMac image tag to
-  deploy, defaults to `pr-9`. Only used on `staging` / `dress-rehearsal`.
+* `ETL_GEM_IMAGE_TAG` (example: `main`) — optional; ETL GEM image tag to deploy,
+  defaults to `main`. Only used on `staging` / `dress-rehearsal`.
+* `ETL_WOODMAC_IMAGE_TAG` (example: `main`) — optional; ETL WoodMac image tag to
+  deploy, defaults to `main`. Only used on `staging` / `dress-rehearsal`.
   * NOTE: `FRONTEND_PREVIEW_URL_TEMPLATE` must contain the literal `{name}` placeholder.
 For `dress-rehearsal`, the workflow uses `FRONTEND_PRODUCTION_URL` directly. For pull requests, it replaces `{name}` with the raw PR number so PR #106 resolves to `https://witty-mushroom-017a3dc1e-106.westus2.1.azurestaticapps.net`. For other preview deployments, it replaces `{name}` with `deployment_name`.
 

--- a/deployments/stitch-frontend/public/config.json
+++ b/deployments/stitch-frontend/public/config.json
@@ -3,6 +3,8 @@
   "apiUrl": "http://localhost:8000/api/v1",
   "entityLinkageUrl": "http://localhost:8001/api/v1",
   "stitchLlmUrl": "http://localhost:8002/api/v1",
+  "etlGemUrl": "http://localhost:8101/api/v1",
+  "etlWoodmacUrl": "http://localhost:8102/api/v1",
   "auth0Domain": "rmi-spd.us.auth0.com",
   "auth0ClientId": "TS1V1soQbccAV1sitFFCfUaIlSwHD2S2",
   "auth0Audience": "https://stitch-api.local"

--- a/deployments/stitch-frontend/src/App.jsx
+++ b/deployments/stitch-frontend/src/App.jsx
@@ -4,12 +4,14 @@ import HomePage from "./pages/HomePage";
 import ResourceDetailPage from "./pages/ResourceDetailPage";
 import EntityLinkagePage from "./pages/EntityLinkagePage";
 import MergeCandidateReviewPage from "./pages/MergeCandidateReviewPage";
+import EtlPage from "./pages/EtlPage";
 import { LogoutButton } from "./components/LogoutButton";
 
 const NAV_ITEMS = [
   { to: "/", label: "Resources", end: true },
   { to: "/entity-linkage", label: "Entity Linkage" },
   { to: "/merge-candidate-review", label: "Merge Review" },
+  { to: "/etl", label: "ETL Pipelines" },
 ];
 
 function getNavLinkClassName({ isActive }) {
@@ -68,6 +70,7 @@ function App() {
             path="/merge-candidate-review"
             element={<MergeCandidateReviewPage />}
           />
+          <Route path="/etl" element={<EtlPage />} />
         </Routes>
       </main>
     </div>

--- a/deployments/stitch-frontend/src/App.test.jsx
+++ b/deployments/stitch-frontend/src/App.test.jsx
@@ -52,6 +52,9 @@ describe("App", () => {
       "href",
       "/merge-candidate-review",
     );
+    expect(
+      screen.getByRole("link", { name: "ETL Pipelines" }),
+    ).toHaveAttribute("href", "/etl");
     expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
     expect(screen.getByRole("main")).toBeInTheDocument();
   });

--- a/deployments/stitch-frontend/src/App.test.jsx
+++ b/deployments/stitch-frontend/src/App.test.jsx
@@ -52,9 +52,10 @@ describe("App", () => {
       "href",
       "/merge-candidate-review",
     );
-    expect(
-      screen.getByRole("link", { name: "ETL Pipelines" }),
-    ).toHaveAttribute("href", "/etl");
+    expect(screen.getByRole("link", { name: "ETL Pipelines" })).toHaveAttribute(
+      "href",
+      "/etl",
+    );
     expect(screen.getByRole("button", { name: "Log out" })).toBeInTheDocument();
     expect(screen.getByRole("main")).toBeInTheDocument();
   });

--- a/deployments/stitch-frontend/src/config/env.js
+++ b/deployments/stitch-frontend/src/config/env.js
@@ -11,6 +11,8 @@ const OPTIONAL_STRING_CONFIG_KEYS = [
   "apiUrl",
   "entityLinkageUrl",
   "stitchLlmUrl",
+  "etlGemUrl",
+  "etlWoodmacUrl",
 ];
 
 const DEFAULT_CONFIG_PATH = "/config.json";
@@ -61,6 +63,9 @@ function freezeConfig(runtimeConfig) {
       runtimeConfig.entityLinkageUrl || "http://localhost:8001/api/v1",
     stitchLlmBaseUrl:
       runtimeConfig.stitchLlmUrl || "http://localhost:8002/api/v1",
+    etlGemBaseUrl: runtimeConfig.etlGemUrl || "http://localhost:8101/api/v1",
+    etlWoodmacBaseUrl:
+      runtimeConfig.etlWoodmacUrl || "http://localhost:8102/api/v1",
   });
 }
 

--- a/deployments/stitch-frontend/src/config/env.test.js
+++ b/deployments/stitch-frontend/src/config/env.test.js
@@ -21,6 +21,8 @@ describe("config/env", () => {
         apiUrl: "https://example.test/api/v1",
         entityLinkageUrl: "https://entity-linkage.test/api/v1",
         stitchLlmUrl: "https://stitch-llm.test/api/v1",
+        etlGemUrl: "https://etl-gem.test/api/v1",
+        etlWoodmacUrl: "https://etl-woodmac.test/api/v1",
         auth0Domain: "my.auth0.com",
         auth0ClientId: "my-client-id",
         auth0Audience: "https://my-api",
@@ -49,6 +51,8 @@ describe("config/env", () => {
       "https://entity-linkage.test/api/v1",
     );
     expect(config.stitchLlmBaseUrl).toBe("https://stitch-llm.test/api/v1");
+    expect(config.etlGemBaseUrl).toBe("https://etl-gem.test/api/v1");
+    expect(config.etlWoodmacBaseUrl).toBe("https://etl-woodmac.test/api/v1");
     expect(config.appEnv).toBe("test");
 
     expect(config.build.buildId).toBe("gha-123");
@@ -121,6 +125,8 @@ describe("config/env", () => {
         apiUrl: "",
         entityLinkageUrl: "",
         stitchLlmUrl: "",
+        etlGemUrl: "",
+        etlWoodmacUrl: "",
       }),
     });
 
@@ -130,6 +136,8 @@ describe("config/env", () => {
     expect(config.apiBaseUrl).toBe("http://localhost:8000/api/v1");
     expect(config.entityLinkageBaseUrl).toBe("http://localhost:8001/api/v1");
     expect(config.stitchLlmBaseUrl).toBe("http://localhost:8002/api/v1");
+    expect(config.etlGemBaseUrl).toBe("http://localhost:8101/api/v1");
+    expect(config.etlWoodmacBaseUrl).toBe("http://localhost:8102/api/v1");
   });
 
   it("throws when config fetch fails", async () => {

--- a/deployments/stitch-frontend/src/pages/EtlPage.jsx
+++ b/deployments/stitch-frontend/src/pages/EtlPage.jsx
@@ -76,7 +76,10 @@ async function parseJsonResponse(response) {
 function EtlPanel({ title, description, baseUrl, fields, getToken }) {
   const [values, setValues] = useState(() =>
     Object.fromEntries(
-      fields.map((field) => [field.key, field.type === "checkbox" ? false : ""]),
+      fields.map((field) => [
+        field.key,
+        field.type === "checkbox" ? false : "",
+      ]),
     ),
   );
   const [starting, setStarting] = useState(false);
@@ -236,7 +239,9 @@ function EtlPanel({ title, description, baseUrl, fields, getToken }) {
 
       {error ? (
         <div className="mt-4 rounded-md border border-danger/25 bg-danger-soft p-3 text-sm text-danger">
-          {error.message ? <p className="mb-2 font-medium">{error.message}</p> : null}
+          {error.message ? (
+            <p className="mb-2 font-medium">{error.message}</p>
+          ) : null}
           <StructuredDataView
             data={{ status: error.status, response: error.body }}
             label={`${title} error`}
@@ -250,7 +255,8 @@ function EtlPanel({ title, description, baseUrl, fields, getToken }) {
           <StructuredDataView data={record} label={`${title} run status`} />
         ) : (
           <p className="text-sm text-ink-muted">
-            No run started yet. Start a run or refresh to fetch the latest status.
+            No run started yet. Start a run or refresh to fetch the latest
+            status.
           </p>
         )}
       </div>
@@ -275,8 +281,8 @@ export default function EtlPage() {
         </p>
         <h1 className="mt-1 text-3xl font-semibold text-ink">ETL Pipelines</h1>
         <p className="mt-2 text-sm text-ink-muted">
-          Start an ETL run and check its status. Only one run per pipeline may be
-          active at a time.
+          Start an ETL run and check its status. Only one run per pipeline may
+          be active at a time.
         </p>
       </div>
 

--- a/deployments/stitch-frontend/src/pages/EtlPage.jsx
+++ b/deployments/stitch-frontend/src/pages/EtlPage.jsx
@@ -1,0 +1,301 @@
+import { useState } from "react";
+import { useAuth0 } from "@auth0/auth0-react";
+import { useConfig } from "../config/useConfig";
+import StructuredDataView from "../components/StructuredDataView";
+import Button from "../components/Button";
+import Input from "../components/Input";
+
+// Per-ETL run parameters. Empty number/text fields are omitted from the
+// request body so the service falls back to its env-derived defaults.
+const GEM_FIELDS = [
+  {
+    key: "payload_limit",
+    label: "Payload limit",
+    type: "number",
+    help: "Optional cap on payloads posted this run. Leave blank to post all.",
+  },
+  {
+    key: "gem_xlsx_sheet",
+    label: "GEM xlsx sheet",
+    type: "text",
+    placeholder: "Main data",
+    help: "Excel sheet name to load. Leave blank to use the configured default.",
+  },
+];
+
+const WOODMAC_FIELDS = [
+  {
+    key: "payload_limit",
+    label: "Payload limit",
+    type: "number",
+    help: "Optional cap on payloads posted this run. Leave blank to post all.",
+  },
+  {
+    key: "query_limit",
+    label: "Query limit",
+    type: "number",
+    help: "Optional cap on rows requested from the WoodMac query.",
+  },
+  {
+    key: "use_cached",
+    label: "Reuse cached WoodMac result (if within TTL)",
+    type: "checkbox",
+  },
+];
+
+const STATE_STYLES = {
+  running: "border-warning/30 bg-warning-soft text-warning",
+  succeeded: "border-success/25 bg-success-soft text-success-strong",
+  failed: "border-danger/25 bg-danger-soft text-danger",
+};
+
+function StateBadge({ state }) {
+  if (!state) return null;
+
+  const classes = STATE_STYLES[state] ?? "border-line bg-surface text-ink";
+
+  return (
+    <span
+      className={`rounded-full border px-2.5 py-1 text-xs font-semibold capitalize ${classes}`}
+    >
+      {state}
+    </span>
+  );
+}
+
+async function parseJsonResponse(response) {
+  const text = await response.text();
+
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return { raw: text };
+  }
+}
+
+function EtlPanel({ title, description, baseUrl, fields, getToken }) {
+  const [values, setValues] = useState(() =>
+    Object.fromEntries(
+      fields.map((field) => [field.key, field.type === "checkbox" ? false : ""]),
+    ),
+  );
+  const [starting, setStarting] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
+  const [record, setRecord] = useState(null);
+  const [error, setError] = useState(null);
+
+  function setField(key, value) {
+    setValues((prev) => ({ ...prev, [key]: value }));
+  }
+
+  function buildRequestBody() {
+    const body = {};
+
+    for (const field of fields) {
+      const value = values[field.key];
+
+      if (field.type === "checkbox") {
+        body[field.key] = Boolean(value);
+      } else if (value !== "" && value != null) {
+        body[field.key] = field.type === "number" ? Number(value) : value;
+      }
+    }
+
+    return body;
+  }
+
+  async function handleStart() {
+    setStarting(true);
+    setError(null);
+
+    try {
+      const token = await getToken();
+
+      const response = await fetch(`${baseUrl}/start`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify(buildRequestBody()),
+      });
+
+      const parsed = await parseJsonResponse(response);
+
+      if (response.status === 409) {
+        setError({
+          status: 409,
+          message: "A run is already in progress — refresh status to check.",
+          body: parsed,
+        });
+        return;
+      }
+
+      if (!response.ok) {
+        setError({ status: response.status, body: parsed });
+        return;
+      }
+
+      setRecord(parsed);
+    } catch (err) {
+      setError({
+        status: null,
+        body: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setStarting(false);
+    }
+  }
+
+  async function handleRefresh() {
+    setRefreshing(true);
+    setError(null);
+
+    try {
+      // GET /status is unauthenticated per the ETL OpenAPI spec.
+      const response = await fetch(`${baseUrl}/status`);
+      const parsed = await parseJsonResponse(response);
+
+      if (!response.ok) {
+        setError({ status: response.status, body: parsed });
+        return;
+      }
+
+      setRecord(parsed);
+    } catch (err) {
+      setError({
+        status: null,
+        body: err instanceof Error ? err.message : String(err),
+      });
+    } finally {
+      setRefreshing(false);
+    }
+  }
+
+  const isRunning = record?.state === "running";
+
+  return (
+    <section className="rounded-md border border-line bg-panel p-4">
+      <div className="flex flex-wrap items-baseline justify-between gap-2">
+        <h2 className="text-lg font-semibold text-ink">{title}</h2>
+        <StateBadge state={record?.state} />
+      </div>
+      <p className="mt-1 text-sm text-ink-muted">{description}</p>
+
+      <div className="mt-4 space-y-4">
+        {fields.map((field) =>
+          field.type === "checkbox" ? (
+            <div key={field.key}>
+              <label className="flex items-center gap-3 text-sm font-medium text-ink">
+                <input
+                  type="checkbox"
+                  checked={values[field.key]}
+                  onChange={(e) => setField(field.key, e.target.checked)}
+                  className="accent-primary"
+                />
+                <span>{field.label}</span>
+              </label>
+            </div>
+          ) : (
+            <div key={field.key}>
+              <label className="block text-sm font-medium text-ink">
+                <span className="mb-1 block">{field.label}</span>
+                <Input
+                  type={field.type}
+                  value={values[field.key]}
+                  onChange={(e) => setField(field.key, e.target.value)}
+                  placeholder={field.placeholder}
+                  min={field.type === "number" ? 1 : undefined}
+                  className="w-full"
+                />
+              </label>
+              {field.help ? (
+                <p className="mt-1 text-xs text-ink-muted">{field.help}</p>
+              ) : null}
+            </div>
+          ),
+        )}
+      </div>
+
+      <div className="mt-4 flex flex-wrap gap-2">
+        <Button
+          onClick={handleStart}
+          disabled={starting || isRunning}
+          variant="primary"
+        >
+          {starting ? "Starting…" : "Start run"}
+        </Button>
+        <Button
+          onClick={handleRefresh}
+          disabled={refreshing}
+          variant="secondary"
+        >
+          {refreshing ? "Refreshing…" : "Refresh status"}
+        </Button>
+      </div>
+
+      {error ? (
+        <div className="mt-4 rounded-md border border-danger/25 bg-danger-soft p-3 text-sm text-danger">
+          {error.message ? <p className="mb-2 font-medium">{error.message}</p> : null}
+          <StructuredDataView
+            data={{ status: error.status, response: error.body }}
+            label={`${title} error`}
+          />
+        </div>
+      ) : null}
+
+      <div className="mt-4 border-t border-line pt-4">
+        <h3 className="mb-2 text-sm font-semibold text-ink">Run status</h3>
+        {record ? (
+          <StructuredDataView data={record} label={`${title} run status`} />
+        ) : (
+          <p className="text-sm text-ink-muted">
+            No run started yet. Start a run or refresh to fetch the latest status.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}
+
+export default function EtlPage() {
+  const config = useConfig();
+  const { getAccessTokenSilently } = useAuth0();
+
+  const getToken = () =>
+    getAccessTokenSilently({
+      authorizationParams: { audience: config.auth0.audience },
+    });
+
+  return (
+    <div className="mx-auto max-w-6xl">
+      <div className="mb-6">
+        <p className="text-xs font-semibold uppercase tracking-wide text-primary">
+          Batch workflow
+        </p>
+        <h1 className="mt-1 text-3xl font-semibold text-ink">ETL Pipelines</h1>
+        <p className="mt-2 text-sm text-ink-muted">
+          Start an ETL run and check its status. Only one run per pipeline may be
+          active at a time.
+        </p>
+      </div>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <EtlPanel
+          title="GEM"
+          description="Load GEM oil & gas data from the configured spreadsheet and post it to Stitch."
+          baseUrl={config.etlGemBaseUrl}
+          fields={GEM_FIELDS}
+          getToken={getToken}
+        />
+        <EtlPanel
+          title="WoodMac"
+          description="Fetch WoodMac query results and post them to Stitch."
+          baseUrl={config.etlWoodmacBaseUrl}
+          fields={WOODMAC_FIELDS}
+          getToken={getToken}
+        />
+      </div>
+    </div>
+  );
+}

--- a/deployments/stitch-frontend/src/pages/EtlPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/EtlPage.test.jsx
@@ -27,9 +27,9 @@ describe("EtlPage", () => {
     expect(
       screen.getByRole("heading", { name: "WoodMac" }),
     ).toBeInTheDocument();
-    expect(
-      screen.getAllByRole("button", { name: "Start run" }),
-    ).toHaveLength(2);
+    expect(screen.getAllByRole("button", { name: "Start run" })).toHaveLength(
+      2,
+    );
     expect(
       screen.getAllByRole("button", { name: "Refresh status" }),
     ).toHaveLength(2);
@@ -56,9 +56,9 @@ describe("EtlPage", () => {
     );
 
     await waitFor(() => {
-      expect(
-        within(gemPanel).getAllByText("running").length,
-      ).toBeGreaterThan(0);
+      expect(within(gemPanel).getAllByText("running").length).toBeGreaterThan(
+        0,
+      );
     });
 
     expect(getAccessTokenSilently).toHaveBeenCalledWith({

--- a/deployments/stitch-frontend/src/pages/EtlPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/EtlPage.test.jsx
@@ -1,0 +1,132 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { useAuth0 } from "@auth0/auth0-react";
+import EtlPage from "./EtlPage";
+import { auth0TestDefaults, renderWithQueryClient } from "../test/utils";
+
+function getPanel(title) {
+  return screen.getByRole("heading", { name: title }).closest("section");
+}
+
+describe("EtlPage", () => {
+  let getAccessTokenSilently;
+
+  beforeEach(() => {
+    getAccessTokenSilently = vi.fn().mockResolvedValue("test-access-token");
+    vi.mocked(useAuth0).mockReturnValue({
+      ...auth0TestDefaults,
+      getAccessTokenSilently,
+    });
+  });
+
+  it("renders a panel for each ETL pipeline", () => {
+    renderWithQueryClient(<EtlPage />);
+
+    expect(screen.getByRole("heading", { name: "GEM" })).toBeInTheDocument();
+    expect(
+      screen.getByRole("heading", { name: "WoodMac" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getAllByRole("button", { name: "Start run" }),
+    ).toHaveLength(2);
+    expect(
+      screen.getAllByRole("button", { name: "Refresh status" }),
+    ).toHaveLength(2);
+  });
+
+  it("starts a GEM run with an authenticated token and shows the returned state", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 202,
+      text: async () =>
+        JSON.stringify({
+          job_id: "job-123",
+          state: "running",
+          started_at: "2026-06-11T10:00:00Z",
+          initiated_by: "Test User",
+        }),
+    });
+
+    renderWithQueryClient(<EtlPage />);
+
+    const gemPanel = getPanel("GEM");
+    await userEvent.click(
+      within(gemPanel).getByRole("button", { name: "Start run" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        within(gemPanel).getAllByText("running").length,
+      ).toBeGreaterThan(0);
+    });
+
+    expect(getAccessTokenSilently).toHaveBeenCalledWith({
+      authorizationParams: { audience: "https://stitch-api.local" },
+    });
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8101/api/v1/start",
+      expect.objectContaining({
+        method: "POST",
+        headers: expect.objectContaining({
+          Authorization: "Bearer test-access-token",
+        }),
+      }),
+    );
+  });
+
+  it("surfaces a friendly message when a run is already in progress (409)", async () => {
+    vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: false,
+      status: 409,
+      text: async () => JSON.stringify({ detail: "A run is already active" }),
+    });
+
+    renderWithQueryClient(<EtlPage />);
+
+    const woodmacPanel = getPanel("WoodMac");
+    await userEvent.click(
+      within(woodmacPanel).getByRole("button", { name: "Start run" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        within(woodmacPanel).getByText(
+          "A run is already in progress — refresh status to check.",
+        ),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it("refreshes status via an unauthenticated GET", async () => {
+    const fetchMock = vi.spyOn(globalThis, "fetch").mockResolvedValue({
+      ok: true,
+      status: 200,
+      text: async () =>
+        JSON.stringify({
+          job_id: "job-789",
+          state: "succeeded",
+          started_at: "2026-06-11T10:00:00Z",
+          finished_at: "2026-06-11T10:05:00Z",
+          result: { payloads_posted: 42 },
+        }),
+    });
+
+    renderWithQueryClient(<EtlPage />);
+
+    const woodmacPanel = getPanel("WoodMac");
+    await userEvent.click(
+      within(woodmacPanel).getByRole("button", { name: "Refresh status" }),
+    );
+
+    await waitFor(() => {
+      expect(
+        within(woodmacPanel).getAllByText("succeeded").length,
+      ).toBeGreaterThan(0);
+    });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost:8102/api/v1/status",
+    );
+  });
+});

--- a/deployments/stitch-frontend/src/test/setup.js
+++ b/deployments/stitch-frontend/src/test/setup.js
@@ -10,6 +10,8 @@ const TEST_CONFIG = {
   apiBaseUrl: "http://localhost:8000/api/v1",
   entityLinkageBaseUrl: "http://localhost:8001/api/v1",
   stitchLlmBaseUrl: "http://localhost:8002/api/v1",
+  etlGemBaseUrl: "http://localhost:8101/api/v1",
+  etlWoodmacBaseUrl: "http://localhost:8102/api/v1",
   auth0: {
     domain: "example.auth0.com",
     clientId: "client-id",


### PR DESCRIPTION
Add frontend for invoking ETL pipelines, and add deploy mechanisms to CICD pipeline.

Tested as: https://github.com/RMI/stitch/pull/130

Deploys `etl-gem` and `etl-woodmac` services on deployments to `staging` and `dress-rehearsal`, instead of the `seed` job. These are long-standing services (fastAPI wrapper around a terminating job) introduced in https://github.com/RMI/stitch-etl-poc/pull/9.

Adds UI to frontend to make initiating and observing ETL jobs a bit friendlier than through OpenAPI docs.

Other CD workflow changes include 
* arguments to control number of replicas (at deploy time) which offers control over the "hibernation" behavior we have in dev (and disable it in prod/staging).
* Ability to pull from private GH repos packages (with new PAT)
* Attaching Storage to container apps (requires setup in Azure)

Operational changes on the Azure side are documented in CI_DEPLOYMENTS.md