### PR TITLE
Feat/observability

### DIFF
--- a/deployments/PERFORMANCE.md
+++ b/deployments/PERFORMANCE.md
@@ -163,7 +163,9 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml \
 
 Useful flags: `--top N`, `--width N` (statement column),
 `--sort {total,count,p95,max,mean,queries}` (`queries` = avg DB queries per
-request, for hunting N+1), `--queries-only`, `--routes-only`.
+request, for hunting N+1), `--queries-only`, `--routes-only`,
+`--group-by scenario` (compare tagged variants — see
+[Comparing variants](#comparing-variants-data-volume--params)), `--baseline`.
 
 Example output:
 
@@ -193,6 +195,111 @@ ROUTES — top 3 by total
   firing 15 queries per request is doing per-row lookups; the `⚠ N+1?` flag marks
   ≥ 10. Cross-reference with the query stream to see which statement repeats.
 - **`errs`** counts 5xx responses per route.
+
+---
+
+## Comparing variants (data volume / params)
+
+To see how the *same* query behaves under different conditions, **tag each batch
+of traffic** with an `X-Perf-Scenario: <label>` request header. The label is
+recorded on every request *and* query event it triggers, so a single log
+captures all variants and the analyzer compares them with `--group-by scenario`.
+No log slicing, no separate files.
+
+Make sure `LOG_ALL_QUERIES=true` is set in `.env` first (Step 1) so query events
+are recorded. Define a shorthand for the compose command:
+
+```bash
+COMPOSE="docker compose -f docker-compose.yml -f docker-compose.local.yml"
+```
+
+### Variant by data volume (re-seed between runs)
+
+The seed volume is controlled from `.env` via `SEED_FAKER_POST_COUNT` (the
+`seed` service reads it; default 5). Re-running the seed service **adds** more
+rows, so you can build up a volume ladder on a live stack.
+
+1. **Start the stack at the first volume.** Set `SEED_FAKER_POST_COUNT=1000` in
+   `.env`, then bring it up — the `full` profile seeds automatically:
+
+   ```bash
+   make reboot-docker        # (foreground; or `$COMPOSE --profile full up -d`)
+   ```
+
+2. **Drive load, tagging it with the volume label:**
+
+   ```bash
+   for i in $(seq 200); do
+     curl -s -o /dev/null -H 'X-Perf-Scenario: vol=1k' \
+       "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=50"
+   done
+   ```
+
+3. **Re-seed to a larger volume.** Bump `SEED_FAKER_POST_COUNT` (e.g. to
+   `50000`) in `.env`, then re-run *only* the seed service against the running
+   stack:
+
+   ```bash
+   $COMPOSE --profile seed up seed --build
+   ```
+
+4. **Drive load again with a new label:**
+
+   ```bash
+   for i in $(seq 200); do
+     curl -s -o /dev/null -H 'X-Perf-Scenario: vol=50k' \
+       "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=50"
+   done
+   ```
+
+5. **Dump the log once and compare** — both variants are in the same stream:
+
+   ```bash
+   $COMPOSE logs --no-log-prefix api > /tmp/perf.log
+   python3 tools/analyze_logs.py /tmp/perf.log --group-by scenario
+   ```
+
+   ```
+   QUERIES by scenario — top 1 (baseline = fastest variant)
+
+   SELECT r.id, max(case when p.priority=? then s.name end) FROM resources r ...
+     scenario                   count     mean      p95   total_ms   vs base
+     vol=1k                       150     43.9     53.9     6582.0    1.00×  ← base
+     vol=50k                      150    394.3    453.7    59147.5    8.99×
+   ```
+
+   A statement whose `vs base` ratio climbs steeply with volume is the one that
+   scales badly — your culprit. By default the fastest variant is the baseline;
+   pin a specific one with `--baseline vol=1k`.
+
+> Re-seeding is **cumulative** (volume keeps growing), which is what you want for
+> a volume ladder. For *independent*, repeatable volumes, set
+> `SEED_FAKER_POST_COUNT` and run `make reboot-docker` before each labelled run —
+> it wipes the DB so the volumes don't stack.
+
+### Variant by query params
+
+Keep the data volume fixed and vary the request between batches, giving each its
+own label — the param values are a natural label:
+
+```bash
+for ps in 50 500; do
+  for i in $(seq 200); do
+    curl -s -o /dev/null -H "X-Perf-Scenario: page_size=$ps" \
+      "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=$ps"
+  done
+done
+$COMPOSE logs --no-log-prefix api > /tmp/perf.log
+python3 tools/analyze_logs.py /tmp/perf.log --group-by scenario
+```
+
+The `--group-by scenario` view breaks each query/route down by label, so
+`page_size=50` and `page_size=500` sit side by side even though they hit the
+same route template.
+
+> The `X-Perf-Scenario` label is opaque to the server (truncated to 80 chars)
+> and recorded only when sent, so it's safe to leave the feature in place — it
+> costs nothing on untagged production traffic.
 
 ---
 

--- a/deployments/PERFORMANCE.md
+++ b/deployments/PERFORMANCE.md
@@ -39,7 +39,7 @@ Configured via env vars (read by [`settings.py`](api/src/stitch/api/settings.py)
 | `LOG_ALL_QUERIES` | `false` | `true` logs **every** query — use for local profiling |
 | `SLOW_QUERY_MS` | `200` | log only queries at/above this many ms — use in prod |
 | `LOG_FORMAT` | `json` | `json` (structured) or `plain` |
-| `API_LOG_LEVEL` | `info` | events log at INFO; this already shows them |
+| `LOG_LEVEL` | `INFO` | events log at INFO, so the default already shows them |
 
 The request stream is always on. The query stream is gated: by default you only
 see queries ≥ 200 ms. For local profiling you usually want **everything**.
@@ -63,9 +63,12 @@ SLOW_QUERY_MS=0
 
 then `make reboot-docker` as usual.
 
-> ⚠️ `LOG_LEVEL` is **not** read from `.env` for the compose `api` service — the
-> `environment:` block hard-sets it from `API_LOG_LEVEL`. Use `API_LOG_LEVEL` to
-> change the level. `LOG_ALL_QUERIES` / `SLOW_QUERY_MS` pass through `.env` fine.
+> ⚠️ The settings model reads **`LOG_LEVEL`** (that's the variable to set for
+> non-docker runs like `make api-dev`). Under docker-compose, though, the `api`
+> service's `environment:` block hard-sets `LOG_LEVEL` from `API_LOG_LEVEL`, so
+> for `make reboot-docker` set **`API_LOG_LEVEL`** in `.env` (a plain `LOG_LEVEL`
+> there is ignored). `LOG_ALL_QUERIES` / `SLOW_QUERY_MS` pass through `.env` fine
+> either way.
 
 ### Deployed (Azure Container Apps)
 
@@ -78,8 +81,10 @@ start — only genuinely slow queries are recorded, keeping log volume sane).
 
 Make sure the DB has realistic row counts first. The `full` profile (used by
 `make reboot-docker` and `make dev-docker`) includes the `seed` service, so a
-fresh stack is already seeded; tune volume with `FAKER_POST_COUNT` in `.env`
-(see [`deployments/seed`](seed)). To re-seed an existing stack:
+fresh stack is already seeded; tune volume by setting `SEED_FAKER_POST_COUNT` in
+`.env` (compose maps it to the seed service's `FAKER_POST_COUNT` — a bare
+`FAKER_POST_COUNT` in `.env` is ignored; see [`deployments/seed`](seed)). To
+re-seed an existing stack:
 
 ```bash
 docker compose -f docker-compose.yml -f docker-compose.local.yml \

--- a/deployments/PERFORMANCE.md
+++ b/deployments/PERFORMANCE.md
@@ -1,0 +1,224 @@
+# Performance testing & query profiling
+
+Stitch's API is instrumented to record **what database queries run, how long
+they take, and which endpoint triggered them**. The data is emitted as
+structured JSON to stdout — captured by Azure Container Apps → Log Analytics in
+the cloud, and readable straight from the terminal locally — so you can find
+slow/frequent queries from real data instead of guessing.
+
+This doc covers the basic loop: **enable capture → drive traffic → analyze**.
+
+> The instrumentation lives in the app code
+> ([`deployments/api/src/stitch/api/observability/`](api/src/stitch/api/observability/)),
+> so it works under any entrypoint that runs the API (`make api-dev`,
+> `make reboot-docker`, or the deployed container) — only *how you configure and
+> collect it* differs.
+
+---
+
+## What gets captured
+
+Two structured log streams, distinguished by the `logger` field:
+
+| Logger | Emitted | Key fields |
+|---|---|---|
+| `stitch.api.observability.request` | once per HTTP request (always) | `route`, `method`, `status_code`, `duration_ms`, `db_query_count`, `db_time_ms`, `request_id` |
+| `stitch.api.observability.query` | once per query above the slow threshold | `statement` (parameterized SQL, **no bound values**), `duration_ms`, `rowcount`, `route`, `request_id` |
+
+`db_query_count` on a request is the N+1 detector; the `query` stream tells you
+*which* statement is expensive.
+
+---
+
+## Step 1 — Enable capture (the knobs)
+
+Configured via env vars (read by [`settings.py`](api/src/stitch/api/settings.py)):
+
+| Env var | Default | Use |
+|---|---|---|
+| `LOG_ALL_QUERIES` | `false` | `true` logs **every** query — use for local profiling |
+| `SLOW_QUERY_MS` | `200` | log only queries at/above this many ms — use in prod |
+| `LOG_FORMAT` | `json` | `json` (structured) or `plain` |
+| `API_LOG_LEVEL` | `info` | events log at INFO; this already shows them |
+
+The request stream is always on. The query stream is gated: by default you only
+see queries ≥ 200 ms. For local profiling you usually want **everything**.
+
+### `make api-dev`
+
+Inline:
+
+```bash
+LOG_ALL_QUERIES=true make api-dev
+```
+
+### `make reboot-docker` (full docker-compose stack)
+
+The `api` service reads `.env`, so add to your `.env`:
+
+```bash
+LOG_ALL_QUERIES=true
+SLOW_QUERY_MS=0
+```
+
+then `make reboot-docker` as usual.
+
+> ⚠️ `LOG_LEVEL` is **not** read from `.env` for the compose `api` service — the
+> `environment:` block hard-sets it from `API_LOG_LEVEL`. Use `API_LOG_LEVEL` to
+> change the level. `LOG_ALL_QUERIES` / `SLOW_QUERY_MS` pass through `.env` fine.
+
+### Deployed (Azure Container Apps)
+
+Leave `LOG_ALL_QUERIES=false` and set `SLOW_QUERY_MS` per lane (200 is a sane
+start — only genuinely slow queries are recorded, keeping log volume sane).
+
+---
+
+## Step 2 — Drive traffic
+
+Make sure the DB has realistic row counts first. The `full` profile (used by
+`make reboot-docker` and `make dev-docker`) includes the `seed` service, so a
+fresh stack is already seeded; tune volume with `FAKER_POST_COUNT` in `.env`
+(see [`deployments/seed`](seed)). To re-seed an existing stack:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml \
+  --profile seed up seed --build
+```
+
+Then generate load against the endpoint you suspect. Dev lanes run with auth
+disabled, so plain `curl` works. A simple repeat loop is enough to surface a hot
+query:
+
+```bash
+# hammer the list endpoint 200x
+for i in $(seq 200); do
+  curl -s -o /dev/null "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=50"
+done
+```
+
+For concurrency/throughput numbers, use a load tool if you have one installed
+(`hey`, `wrk`, `ab`):
+
+```bash
+hey -n 500 -c 20 "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=50"
+```
+
+The instrumentation records every request regardless of how it's generated.
+
+---
+
+## Step 3 — Capture the logs to a file
+
+### Local (`make api-dev`)
+
+```bash
+LOG_ALL_QUERIES=true make api-dev 2>&1 \
+  | tee /tmp/stitch-raw.log \
+  | jq -Rc 'fromjson? | select(.logger | test("observability"))' \
+  > /tmp/stitch-events.jsonl
+```
+
+### Local (docker-compose)
+
+Run the stack in one terminal; collect `api` logs in another:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml \
+  logs --no-log-prefix api > /tmp/stitch-api.log
+```
+
+(`--no-log-prefix` keeps lines as pure JSON. The analyzer in the next step also
+strips the `api-1 | ` prefix and skips non-JSON lines, so a raw capture is fine.)
+
+### Deployed (Log Analytics via `az`)
+
+```bash
+az monitor log-analytics query \
+  -w <LOG_ANALYTICS_WORKSPACE_ID> \
+  --analytics-query '
+    ContainerAppConsoleLogs_CL
+    | where ContainerName_s == "api"
+    | where TimeGenerated > ago(1h)
+    | extend p = parse_json(Log_s)
+    | where tostring(p.logger) startswith "stitch.api.observability"
+    | project line = Log_s' \
+  -o tsv > /tmp/prod-events.jsonl
+```
+
+---
+
+## Step 4 — Analyze
+
+[`tools/analyze_logs.py`](../tools/analyze_logs.py) (stdlib only — runs with
+plain `python3`) ranks queries and routes from any dump:
+
+```bash
+python3 tools/analyze_logs.py /tmp/stitch-events.jsonl
+
+# or stream straight from docker
+docker compose -f docker-compose.yml -f docker-compose.local.yml \
+  logs --no-log-prefix api | python3 tools/analyze_logs.py -
+```
+
+Useful flags: `--top N`, `--width N` (statement column),
+`--sort {total,count,p95,max,mean,queries}` (`queries` = avg DB queries per
+request, for hunting N+1), `--queries-only`, `--routes-only`.
+
+Example output:
+
+```
+QUERIES — top 3 by total
+  count    total_ms     mean      p95      max  share                     statement
+    120     36276.2    302.3    405.4    418.2  ████████████████████████  SELECT r.id, max(case when p.priority=? ...
+    120       641.4      5.3      8.7      8.9  ························  SELECT count(*) FROM resources
+    300       348.3      1.2      1.9      2.0  ························  SELECT * FROM oil_gas_field_sources WHERE pk = ?
+
+ROUTES — top 3 by total
+  reqs  mean_ms   p95_ms   max_ms  avg_q  max_q  errs  route
+   125    396.3    489.9   1433.8    3.0      3     5  /api/v1/oil-gas-fields/
+    60    103.6    156.9    159.4   14.9     18     0  /api/v1/oil-gas-fields/{id}  ⚠ N+1?
+```
+
+### How to read it
+
+- **`QUERIES` sorted by `total_ms`** = cumulative cost (`mean × count`). The top
+  row is the single best optimization target — slow *and* frequent. The `share`
+  bar shows how dominant it is.
+- **High `count`, low `mean`** = a cheap query run too often (caching / batching
+  opportunity) rather than a slow query.
+- **`p95` ≫ `mean`** = inconsistent latency (lock contention, cold cache, a bad
+  plan for some inputs).
+- **`ROUTES` `avg_q` (avg queries/request)** = N+1 smell. A detail endpoint
+  firing 15 queries per request is doing per-row lookups; the `⚠ N+1?` flag marks
+  ≥ 10. Cross-reference with the query stream to see which statement repeats.
+- **`errs`** counts 5xx responses per route.
+
+---
+
+## Interpreting → acting
+
+1. Find the top query by `total_ms`.
+2. Confirm its plan in Postgres: `EXPLAIN (ANALYZE, BUFFERS) <statement>`.
+3. Typical fixes: add/adjust an index, eliminate an N+1 (eager-load with
+   `selectinload`), avoid rebuilding an expensive CTE per request, or cache.
+4. Re-run the same load and diff the `total_ms` ranking to confirm the win.
+
+The suspected hot path today is the licensed-resource CTE built per request in
+[`og_field_resource_actions.py`](api/src/stitch/api/db/og_field_resource_actions.py)
+behind `GET /api/v1/oil-gas-fields/`. Let the data confirm it before optimizing.
+
+---
+
+## Notes
+
+- **Query logs are self-limiting in prod** via `SLOW_QUERY_MS`; the per-request
+  summary logs on every request (one line each). If that's too chatty at scale,
+  raise the threshold or add sampling.
+- **No PII in logs** — only parameterized statement text is recorded, never
+  bound parameter values.
+- **Future / OpenTelemetry**: all emission flows through one seam
+  ([`observability/sinks.py`](api/src/stitch/api/observability/sinks.py)). When
+  richer analysis is worth it, the Azure Monitor OpenTelemetry distro can emit
+  spans (per-query dependency waterfalls, percentiles) from the same timing data
+  without reworking the instrumentation. Deliberately not enabled yet.

--- a/deployments/PERFORMANCE.md
+++ b/deployments/PERFORMANCE.md
@@ -86,22 +86,54 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml \
   --profile seed up seed --build
 ```
 
-Then generate load against the endpoint you suspect. Dev lanes run with auth
-disabled, so plain `curl` works. A simple repeat loop is enough to surface a hot
-query:
+> **Auth matters here.** Protected endpoints return **401 before the handler
+> runs**, so unauthenticated requests do *zero* DB work — you'll see requests
+> logged with `db_query_count: 0` and a high `err%`, and no query events. If your
+> query report comes back empty or routes show `err%` near 100%, this is almost
+> certainly why. Two ways to make load actually hit the DB:
+>
+> - **Disable auth (simplest, dev only):** set `AUTH_DISABLED=true` in `.env`
+>   (allowed when `ENVIRONMENT` is `dev`/`main`/`dev-*`/`pr-*`) and restart the
+>   stack — requests then run as a dev user.
+> - **Send a token:** reuse the privileged bearer token the `seed` service
+>   already authenticates with, read straight from `.env` (see the loop below).
+
+Then generate load against the endpoint you suspect. Pull the token from `.env`
+(without printing it), confirm one request is accepted, then hammer the endpoint:
 
 ```bash
-# hammer the list endpoint 200x
+# Extract the token: everything after the '=', minus quotes / CR.
+# (Add a single-quote to the tr set if your value is single-quoted.)
+TOKEN=$(sed -n 's/^STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN=//p' .env | tr -d '"\r')
+
+# Sanity check — expect 200, not 401:
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -H "Authorization: Bearer $TOKEN" \
+  "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=1"
+
+# Hammer the list endpoint 200x, tagged for comparison:
 for i in $(seq 200); do
-  curl -s -o /dev/null "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=50"
+  curl -s -o /dev/null \
+    -H "Authorization: Bearer $TOKEN" \
+    -H 'X-Perf-Scenario: vol=8k' \
+    "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=50"
 done
 ```
 
+> Don't `echo "$TOKEN"` — keep the secret out of your shell history. If the
+> sanity check still returns `401`, the running API validates against a
+> different token than what's in `.env` (a quick tell is whether the `seed`
+> service itself succeeds, since it uses the same one). If auth is disabled
+> instead, drop the `Authorization` header — the `TOKEN` line is then unneeded.
+
 For concurrency/throughput numbers, use a load tool if you have one installed
-(`hey`, `wrk`, `ab`):
+(`hey`, `wrk`, `ab`) — pass the same auth header (and scenario label):
 
 ```bash
-hey -n 500 -c 20 "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=50"
+hey -n 500 -c 20 \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "X-Perf-Scenario: vol=8k" \
+  "http://localhost:8000/api/v1/oil-gas-fields/?page=1&page_size=50"
 ```
 
 The instrumentation records every request regardless of how it's generated.
@@ -177,9 +209,9 @@ QUERIES — top 3 by total
     300       348.3      1.2      1.9      2.0  ························  SELECT * FROM oil_gas_field_sources WHERE pk = ?
 
 ROUTES — top 3 by total
-  reqs  mean_ms   p95_ms   max_ms  avg_q  max_q  errs  route
-   125    396.3    489.9   1433.8    3.0      3     5  /api/v1/oil-gas-fields/
-    60    103.6    156.9    159.4   14.9     18     0  /api/v1/oil-gas-fields/{id}  ⚠ N+1?
+  reqs  mean_ms   p95_ms   max_ms  avg_q  max_q   err%  route
+   125    396.3    489.9   1433.8    3.0      3   4.0%  /api/v1/oil-gas-fields/
+    60    103.6    156.9    159.4   14.9     18   0.0%  /api/v1/oil-gas-fields/{id}  ⚠ N+1?
 ```
 
 ### How to read it
@@ -194,7 +226,10 @@ ROUTES — top 3 by total
 - **`ROUTES` `avg_q` (avg queries/request)** = N+1 smell. A detail endpoint
   firing 15 queries per request is doing per-row lookups; the `⚠ N+1?` flag marks
   ≥ 10. Cross-reference with the query stream to see which statement repeats.
-- **`errs`** counts 5xx responses per route.
+- **`err%`** = share of requests with status ≥ 400 (includes **401/403** auth
+  failures, not just 5xx). A route at ~100% `err%` with `avg_q` 0 means the
+  requests are being rejected before any DB work — usually unauthenticated load
+  (see the auth note in Step 2).
 
 ---
 

--- a/deployments/PERFORMANCE.md
+++ b/deployments/PERFORMANCE.md
@@ -163,6 +163,29 @@ docker compose -f docker-compose.yml -f docker-compose.local.yml \
 (`--no-log-prefix` keeps lines as pure JSON. The analyzer in the next step also
 strips the `api-1 | ` prefix and skips non-JSON lines, so a raw capture is fine.)
 
+This one-shot dump reads whatever the container still has on disk — fine for
+modest runs. It does **not** time out, but two things can make earlier events
+disappear before you capture them:
+
+- **Container recreation.** `make reboot-docker` (via `clean-docker`) and
+  `docker compose down` discard the container's logs entirely. A plain
+  stop/start keeps them.
+- **Log rotation.** *Only* if the `json-file`/`local` driver has `max-size` /
+  `max-file` set (it isn't by default, so logs grow unbounded). If a cap is
+  configured, the oldest lines silently roll off once it's hit. Check with:
+  `docker compose ... ps -q api` →
+  `docker inspect <id> --format '{{json .HostConfig.LogConfig}}'`.
+
+**For large or long runs, capture the live stream instead** — start this
+*before* driving load and Ctrl-C when done. `-f` follows; `tee -a` writes to disk
+as events arrive, so nothing depends on container retention and it survives a
+later `reboot-docker`:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.local.yml \
+  logs -f --no-log-prefix api | tee -a /tmp/stitch-api.log
+```
+
 ### Deployed (Log Analytics via `az`)
 
 ```bash

--- a/deployments/api/src/stitch/api/db/config.py
+++ b/deployments/api/src/stitch/api/db/config.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import (
     create_async_engine,
 )
 
+from stitch.api.observability import register_query_timing
 from stitch.api.settings import get_settings
 
 
@@ -47,11 +48,17 @@ class UnitOfWork:
 @lru_cache
 def get_engine() -> AsyncEngine:
     settings = get_settings()
-    return create_async_engine(
+    engine = create_async_engine(
         settings.get_database_url(),
         echo=not settings.is_prod,
         pool_pre_ping=True,
     )
+    register_query_timing(
+        engine.sync_engine,
+        slow_query_ms=settings.slow_query_ms,
+        log_all_queries=settings.log_all_queries,
+    )
+    return engine
 
 
 @lru_cache

--- a/deployments/api/src/stitch/api/main.py
+++ b/deployments/api/src/stitch/api/main.py
@@ -8,6 +8,7 @@ from starlette.status import HTTP_503_SERVICE_UNAVAILABLE
 from .middleware import register_middlewares
 from .db.config import dispose_engine
 from .auth import validate_auth_config_at_startup
+from .observability import configure_logging
 from .settings import get_settings
 
 from .routers.auth import router as auth_router
@@ -32,9 +33,11 @@ async def lifespan(app: FastAPI):
     await dispose_engine()
 
 
-app = FastAPI(lifespan=lifespan)
-
 settings = get_settings()
+
+configure_logging(level=settings.log_level, log_format=settings.log_format)
+
+app = FastAPI(lifespan=lifespan)
 
 register_middlewares(application=app, settings=settings)
 

--- a/deployments/api/src/stitch/api/middleware.py
+++ b/deployments/api/src/stitch/api/middleware.py
@@ -1,6 +1,7 @@
 from typing import Final
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
+from stitch.api.observability import RequestTimingMiddleware
 from stitch.api.settings import Settings
 
 ALLOWED_METHODS: Final[tuple[str, ...]] = (
@@ -27,3 +28,6 @@ def register_middlewares(application: FastAPI, settings: Settings):
         allow_methods=ALLOWED_METHODS,
         allow_headers=ALLOWED_HEADERS,
     )
+    # Added last so it is the outermost middleware and times the full request,
+    # including time spent in CORS handling.
+    application.add_middleware(RequestTimingMiddleware)

--- a/deployments/api/src/stitch/api/observability/__init__.py
+++ b/deployments/api/src/stitch/api/observability/__init__.py
@@ -1,0 +1,21 @@
+"""Lightweight performance instrumentation for the Stitch API.
+
+Captures per-query and per-request timing and emits it as structured logs to
+stdout, where Azure Container Apps forwards it to Log Analytics for querying.
+
+The instrumentation is deliberately small: a SQLAlchemy event listener at the
+single engine chokepoint (:mod:`query_timing`) and a request-timing middleware
+(:mod:`request_logging`). All emission flows through :mod:`sinks`, which is the
+seam where OpenTelemetry spans can later be added without touching the timing
+code (see that module's docstring).
+"""
+
+from .logging_config import configure_logging
+from .query_timing import register_query_timing
+from .request_logging import RequestTimingMiddleware
+
+__all__ = [
+    "configure_logging",
+    "register_query_timing",
+    "RequestTimingMiddleware",
+]

--- a/deployments/api/src/stitch/api/observability/context.py
+++ b/deployments/api/src/stitch/api/observability/context.py
@@ -1,0 +1,26 @@
+"""Per-request context shared between the request middleware and the query
+timing listener.
+
+The middleware sets these context variables *before* handing off to the rest
+of the app, so the values (and the mutable ``db_stats`` dict) are captured into
+the downstream task and visible to the SQLAlchemy listener. The listener
+mutates the same ``db_stats`` dict in place, which is how the middleware reads
+back the aggregated query count / time once the request completes.
+"""
+
+from contextvars import ContextVar
+from typing import TypedDict
+
+
+class DbStats(TypedDict):
+    count: int
+    time_ms: float
+
+
+request_id_var: ContextVar[str | None] = ContextVar("stitch_request_id", default=None)
+route_var: ContextVar[str | None] = ContextVar("stitch_route", default=None)
+db_stats_var: ContextVar[DbStats | None] = ContextVar("stitch_db_stats", default=None)
+
+
+def new_db_stats() -> DbStats:
+    return {"count": 0, "time_ms": 0.0}

--- a/deployments/api/src/stitch/api/observability/context.py
+++ b/deployments/api/src/stitch/api/observability/context.py
@@ -20,6 +20,10 @@ class DbStats(TypedDict):
 request_id_var: ContextVar[str | None] = ContextVar("stitch_request_id", default=None)
 route_var: ContextVar[str | None] = ContextVar("stitch_route", default=None)
 db_stats_var: ContextVar[DbStats | None] = ContextVar("stitch_db_stats", default=None)
+# Optional caller-supplied experiment label (from the X-Perf-Scenario header).
+# Lets a batch of traffic be tagged so query/request events can be compared
+# across variants (e.g. data volume, query params) by the analyzer.
+scenario_var: ContextVar[str | None] = ContextVar("stitch_scenario", default=None)
 
 
 def new_db_stats() -> DbStats:

--- a/deployments/api/src/stitch/api/observability/logging_config.py
+++ b/deployments/api/src/stitch/api/observability/logging_config.py
@@ -9,6 +9,7 @@ JSON formatter so the per-query / per-request events emitted via
 import json
 import logging
 import os
+import sys
 from typing import Literal
 
 # Standard LogRecord attributes; everything else attached via ``extra`` is
@@ -71,7 +72,9 @@ def configure_logging(
     level_name = (level or os.getenv("LOG_LEVEL", "INFO")).upper()
     resolved = getattr(logging, level_name, logging.INFO)
 
-    handler = logging.StreamHandler()
+    # Explicitly stdout: StreamHandler() defaults to stderr, which would
+    # contradict the docstring and break stdout-only capture pipelines.
+    handler = logging.StreamHandler(sys.stdout)
     if log_format == "json":
         handler.setFormatter(JsonFormatter())
     else:

--- a/deployments/api/src/stitch/api/observability/logging_config.py
+++ b/deployments/api/src/stitch/api/observability/logging_config.py
@@ -1,0 +1,91 @@
+"""Logging setup for the API.
+
+Despite ``LOG_LEVEL`` being passed to every container, the API never
+configured logging — only the ``seed`` service did. This wires it up and adds a
+JSON formatter so the per-query / per-request events emitted via
+:mod:`sinks` are machine-parseable in Log Analytics.
+"""
+
+import json
+import logging
+import os
+from typing import Literal
+
+# Standard LogRecord attributes; everything else attached via ``extra`` is
+# treated as part of the structured payload.
+_RESERVED = frozenset(logging.LogRecord("", 0, "", 0, "", (), None).__dict__.keys()) | {
+    "message",
+    "asctime",
+    "taskName",
+}
+
+LogFormat = Literal["json", "plain"]
+
+
+class JsonFormatter(logging.Formatter):
+    """Render each record as a single JSON object.
+
+    The ``event`` dict attached by the sinks is flattened into the top level so
+    fields like ``duration_ms`` and ``route`` are directly queryable.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict = {
+            "ts": self.formatTime(record),
+            "level": record.levelname,
+            "logger": record.name,
+            "msg": record.getMessage(),
+        }
+
+        event = getattr(record, "event", None)
+        if isinstance(event, dict):
+            payload.update(event)
+
+        # Pick up any other ad-hoc ``extra`` fields without clobbering core keys.
+        for key, value in record.__dict__.items():
+            if key not in _RESERVED and key != "event" and key not in payload:
+                payload[key] = value
+
+        if record.exc_info:
+            payload["exc_info"] = self.formatException(record.exc_info)
+
+        return json.dumps(payload, default=str)
+
+
+_PLAIN_FORMAT = "%(asctime)s | %(levelname)s | %(name)s | %(message)s"
+
+
+def configure_logging(
+    *,
+    level: str | None = None,
+    log_format: LogFormat = "json",
+) -> None:
+    """Install a single stdout handler on the root logger.
+
+    Called once at import time. Safe to call again (it replaces handlers).
+    ``uvicorn`` does not pass ``--log-config``, so configuring the root logger
+    here wins; we also stop uvicorn's loggers from carrying their own handlers
+    and quiet its per-request access log (our request middleware emits a richer
+    summary).
+    """
+    level_name = (level or os.getenv("LOG_LEVEL", "INFO")).upper()
+    resolved = getattr(logging, level_name, logging.INFO)
+
+    handler = logging.StreamHandler()
+    if log_format == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(logging.Formatter(_PLAIN_FORMAT))
+
+    root = logging.getLogger()
+    root.handlers = [handler]
+    root.setLevel(resolved)
+
+    for name in ("uvicorn", "uvicorn.error", "uvicorn.access"):
+        uvicorn_logger = logging.getLogger(name)
+        uvicorn_logger.handlers = []
+        uvicorn_logger.propagate = True
+
+    # Our request middleware logs every request; uvicorn's access log would
+    # just duplicate that, so keep it quiet.
+    logging.getLogger("uvicorn.access").setLevel(logging.WARNING)

--- a/deployments/api/src/stitch/api/observability/query_timing.py
+++ b/deployments/api/src/stitch/api/observability/query_timing.py
@@ -17,6 +17,7 @@ from sqlalchemy.engine import Engine
 from .context import db_stats_var
 from .context import request_id_var
 from .context import route_var
+from .context import scenario_var
 from .sinks import emit_query_event
 
 try:  # py3.12+: monotonic, nanosecond resolution
@@ -83,5 +84,6 @@ def register_query_timing(
                 "statement": _normalize_statement(statement, statement_max_chars),
                 "request_id": request_id_var.get(),
                 "route": route_var.get(),
+                "scenario": scenario_var.get(),
             }
         )

--- a/deployments/api/src/stitch/api/observability/query_timing.py
+++ b/deployments/api/src/stitch/api/observability/query_timing.py
@@ -54,6 +54,18 @@ def register_query_timing(
     def _before(conn, cursor, statement, parameters, context, executemany):
         conn.info.setdefault(_START_KEY, []).append(perf_counter())
 
+    @event.listens_for(sync_engine, "handle_error")
+    def _on_error(exc_context):
+        # after_cursor_execute does not fire when execution raises, so pop the
+        # start time the before-hook pushed; otherwise it leaks and corrupts the
+        # timing of the next query on this connection.
+        conn = exc_context.connection
+        if conn is None:
+            return
+        start_stack = conn.info.get(_START_KEY)
+        if start_stack:
+            start_stack.pop()
+
     @event.listens_for(sync_engine, "after_cursor_execute")
     def _after(conn, cursor, statement, parameters, context, executemany):
         start_stack = conn.info.get(_START_KEY)

--- a/deployments/api/src/stitch/api/observability/query_timing.py
+++ b/deployments/api/src/stitch/api/observability/query_timing.py
@@ -1,0 +1,87 @@
+"""SQLAlchemy query timing via engine cursor-execute events.
+
+Attaches to the single ``AsyncEngine``'s underlying sync engine (the chokepoint
+every query flows through) and times each statement. Slow statements (or all
+statements when ``log_all_queries`` is set) are emitted via the query sink;
+every statement updates the per-request aggregate in :mod:`context`.
+
+Bound parameter values are intentionally **not** captured — only the
+parameterized statement text — to avoid logging PII or large payloads.
+"""
+
+import re
+
+from sqlalchemy import event
+from sqlalchemy.engine import Engine
+
+from .context import db_stats_var
+from .context import request_id_var
+from .context import route_var
+from .sinks import emit_query_event
+
+try:  # py3.12+: monotonic, nanosecond resolution
+    from time import perf_counter
+except ImportError:  # pragma: no cover - perf_counter always present on 3.12
+    from time import monotonic as perf_counter
+
+_START_KEY = "_stitch_query_start"
+_WHITESPACE = re.compile(r"\s+")
+
+
+def _normalize_statement(statement: str, max_chars: int) -> str:
+    collapsed = _WHITESPACE.sub(" ", statement).strip()
+    if len(collapsed) > max_chars:
+        return collapsed[:max_chars] + "…"
+    return collapsed
+
+
+def register_query_timing(
+    sync_engine: Engine,
+    *,
+    slow_query_ms: float,
+    log_all_queries: bool = False,
+    statement_max_chars: int = 2000,
+) -> None:
+    """Register before/after cursor-execute listeners on ``sync_engine``.
+
+    Pass ``engine.sync_engine`` for an ``AsyncEngine``. Idempotent per engine is
+    not guaranteed — call once per engine (``get_engine`` is ``lru_cache``'d, so
+    that holds in practice).
+    """
+
+    @event.listens_for(sync_engine, "before_cursor_execute")
+    def _before(conn, cursor, statement, parameters, context, executemany):
+        conn.info.setdefault(_START_KEY, []).append(perf_counter())
+
+    @event.listens_for(sync_engine, "after_cursor_execute")
+    def _after(conn, cursor, statement, parameters, context, executemany):
+        start_stack = conn.info.get(_START_KEY)
+        if not start_stack:
+            return
+        elapsed_ms = (perf_counter() - start_stack.pop()) * 1000.0
+
+        stats = db_stats_var.get()
+        if stats is not None:
+            stats["count"] += 1
+            stats["time_ms"] += elapsed_ms
+
+        if not (log_all_queries or elapsed_ms >= slow_query_ms):
+            return
+
+        try:
+            rowcount = cursor.rowcount
+        except Exception:  # pragma: no cover - driver dependent
+            rowcount = None
+
+        emit_query_event(
+            {
+                "duration_ms": round(elapsed_ms, 2),
+                "rowcount": rowcount
+                if rowcount is not None and rowcount >= 0
+                else None,
+                "executemany": executemany,
+                "statement": _normalize_statement(statement, statement_max_chars),
+                "request_id": request_id_var.get(),
+                "route": route_var.get(),
+            }
+        )

--- a/deployments/api/src/stitch/api/observability/request_logging.py
+++ b/deployments/api/src/stitch/api/observability/request_logging.py
@@ -17,10 +17,13 @@ from .context import db_stats_var
 from .context import new_db_stats
 from .context import request_id_var
 from .context import route_var
+from .context import scenario_var
 from .sinks import emit_request_event
 from .query_timing import perf_counter
 
 _REQUEST_ID_HEADER = "X-Request-ID"
+_SCENARIO_HEADER = "X-Perf-Scenario"
+_SCENARIO_MAX_CHARS = 80
 
 
 def _route_template(request: Request) -> str:
@@ -43,10 +46,14 @@ class RequestTimingMiddleware(BaseHTTPMiddleware):
         # Route matching uses scope path/method, both available pre-dispatch, so
         # query events emitted during the request can carry the route too.
         route = _route_template(request)
+        scenario = request.headers.get(_SCENARIO_HEADER)
+        if scenario:
+            scenario = scenario[:_SCENARIO_MAX_CHARS]
         stats = new_db_stats()
         id_token = request_id_var.set(request_id)
         stats_token = db_stats_var.set(stats)
         route_token = route_var.set(route)
+        scenario_token = scenario_var.set(scenario)
 
         start = perf_counter()
         status_code = 500
@@ -66,8 +73,10 @@ class RequestTimingMiddleware(BaseHTTPMiddleware):
                     "duration_ms": round(duration_ms, 2),
                     "db_query_count": stats["count"],
                     "db_time_ms": round(stats["time_ms"], 2),
+                    "scenario": scenario,
                 }
             )
             request_id_var.reset(id_token)
             db_stats_var.reset(stats_token)
             route_var.reset(route_token)
+            scenario_var.reset(scenario_token)

--- a/deployments/api/src/stitch/api/observability/request_logging.py
+++ b/deployments/api/src/stitch/api/observability/request_logging.py
@@ -1,0 +1,73 @@
+"""Per-request timing middleware.
+
+Establishes the per-request context (request id + mutable DB-stats dict)
+*before* delegating downstream, so the query timing listener accumulates into
+the same dict. On completion it emits a single request summary including the
+aggregated database query count and time.
+"""
+
+from uuid import uuid4
+
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+from starlette.routing import Match
+
+from .context import db_stats_var
+from .context import new_db_stats
+from .context import request_id_var
+from .context import route_var
+from .sinks import emit_request_event
+from .query_timing import perf_counter
+
+_REQUEST_ID_HEADER = "X-Request-ID"
+
+
+def _route_template(request: Request) -> str:
+    """Return the matched route template (e.g. ``/oil-gas-fields/{id}``).
+
+    Re-runs route matching against the app's routes — ``scope["route"]`` is not
+    reliably populated across Starlette versions. Falls back to the raw path so
+    we never lose the event, accepting higher cardinality in that case.
+    """
+    for route in request.app.routes:
+        match, _ = route.matches(request.scope)
+        if match == Match.FULL:
+            return getattr(route, "path", request.url.path)
+    return request.url.path
+
+
+class RequestTimingMiddleware(BaseHTTPMiddleware):
+    async def dispatch(self, request: Request, call_next) -> Response:
+        request_id = uuid4().hex
+        # Route matching uses scope path/method, both available pre-dispatch, so
+        # query events emitted during the request can carry the route too.
+        route = _route_template(request)
+        stats = new_db_stats()
+        id_token = request_id_var.set(request_id)
+        stats_token = db_stats_var.set(stats)
+        route_token = route_var.set(route)
+
+        start = perf_counter()
+        status_code = 500
+        try:
+            response = await call_next(request)
+            status_code = response.status_code
+            response.headers[_REQUEST_ID_HEADER] = request_id
+            return response
+        finally:
+            duration_ms = (perf_counter() - start) * 1000.0
+            emit_request_event(
+                {
+                    "request_id": request_id,
+                    "method": request.method,
+                    "route": route,
+                    "status_code": status_code,
+                    "duration_ms": round(duration_ms, 2),
+                    "db_query_count": stats["count"],
+                    "db_time_ms": round(stats["time_ms"], 2),
+                }
+            )
+            request_id_var.reset(id_token)
+            db_stats_var.reset(stats_token)
+            route_var.reset(route_token)

--- a/deployments/api/src/stitch/api/observability/sinks.py
+++ b/deployments/api/src/stitch/api/observability/sinks.py
@@ -1,0 +1,32 @@
+"""Emission seam for instrumentation events.
+
+Today these functions emit structured log records (the JSON formatter in
+:mod:`logging_config` flattens the ``event`` dict into the log line). They are
+intentionally the *only* place that decides what happens to a timing event.
+
+OpenTelemetry seam (not built yet, deliberately):
+    When we are ready to explore OTel on Azure, the migration is local to this
+    module. Either:
+      * install ``azure-monitor-opentelemetry`` and rely on the FastAPI /
+        SQLAlchemy auto-instrumentors (in which case these sinks stay as the
+        lightweight log fallback), or
+      * have ``emit_query_event`` / ``emit_request_event`` additionally open a
+        span from the timing data already collected here.
+    The contextvars in :mod:`context` (request id, route, timing) map directly
+    onto span attributes, so no rework of the timing code is required.
+"""
+
+import logging
+
+_query_logger = logging.getLogger("stitch.api.observability.query")
+_request_logger = logging.getLogger("stitch.api.observability.request")
+
+
+def emit_query_event(event: dict) -> None:
+    """Record a single (slow) database query."""
+    _query_logger.info("db_query", extra={"event": event})
+
+
+def emit_request_event(event: dict) -> None:
+    """Record a completed HTTP request with its database aggregates."""
+    _request_logger.info("request", extra={"event": event})

--- a/deployments/api/src/stitch/api/settings.py
+++ b/deployments/api/src/stitch/api/settings.py
@@ -81,6 +81,13 @@ class Settings(BaseSettings):
     git_sha: str | None = None
     build_time: str | None = None
 
+    # Observability: queries slower than this (ms) are logged individually;
+    # set log_all_queries=True (or slow_query_ms=0) to log every query in dev.
+    log_level: str = "INFO"
+    log_format: Literal["json", "plain"] = "json"
+    slow_query_ms: float = 200.0
+    log_all_queries: bool = False
+
     model_config: ClassVar[SettingsConfigDict] = SettingsConfigDict(
         env_file=".env",
         env_file_encoding="utf-8",

--- a/deployments/api/tests/observability/test_query_timing.py
+++ b/deployments/api/tests/observability/test_query_timing.py
@@ -1,0 +1,107 @@
+"""Tests for the SQLAlchemy query timing listener."""
+
+import logging
+
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from stitch.api.observability import query_timing
+from stitch.api.observability.context import db_stats_var, new_db_stats
+from stitch.api.observability.logging_config import JsonFormatter
+
+
+@pytest.fixture
+async def timed_engine(monkeypatch):
+    """Async SQLite engine with timing registered and emitted events captured."""
+    captured: list[dict] = []
+    monkeypatch.setattr(
+        query_timing, "emit_query_event", lambda event: captured.append(event)
+    )
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    query_timing.register_query_timing(
+        engine.sync_engine, slow_query_ms=0, log_all_queries=True
+    )
+    yield engine, captured
+    await engine.dispose()
+
+
+class TestQueryTiming:
+    @pytest.mark.anyio
+    async def test_emits_event_per_query(self, timed_engine):
+        engine, captured = timed_engine
+
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event["duration_ms"] >= 0
+        assert event["statement"] == "SELECT 1"
+
+    @pytest.mark.anyio
+    async def test_accumulates_into_request_stats(self, timed_engine):
+        engine, _ = timed_engine
+        stats = new_db_stats()
+        token = db_stats_var.set(stats)
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+                await conn.execute(text("SELECT 2"))
+        finally:
+            db_stats_var.reset(token)
+
+        assert stats["count"] == 2
+        assert stats["time_ms"] >= 0
+
+    @pytest.mark.anyio
+    async def test_respects_slow_query_threshold(self, monkeypatch):
+        captured: list[dict] = []
+        monkeypatch.setattr(
+            query_timing, "emit_query_event", lambda event: captured.append(event)
+        )
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+        # Very high threshold and not logging all: trivial query is not emitted.
+        query_timing.register_query_timing(
+            engine.sync_engine, slow_query_ms=10_000, log_all_queries=False
+        )
+        try:
+            async with engine.connect() as conn:
+                await conn.execute(text("SELECT 1"))
+        finally:
+            await engine.dispose()
+
+        assert captured == []
+
+    def test_normalize_statement_collapses_and_truncates(self):
+        collapsed = query_timing._normalize_statement(
+            "SELECT\n  a,\n  b\nFROM t", max_chars=2000
+        )
+        assert collapsed == "SELECT a, b FROM t"
+
+        truncated = query_timing._normalize_statement("x" * 50, max_chars=10)
+        assert truncated == "x" * 10 + "…"
+
+
+class TestJsonFormatter:
+    def test_flattens_event_dict(self):
+        formatter = JsonFormatter()
+        record = logging.LogRecord(
+            name="stitch.api.observability.query",
+            level=logging.INFO,
+            pathname=__file__,
+            lineno=1,
+            msg="db_query",
+            args=(),
+            exc_info=None,
+        )
+        record.event = {"duration_ms": 12.3, "route": "/oil-gas-fields/"}
+
+        import json
+
+        payload = json.loads(formatter.format(record))
+        assert payload["msg"] == "db_query"
+        assert payload["duration_ms"] == 12.3
+        assert payload["route"] == "/oil-gas-fields/"
+        assert payload["level"] == "INFO"

--- a/deployments/api/tests/observability/test_query_timing.py
+++ b/deployments/api/tests/observability/test_query_timing.py
@@ -1,14 +1,16 @@
 """Tests for the SQLAlchemy query timing listener."""
 
 import logging
+import sys
 
 import pytest
-from sqlalchemy import text
+from sqlalchemy import create_engine, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from stitch.api.observability import query_timing
 from stitch.api.observability.context import db_stats_var, new_db_stats
-from stitch.api.observability.logging_config import JsonFormatter
+from stitch.api.observability.logging_config import JsonFormatter, configure_logging
+from stitch.api.observability.query_timing import _START_KEY
 
 
 @pytest.fixture
@@ -74,6 +76,30 @@ class TestQueryTiming:
 
         assert captured == []
 
+    def test_failed_query_does_not_leak_start_time(self, monkeypatch):
+        # A statement that raises skips after_cursor_execute; the handle_error
+        # listener must pop the start time the before-hook pushed, or it leaks
+        # on the connection. Tested on a sync engine for direct conn.info access.
+        captured: list[dict] = []
+        monkeypatch.setattr(
+            query_timing, "emit_query_event", lambda event: captured.append(event)
+        )
+        engine = create_engine("sqlite://")
+        query_timing.register_query_timing(
+            engine, slow_query_ms=0, log_all_queries=True
+        )
+        try:
+            with engine.connect() as conn:
+                with pytest.raises(Exception):
+                    conn.execute(text("SELECT * FROM does_not_exist"))
+                assert not conn.info.get(_START_KEY)  # popped by handle_error
+                conn.execute(text("SELECT 1"))
+                assert not conn.info.get(_START_KEY)  # no residual leak
+        finally:
+            engine.dispose()
+
+        assert any(e["statement"] == "SELECT 1" for e in captured)
+
     def test_normalize_statement_collapses_and_truncates(self):
         collapsed = query_timing._normalize_statement(
             "SELECT\n  a,\n  b\nFROM t", max_chars=2000
@@ -105,3 +131,16 @@ class TestJsonFormatter:
         assert payload["duration_ms"] == 12.3
         assert payload["route"] == "/oil-gas-fields/"
         assert payload["level"] == "INFO"
+
+
+class TestConfigureLogging:
+    def test_handler_writes_to_stdout(self):
+        root = logging.getLogger()
+        saved_handlers, saved_level = root.handlers, root.level
+        try:
+            configure_logging(level="INFO", log_format="json")
+            assert root.handlers, "expected a handler to be installed"
+            stream = getattr(root.handlers[0], "stream", None)
+            assert stream is sys.stdout
+        finally:
+            root.handlers, root.level = saved_handlers, saved_level

--- a/deployments/api/tests/observability/test_request_logging.py
+++ b/deployments/api/tests/observability/test_request_logging.py
@@ -12,14 +12,18 @@ from sqlalchemy import text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from stitch.api.observability import RequestTimingMiddleware, register_query_timing
-from stitch.api.observability import request_logging
+from stitch.api.observability import query_timing, request_logging
 
 
 @pytest.fixture
 async def instrumented_app(monkeypatch):
     captured: list[dict] = []
+    captured_queries: list[dict] = []
     monkeypatch.setattr(
         request_logging, "emit_request_event", lambda event: captured.append(event)
+    )
+    monkeypatch.setattr(
+        query_timing, "emit_query_event", lambda event: captured_queries.append(event)
     )
 
     engine = create_async_engine("sqlite+aiosqlite:///:memory:")
@@ -39,14 +43,14 @@ async def instrumented_app(monkeypatch):
     async def no_db():
         return {"ok": True}
 
-    yield app, captured
+    yield app, captured, captured_queries
     await engine.dispose()
 
 
 class TestRequestTimingMiddleware:
     @pytest.mark.anyio
     async def test_emits_summary_with_db_aggregates(self, instrumented_app):
-        app, captured = instrumented_app
+        app, captured, _ = instrumented_app
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         ) as client:
@@ -63,10 +67,11 @@ class TestRequestTimingMiddleware:
         assert event["db_query_count"] == 2
         assert event["duration_ms"] >= 0
         assert event["db_time_ms"] >= 0
+        assert event["scenario"] is None
 
     @pytest.mark.anyio
     async def test_route_without_db_has_zero_queries(self, instrumented_app):
-        app, captured = instrumented_app
+        app, captured, _ = instrumented_app
         async with AsyncClient(
             transport=ASGITransport(app=app), base_url="http://test"
         ) as client:
@@ -74,3 +79,28 @@ class TestRequestTimingMiddleware:
 
         assert captured[-1]["route"] == "/no-db"
         assert captured[-1]["db_query_count"] == 0
+
+    @pytest.mark.anyio
+    async def test_scenario_header_tags_request_and_query_events(
+        self, instrumented_app
+    ):
+        app, captured, captured_queries = instrumented_app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.get("/things/42", headers={"X-Perf-Scenario": "vol=50k"})
+
+        assert captured[-1]["scenario"] == "vol=50k"
+        # The label propagates from the middleware to the query listener.
+        assert captured_queries, "expected query events to be captured"
+        assert all(q["scenario"] == "vol=50k" for q in captured_queries)
+
+    @pytest.mark.anyio
+    async def test_scenario_header_is_truncated(self, instrumented_app):
+        app, captured, _ = instrumented_app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.get("/no-db", headers={"X-Perf-Scenario": "x" * 200})
+
+        assert len(captured[-1]["scenario"]) == 80

--- a/deployments/api/tests/observability/test_request_logging.py
+++ b/deployments/api/tests/observability/test_request_logging.py
@@ -1,0 +1,76 @@
+"""End-to-end test for the request timing middleware.
+
+Exercises the full middleware -> endpoint -> DB path, which is where the
+per-request DB aggregation depends on contextvar propagation surviving
+BaseHTTPMiddleware's task hand-off and SQLAlchemy's async bridge.
+"""
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+from stitch.api.observability import RequestTimingMiddleware, register_query_timing
+from stitch.api.observability import request_logging
+
+
+@pytest.fixture
+async def instrumented_app(monkeypatch):
+    captured: list[dict] = []
+    monkeypatch.setattr(
+        request_logging, "emit_request_event", lambda event: captured.append(event)
+    )
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    register_query_timing(engine.sync_engine, slow_query_ms=0, log_all_queries=True)
+
+    app = FastAPI()
+    app.add_middleware(RequestTimingMiddleware)
+
+    @app.get("/things/{thing_id}")
+    async def get_thing(thing_id: int):
+        async with engine.connect() as conn:
+            await conn.execute(text("SELECT 1"))
+            await conn.execute(text("SELECT 2"))
+        return {"id": thing_id}
+
+    @app.get("/no-db")
+    async def no_db():
+        return {"ok": True}
+
+    yield app, captured
+    await engine.dispose()
+
+
+class TestRequestTimingMiddleware:
+    @pytest.mark.anyio
+    async def test_emits_summary_with_db_aggregates(self, instrumented_app):
+        app, captured = instrumented_app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            response = await client.get("/things/42")
+
+        assert response.status_code == 200
+        assert response.headers["X-Request-ID"]
+
+        assert len(captured) == 1
+        event = captured[0]
+        assert event["method"] == "GET"
+        assert event["route"] == "/things/{thing_id}"
+        assert event["status_code"] == 200
+        assert event["db_query_count"] == 2
+        assert event["duration_ms"] >= 0
+        assert event["db_time_ms"] >= 0
+
+    @pytest.mark.anyio
+    async def test_route_without_db_has_zero_queries(self, instrumented_app):
+        app, captured = instrumented_app
+        async with AsyncClient(
+            transport=ASGITransport(app=app), base_url="http://test"
+        ) as client:
+            await client.get("/no-db")
+
+        assert captured[-1]["route"] == "/no-db"
+        assert captured[-1]["db_query_count"] == 0

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -34,7 +34,10 @@ services:
     volumes:
       - ./deployments/api/alembic/versions:/app/deployments/api/alembic/versions:rw
     command: ["alembic", "-c", "deployments/api/alembic.ini", "revision", "--autogenerate", "-m", "baseline"]
-    profiles: ["tools", "full", "alembic-generate"]
+    # On-demand only (via `make alembic-autogenerate`). Must NOT be in the
+    # `tools`/`full` profiles, or it autogenerates a blank revision on every
+    # `make api-dev` / `reboot-docker` startup.
+    profiles: ["alembic-generate"]
     restart: "no"
 
   seed:

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -267,9 +267,10 @@ def report_by_scenario(
         reverse=True,
     )[:top]
 
-    _print_header(
-        f"{label} by scenario — top {len(ranked)} (baseline = fastest variant)"
+    baseline_desc = (
+        f"baseline = {baseline}" if baseline else "baseline = fastest variant"
     )
+    _print_header(f"{label} by scenario — top {len(ranked)} ({baseline_desc})")
     for primary, by_scenario in ranked:
         print(f"\n{_truncate(primary, width)}")
         base = _baseline_scenario(by_scenario, baseline)

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import math
 import re
 import sys
 from dataclasses import dataclass, field
@@ -37,14 +38,17 @@ _DOCKER_PREFIX = re.compile(r"^[a-zA-Z0-9._-]+\s*\|\s*")
 
 
 def _percentile(values: list[float], pct: float) -> float:
-    """Nearest-rank percentile (pct in 0..100). values need not be sorted."""
+    """Nearest-rank percentile (pct in 0..100). values need not be sorted.
+
+    Uses the textbook nearest-rank method: the smallest value at or below which
+    at least ``pct`` percent of the data falls (rank = ceil(pct/100 * n)).
+    """
     if not values:
         return 0.0
     ordered = sorted(values)
-    if len(ordered) == 1:
-        return ordered[0]
-    rank = max(0, min(len(ordered) - 1, round((pct / 100) * (len(ordered) - 1))))
-    return ordered[rank]
+    rank = math.ceil((pct / 100.0) * len(ordered))
+    rank = min(max(rank, 1), len(ordered))
+    return ordered[rank - 1]
 
 
 def parse_events(lines) -> list[dict]:
@@ -131,10 +135,12 @@ def report_queries(events: list[dict], top: int, sort_key: str, width: int) -> N
         "max": lambda s: s.maximum,
         "mean": lambda s: s.mean,
     }
-    ranked = sorted(stats.values(), key=sorters[sort_key], reverse=True)
+    # 'queries' (avg DB queries/request) is routes-only; fall back to total.
+    effective = sort_key if sort_key in sorters else "total"
+    ranked = sorted(stats.values(), key=sorters[effective], reverse=True)
     peak_total = ranked[0].total
 
-    _print_header(f"QUERIES — top {min(top, len(ranked))} by {sort_key}")
+    _print_header(f"QUERIES — top {min(top, len(ranked))} by {effective}")
     print(
         f"{'count':>7} {'total_ms':>11} {'mean':>8} {'p95':>8} {'max':>8}  "
         f"{'share':<24}  statement"

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+"""Analyze Stitch observability logs to find slow / frequent queries.
+
+Reads the structured JSON events emitted by ``stitch.api.observability`` (one
+JSON object per line) and prints two reports:
+
+  * QUERIES  - grouped by SQL statement: how often each runs and how much total
+               time it costs. The query at the top of the "total time" ranking
+               is the one to optimize first (slow x frequent).
+  * ROUTES   - grouped by endpoint: request latency plus how many DB queries
+               each request fires (a high average is an N+1 smell).
+
+Input is tolerant: it accepts a clean ``.jsonl`` file, raw ``docker compose
+logs`` output (the ``api-1 | `` prefix is stripped), or stdin. Non-JSON lines
+are ignored, so you can point it straight at mixed log output.
+
+Examples:
+    python3 tools/analyze_logs.py /tmp/stitch-events.jsonl
+    docker compose logs --no-log-prefix api | python3 tools/analyze_logs.py -
+    python3 tools/analyze_logs.py dump.jsonl --top 25 --sort count
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+from dataclasses import dataclass, field
+
+# Strips a leading docker-compose service prefix like "api-1  | " or "api | ".
+_DOCKER_PREFIX = re.compile(r"^[a-zA-Z0-9._-]+\s*\|\s*")
+
+
+def _percentile(values: list[float], pct: float) -> float:
+    """Nearest-rank percentile (pct in 0..100). values need not be sorted."""
+    if not values:
+        return 0.0
+    ordered = sorted(values)
+    if len(ordered) == 1:
+        return ordered[0]
+    rank = max(0, min(len(ordered) - 1, round((pct / 100) * (len(ordered) - 1))))
+    return ordered[rank]
+
+
+def parse_events(lines) -> list[dict]:
+    events: list[dict] = []
+    for raw in lines:
+        line = _DOCKER_PREFIX.sub("", raw.strip())
+        if not line or not line.startswith("{"):
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and isinstance(obj.get("logger"), str):
+            events.append(obj)
+    return events
+
+
+@dataclass
+class Stat:
+    key: str
+    durations: list[float] = field(default_factory=list)
+    # route-only extras
+    db_counts: list[int] = field(default_factory=list)
+    db_times: list[float] = field(default_factory=list)
+    statuses: list[int] = field(default_factory=list)
+
+    @property
+    def count(self) -> int:
+        return len(self.durations)
+
+    @property
+    def total(self) -> float:
+        return sum(self.durations)
+
+    @property
+    def mean(self) -> float:
+        return self.total / self.count if self.count else 0.0
+
+    @property
+    def p95(self) -> float:
+        return _percentile(self.durations, 95)
+
+    @property
+    def maximum(self) -> float:
+        return max(self.durations) if self.durations else 0.0
+
+
+def _truncate(text: str, width: int) -> str:
+    return text if len(text) <= width else text[: width - 1] + "…"
+
+
+def _bar(value: float, peak: float, width: int = 24) -> str:
+    if peak <= 0:
+        return ""
+    filled = int(round((value / peak) * width))
+    return "█" * filled + "·" * (width - filled)
+
+
+def _print_header(title: str) -> None:
+    print(f"\n{title}")
+    print("=" * len(title))
+
+
+def report_queries(events: list[dict], top: int, sort_key: str, width: int) -> None:
+    stats: dict[str, Stat] = {}
+    for e in events:
+        if not e.get("logger", "").endswith(".query"):
+            continue
+        stmt = e.get("statement", "<none>")
+        dur = float(e.get("duration_ms") or 0.0)
+        stats.setdefault(stmt, Stat(stmt)).durations.append(dur)
+
+    if not stats:
+        print(
+            "\n(no query events found — run with LOG_ALL_QUERIES=true or a "
+            "lower SLOW_QUERY_MS to capture queries)"
+        )
+        return
+
+    sorters = {
+        "total": lambda s: s.total,
+        "count": lambda s: s.count,
+        "p95": lambda s: s.p95,
+        "max": lambda s: s.maximum,
+        "mean": lambda s: s.mean,
+    }
+    ranked = sorted(stats.values(), key=sorters[sort_key], reverse=True)
+    peak_total = ranked[0].total
+
+    _print_header(f"QUERIES — top {min(top, len(ranked))} by {sort_key}")
+    print(
+        f"{'count':>7} {'total_ms':>11} {'mean':>8} {'p95':>8} {'max':>8}  "
+        f"{'share':<24}  statement"
+    )
+    print("-" * (7 + 11 + 8 + 8 + 8 + 24 + 20))
+    for s in ranked[:top]:
+        print(
+            f"{s.count:>7} {s.total:>11.1f} {s.mean:>8.1f} {s.p95:>8.1f} "
+            f"{s.maximum:>8.1f}  {_bar(s.total, peak_total):<24}  "
+            f"{_truncate(s.key, width)}"
+        )
+
+
+def report_routes(events: list[dict], top: int, sort_key: str, width: int) -> None:
+    stats: dict[str, Stat] = {}
+    for e in events:
+        if not e.get("logger", "").endswith(".request"):
+            continue
+        route = e.get("route", "<none>")
+        s = stats.setdefault(route, Stat(route))
+        s.durations.append(float(e.get("duration_ms") or 0.0))
+        s.db_counts.append(int(e.get("db_query_count") or 0))
+        s.db_times.append(float(e.get("db_time_ms") or 0.0))
+        s.statuses.append(int(e.get("status_code") or 0))
+
+    if not stats:
+        print("\n(no request events found)")
+        return
+
+    def avg_db(s: Stat) -> float:
+        return sum(s.db_counts) / s.count if s.count else 0.0
+
+    sorters = {
+        "total": lambda s: s.total,
+        "count": lambda s: s.count,
+        "p95": lambda s: s.p95,
+        "max": lambda s: s.maximum,
+        "mean": lambda s: s.mean,
+        "queries": avg_db,
+    }
+    key = sorters.get(sort_key, sorters["total"])
+    ranked = sorted(stats.values(), key=key, reverse=True)
+
+    _print_header(
+        f"ROUTES — top {min(top, len(ranked))} by "
+        f"{sort_key if sort_key in sorters else 'total'}"
+    )
+    print(
+        f"{'reqs':>6} {'mean_ms':>8} {'p95_ms':>8} {'max_ms':>8} "
+        f"{'avg_q':>6} {'max_q':>6} {'errs':>5}  route"
+    )
+    print("-" * (6 + 8 + 8 + 8 + 6 + 6 + 5 + 40))
+    for s in ranked[:top]:
+        errs = sum(1 for c in s.statuses if c >= 500)
+        flag = "  ⚠ N+1?" if avg_db(s) >= 10 else ""
+        print(
+            f"{s.count:>6} {s.mean:>8.1f} {s.p95:>8.1f} {s.maximum:>8.1f} "
+            f"{avg_db(s):>6.1f} {max(s.db_counts, default=0):>6} {errs:>5}  "
+            f"{_truncate(s.key, width)}{flag}"
+        )
+
+
+def summarize(events: list[dict]) -> None:
+    reqs = [e for e in events if e.get("logger", "").endswith(".request")]
+    queries = [e for e in events if e.get("logger", "").endswith(".query")]
+    times = sorted(e["ts"] for e in events if e.get("ts"))
+    _print_header("SUMMARY")
+    print(f"events parsed : {len(events)}")
+    print(f"requests      : {len(reqs)}")
+    print(f"queries logged: {len(queries)}")
+    if times:
+        print(f"time range    : {times[0]}  ->  {times[-1]}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("path", help="JSONL file, or '-' for stdin")
+    parser.add_argument("--top", type=int, default=15, help="rows per report")
+    parser.add_argument(
+        "--sort",
+        default="total",
+        choices=["total", "count", "p95", "max", "mean", "queries"],
+        help="ranking metric (queries=avg DB queries/request, routes only)",
+    )
+    parser.add_argument(
+        "--width",
+        type=int,
+        default=90,
+        help="max characters for statement/route column",
+    )
+    parser.add_argument("--queries-only", action="store_true")
+    parser.add_argument("--routes-only", action="store_true")
+    args = parser.parse_args(argv)
+
+    if args.path == "-":
+        events = parse_events(sys.stdin)
+    else:
+        with open(args.path, encoding="utf-8") as fh:
+            events = parse_events(fh)
+
+    if not events:
+        print("No events found. Is this a stitch observability log?", file=sys.stderr)
+        return 1
+
+    summarize(events)
+    if not args.routes_only:
+        report_queries(events, args.top, args.sort, args.width)
+    if not args.queries_only:
+        route_sort = args.sort
+        report_routes(events, args.top, route_sort, args.width)
+    print()
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -184,15 +184,14 @@ def report_routes(events: list[dict], top: int, sort_key: str, width: int) -> No
     )
     print(
         f"{'reqs':>6} {'mean_ms':>8} {'p95_ms':>8} {'max_ms':>8} "
-        f"{'avg_q':>6} {'max_q':>6} {'errs':>5}  route"
+        f"{'avg_q':>6} {'max_q':>6} {'err%':>6}  route"
     )
-    print("-" * (6 + 8 + 8 + 8 + 6 + 6 + 5 + 40))
+    print("-" * (6 + 8 + 8 + 8 + 6 + 6 + 6 + 40))
     for s in ranked[:top]:
-        errs = sum(1 for c in s.statuses if c >= 500)
         flag = "  ⚠ N+1?" if avg_db(s) >= 10 else ""
         print(
             f"{s.count:>6} {s.mean:>8.1f} {s.p95:>8.1f} {s.maximum:>8.1f} "
-            f"{avg_db(s):>6.1f} {max(s.db_counts, default=0):>6} {errs:>5}  "
+            f"{avg_db(s):>6.1f} {max(s.db_counts, default=0):>6} {_error_rate(s):>5.1f}%  "
             f"{_truncate(s.key, width)}{flag}"
         )
 
@@ -215,7 +214,14 @@ def _grouped_stats(
         stat = by_scenario.setdefault(scenario, Stat(scenario))
         stat.durations.append(float(e.get("duration_ms") or 0.0))
         stat.db_counts.append(int(e.get("db_query_count") or 0))
+        stat.statuses.append(int(e.get("status_code") or 0))
     return grouped
+
+
+def _error_rate(stat: Stat) -> float:
+    """Percentage of requests that failed (status >= 400, incl. 401/403)."""
+    failures = sum(1 for c in stat.statuses if c >= 400)
+    return 100.0 * failures / stat.count if stat.count else 0.0
 
 
 def _baseline_scenario(by_scenario: dict[str, Stat], baseline: str | None) -> str:
@@ -262,7 +268,7 @@ def report_by_scenario(
         print(f"\n{_truncate(primary, width)}")
         base = _baseline_scenario(by_scenario, baseline)
         base_mean = by_scenario[base].mean
-        extra = f" {'avg_q':>6}" if show_db else ""
+        extra = f" {'avg_q':>6} {'err%':>6}" if show_db else ""
         print(
             f"  {'scenario':<24} {'count':>7} {'mean':>8} {'p95':>8} "
             f"{'total_ms':>10}{extra} {'vs base':>9}"
@@ -271,7 +277,7 @@ def report_by_scenario(
             s = by_scenario[sc]
             ratio = (s.mean / base_mean) if base_mean else 0.0
             avg_q = (sum(s.db_counts) / s.count) if (show_db and s.count) else 0.0
-            extra_val = f" {avg_q:>6.1f}" if show_db else ""
+            extra_val = f" {avg_q:>6.1f} {_error_rate(s):>5.1f}%" if show_db else ""
             tag = "  ← base" if sc == base else ""
             print(
                 f"  {_truncate(sc, 24):<24} {s.count:>7} {s.mean:>8.1f} "

--- a/tools/analyze_logs.py
+++ b/tools/analyze_logs.py
@@ -14,10 +14,14 @@ Input is tolerant: it accepts a clean ``.jsonl`` file, raw ``docker compose
 logs`` output (the ``api-1 | `` prefix is stripped), or stdin. Non-JSON lines
 are ignored, so you can point it straight at mixed log output.
 
+Tag traffic with an ``X-Perf-Scenario: <label>`` request header to compare
+variants (data volume, query params, ...) with ``--group-by scenario``.
+
 Examples:
     python3 tools/analyze_logs.py /tmp/stitch-events.jsonl
     docker compose logs --no-log-prefix api | python3 tools/analyze_logs.py -
     python3 tools/analyze_logs.py dump.jsonl --top 25 --sort count
+    python3 tools/analyze_logs.py dump.jsonl --group-by scenario --baseline vol=1k
 """
 
 from __future__ import annotations
@@ -193,6 +197,88 @@ def report_routes(events: list[dict], top: int, sort_key: str, width: int) -> No
         )
 
 
+def _scenario_of(event: dict) -> str:
+    return event.get("scenario") or "(none)"
+
+
+def _grouped_stats(
+    events: list[dict], suffix: str, key_field: str
+) -> dict[str, dict[str, Stat]]:
+    """Bucket events as {primary_key: {scenario: Stat}}."""
+    grouped: dict[str, dict[str, Stat]] = {}
+    for e in events:
+        if not e.get("logger", "").endswith(suffix):
+            continue
+        primary = e.get(key_field, "<none>")
+        scenario = _scenario_of(e)
+        by_scenario = grouped.setdefault(primary, {})
+        stat = by_scenario.setdefault(scenario, Stat(scenario))
+        stat.durations.append(float(e.get("duration_ms") or 0.0))
+        stat.db_counts.append(int(e.get("db_query_count") or 0))
+    return grouped
+
+
+def _baseline_scenario(by_scenario: dict[str, Stat], baseline: str | None) -> str:
+    if baseline and baseline in by_scenario:
+        return baseline
+    # Default: the fastest variant, so deltas read as "N× slower than best".
+    return min(by_scenario.values(), key=lambda s: s.mean).key
+
+
+def report_by_scenario(
+    events: list[dict],
+    *,
+    suffix: str,
+    key_field: str,
+    label: str,
+    top: int,
+    width: int,
+    baseline: str | None,
+    show_db: bool,
+) -> None:
+    grouped = _grouped_stats(events, suffix, key_field)
+    if not grouped:
+        print(f"\n(no {label.lower()} events found)")
+        return
+
+    scenarios = {sc for sm in grouped.values() for sc in sm}
+    if scenarios == {"(none)"}:
+        print(
+            f"\n{label}: no scenarios tagged — send requests with an "
+            "'X-Perf-Scenario: <label>' header to compare variants."
+        )
+        return
+
+    ranked = sorted(
+        grouped.items(),
+        key=lambda kv: sum(s.total for s in kv[1].values()),
+        reverse=True,
+    )[:top]
+
+    _print_header(
+        f"{label} by scenario — top {len(ranked)} (baseline = fastest variant)"
+    )
+    for primary, by_scenario in ranked:
+        print(f"\n{_truncate(primary, width)}")
+        base = _baseline_scenario(by_scenario, baseline)
+        base_mean = by_scenario[base].mean
+        extra = f" {'avg_q':>6}" if show_db else ""
+        print(
+            f"  {'scenario':<24} {'count':>7} {'mean':>8} {'p95':>8} "
+            f"{'total_ms':>10}{extra} {'vs base':>9}"
+        )
+        for sc in sorted(by_scenario):
+            s = by_scenario[sc]
+            ratio = (s.mean / base_mean) if base_mean else 0.0
+            avg_q = (sum(s.db_counts) / s.count) if (show_db and s.count) else 0.0
+            extra_val = f" {avg_q:>6.1f}" if show_db else ""
+            tag = "  ← base" if sc == base else ""
+            print(
+                f"  {_truncate(sc, 24):<24} {s.count:>7} {s.mean:>8.1f} "
+                f"{s.p95:>8.1f} {s.total:>10.1f}{extra_val} {ratio:>7.2f}×{tag}"
+            )
+
+
 def summarize(events: list[dict]) -> None:
     reqs = [e for e in events if e.get("logger", "").endswith(".request")]
     queries = [e for e in events if e.get("logger", "").endswith(".query")]
@@ -225,6 +311,16 @@ def main(argv: list[str] | None = None) -> int:
     )
     parser.add_argument("--queries-only", action="store_true")
     parser.add_argument("--routes-only", action="store_true")
+    parser.add_argument(
+        "--group-by",
+        choices=["scenario"],
+        help="compare variants tagged via the X-Perf-Scenario header, "
+        "broken down per query/route",
+    )
+    parser.add_argument(
+        "--baseline",
+        help="scenario to use as the 1.0× baseline (default: fastest variant)",
+    )
     args = parser.parse_args(argv)
 
     if args.path == "-":
@@ -238,11 +334,34 @@ def main(argv: list[str] | None = None) -> int:
         return 1
 
     summarize(events)
-    if not args.routes_only:
-        report_queries(events, args.top, args.sort, args.width)
-    if not args.queries_only:
-        route_sort = args.sort
-        report_routes(events, args.top, route_sort, args.width)
+    if args.group_by == "scenario":
+        if not args.routes_only:
+            report_by_scenario(
+                events,
+                suffix=".query",
+                key_field="statement",
+                label="QUERIES",
+                top=args.top,
+                width=args.width,
+                baseline=args.baseline,
+                show_db=False,
+            )
+        if not args.queries_only:
+            report_by_scenario(
+                events,
+                suffix=".request",
+                key_field="route",
+                label="ROUTES",
+                top=args.top,
+                width=args.width,
+                baseline=args.baseline,
+                show_db=True,
+            )
+    else:
+        if not args.routes_only:
+            report_queries(events, args.top, args.sort, args.width)
+        if not args.queries_only:
+            report_routes(events, args.top, args.sort, args.width)
     print()
     return 0
 


### PR DESCRIPTION
Adds an observability layer, and ties into middleware and DB queries, to capture performance information about both.

Deliberately simple at this point, but generally compatible with transitioning to OTel later.

See `deployments/PERFORMANCE.md` for more detailed instructions on capture and analysis, but highlights:
* Emits JSON structured records
* Can filter samples in API (only emit for long queries), configurable to capture all
* Can make requests `X-Perf-Scenario: <label>` request header to tag requests and their related queries for grouping
* Includes basic analysis script

Most code by claude.