### PR TITLE
ci(staging): enable `demo/*` branches to deploy to staging

### DIFF
--- a/.github/rulesets/gitflow-next-lifecycle.json
+++ b/.github/rulesets/gitflow-next-lifecycle.json
@@ -10,7 +10,8 @@
       "exclude": [],
       "include": [
         "refs/heads/next",
-        "refs/heads/hotfix/**"
+        "refs/heads/hotfix/**",
+        "refs/heads/demo/**"
       ]
     }
   },

--- a/.github/workflows/resolve-deployment-context.yml
+++ b/.github/workflows/resolve-deployment-context.yml
@@ -57,7 +57,7 @@ jobs:
               esac
               ;;
             pull_request)
-              if [ "$BASE_REF" = "production" ]; then
+              if [ "$BASE_REF" = "production" ] || [ "${HEAD_REF#demo/}" != "$HEAD_REF" ]; then
                 deployment_lane="staging"
                 deployment_name="$(normalize_name "$HEAD_REF")"
               else

--- a/.github/workflows/resolve-deployment-context.yml
+++ b/.github/workflows/resolve-deployment-context.yml
@@ -57,7 +57,7 @@ jobs:
               esac
               ;;
             pull_request)
-              if [ "$BASE_REF" = "production" ] || [ "${HEAD_REF#demo/}" != "$HEAD_REF" ]; then
+              if [[ "$BASE_REF" == "production" || "$HEAD_REF" == demo/* ]]; then
                 deployment_lane="staging"
                 deployment_name="$(normalize_name "$HEAD_REF")"
               else

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -13,12 +13,14 @@ Branch behavior is:
 * any PR not targeting `production` -> `deployment_lane=development`, `deployment_name=pr-<number>`
 * push to `production` -> `deployment_lane=dress-rehearsal`, `deployment_name=production`
 * any PR targeting `production` -> `deployment_lane=staging`, branch-derived `deployment_name`
+* any PR from a `demo/*` branch -> `deployment_lane=staging`, branch-derived `deployment_name` (regardless of whether it targets `main` or `production`)
 
 Examples:
 
 * PR #57 into `main` -> `deployment_name=pr-57`
 * PR from `next` into `production` -> `deployment_name=next`
 * PR from `hotfix/fix-auth` into `production` -> `deployment_name=hotfix-fix-auth`
+* PR from `demo/q3-pitch` into `main` -> `deployment_name=demo-q3-pitch`
 
 It builds Docker images for:
 


### PR DESCRIPTION
Includes PRs to non-`production` branches, for more flexible demos