### PR TITLE
Enable higher-resource containers

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -302,6 +302,10 @@ jobs:
       deployment-label: entity-linkage
       # Keep staging / dress-rehearsal always-on; development scales to zero.
       min-replicas: ${{ needs.resolve-context.outputs.deployment-lane != 'development' && '1' || '' }}
+      # Unoptimized service; needs more than the default ~0.5 vCPU / 1 GiB.
+      # 4 GiB on the Consumption profile is only valid paired with 2.0 vCPU.
+      cpu: "2.0"
+      memory: "4.0Gi"
 
   deploy-stitch-llm:
     name: "Deploy stitch-llm"
@@ -391,6 +395,10 @@ jobs:
       # Single job at a time + in-memory /status state: keep exactly one replica.
       min-replicas: "1"
       max-replicas: "1"
+      # Unoptimized ETL; needs more than the default ~0.5 vCPU / 1 GiB.
+      # 4 GiB on the Consumption profile is only valid paired with 2.0 vCPU.
+      cpu: "2.0"
+      memory: "4.0Gi"
       environment-variables: >-
         LOG_LEVEL=info
         AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -48,6 +48,16 @@ on:
         required: false
         default: ""
         type: string
+      cpu:
+        description: "Optional. vCPU allocation to reassert after deploy (e.g. '2.0'). Must be set together with memory. On the Consumption profile only fixed pairs are valid (memory Gi = 2x cpu)."
+        required: false
+        default: ""
+        type: string
+      memory:
+        description: "Optional. Memory allocation to reassert after deploy (e.g. '4.0Gi'). Must be set together with cpu."
+        required: false
+        default: ""
+        type: string
       storage-name:
         description: "Optional. Name of an Azure Files storage already registered on the Container Apps environment. When set, it is mounted into the app after deploy."
         required: false
@@ -106,6 +116,8 @@ jobs:
           REGISTRY_PASSWORD: ${{ secrets.registry-password }}
           STORAGE_NAME: ${{ inputs.storage-name }}
           MOUNT_PATH: ${{ inputs.storage-mount-path }}
+          CPU: ${{ inputs.cpu }}
+          MEMORY: ${{ inputs.memory }}
         run: |
           set -euo pipefail
           : "${AZURE_RESOURCE_GROUP:?Missing required variable AZURE_RESOURCE_GROUP}"
@@ -131,6 +143,19 @@ jobs:
           fi
           if [ -n "${MOUNT_PATH:-}" ] && [ -z "${STORAGE_NAME:-}" ]; then
             echo "::error::storage-mount-path is set but storage-name is empty (check the lane's ETL_STORAGE_NAME variable)" >&2
+            exit 1
+          fi
+
+          # Container Apps requires cpu and memory to be set together, and on the
+          # Consumption profile only fixed pairs are valid (memory Gi = 2x cpu, so
+          # 4.0Gi pairs with 2.0). Fail fast on one-without-the-other rather than
+          # letting `az containerapp update` reject it later.
+          if [ -n "${CPU:-}" ] && [ -z "${MEMORY:-}" ]; then
+            echo "::error::cpu is set but memory is empty (Container Apps requires both together)" >&2
+            exit 1
+          fi
+          if [ -n "${MEMORY:-}" ] && [ -z "${CPU:-}" ]; then
+            echo "::error::memory is set but cpu is empty (Container Apps requires both together)" >&2
             exit 1
           fi
 
@@ -187,21 +212,26 @@ jobs:
           registryUsername: ${{ inputs.registry-username }}
           registryPassword: ${{ secrets.registry-password }}
 
-      - name: Pin replica scaling
+      - name: Reassert resources and replica scaling
         # `az containerapp up` (the deploy action) does not reliably preserve
-        # scale settings, so reassert them after every deploy when requested.
-        # Single-job apps (the ETLs) pass min=max=1 to avoid multiple replicas.
-        if: ${{ inputs.min-replicas != '' || inputs.max-replicas != '' }}
+        # resource (cpu/memory) or scale settings, so reassert them after every
+        # deploy when requested. Single-job apps (the ETLs) pass min=max=1 to
+        # avoid multiple replicas; memory-heavy apps pass cpu/memory.
+        if: ${{ inputs.min-replicas != '' || inputs.max-replicas != '' || inputs.cpu != '' || inputs.memory != '' }}
         shell: bash
         env:
           AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
           MIN_REPLICAS: ${{ inputs.min-replicas }}
           MAX_REPLICAS: ${{ inputs.max-replicas }}
+          CPU: ${{ inputs.cpu }}
+          MEMORY: ${{ inputs.memory }}
         run: |
           set -euo pipefail
           args=()
           [ -n "${MIN_REPLICAS}" ] && args+=(--min-replicas "${MIN_REPLICAS}")
           [ -n "${MAX_REPLICAS}" ] && args+=(--max-replicas "${MAX_REPLICAS}")
+          [ -n "${CPU}" ] && args+=(--cpu "${CPU}")
+          [ -n "${MEMORY}" ] && args+=(--memory "${MEMORY}")
           az containerapp update \
             --name "${{ inputs.container-app-name }}" \
             --resource-group "${AZURE_RESOURCE_GROUP}" \

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -160,6 +160,21 @@ reset on the next pipeline run. Instead, `deploy-container.yml` takes optional
 ETL jobs pass `min-replicas: "1"` and `max-replicas: "1"`, so the pin is
 self-healing — no manual Portal step needed, and it survives every redeploy.
 
+#### Container CPU / memory sizing (wired in CI)
+
+Like replica scaling, per-app CPU and memory are reasserted after deploy rather
+than left to the action's defaults (~0.5 vCPU / 1 GiB). `deploy-container.yml`
+takes optional `cpu` / `memory` inputs and folds them into the same post-deploy
+`az containerapp update` that pins replicas. `entity-linkage` and `etl-woodmac`
+are unoptimized and need more memory, so both pass `cpu: "2.0"` /
+`memory: "4.0Gi"`.
+
+On the default **Consumption** workload profile, CPU and memory are not
+independent — only fixed pairs are valid, with memory (Gi) = 2× vCPU. So **4.0Gi
+is only reachable at 2.0 vCPU**; there is no "low CPU + 4 GiB" option without
+moving the environment to a Dedicated workload profile. The inputs must be set
+together (the deploy validates one-without-the-other and fails fast).
+
 #### Keeping staging / dress-rehearsal awake (scale-to-zero policy)
 
 By default a Container App scales to zero (`min-replicas: 0`) when idle, so the


### PR DESCRIPTION
Some of our services require more memory than others, because for now they are loading a working dataset into memory, and then processing. This PR changes so that they are set as part of deploy, rather than requiring a manual tweak after the fact