### PR TITLE
add CLAUDE.md that imports AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md


### PR DESCRIPTION
While there are claims that Claude Code can read `AGENTS.md`, official docs point to only `CLAUDE.md`, so this addition is to ensure that Claude Code will correctly import contents from `AGENTS.md`.