### PR TITLE
feat: consolidate etl deployments

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -27,13 +27,8 @@ on:
         description: "Base stitch-llm URL to inject into runtime config"
         required: true
         type: string
-      etl-gem-url:
-        description: "Base ETL GEM URL to inject into runtime config (empty when not deployed)"
-        required: false
-        default: ''
-        type: string
-      etl-woodmac-url:
-        description: "Base ETL WoodMac URL to inject into runtime config (empty when not deployed)"
+      etl-url:
+        description: "Base ETL URL to inject into runtime config (empty when not deployed)"
         required: false
         default: ''
         type: string
@@ -128,8 +123,7 @@ jobs:
             "apiUrl": "${{ inputs.api-url }}",
             "entityLinkageUrl": "${{ inputs.entity-linkage-url }}",
             "stitchLlmUrl": "${{ inputs.stitch-llm-url }}",
-            "etlGemUrl": "${{ inputs.etl-gem-url }}",
-            "etlWoodmacUrl": "${{ inputs.etl-woodmac-url }}",
+            "etlUrl": "${{ inputs.etl-url }}",
             "auth0Domain": "${{ inputs.auth0-domain }}",
             "auth0ClientId": "${{ inputs.auth0-client-id }}",
             "auth0Audience": "${{ inputs.auth0-audience }}",

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -338,44 +338,8 @@ jobs:
       # Keep staging / dress-rehearsal always-on; development scales to zero.
       min-replicas: ${{ needs.resolve-context.outputs.deployment-lane != 'development' && '1' || '' }}
 
-  deploy-etl-gem:
-    name: "Deploy ETL GEM"
-    if: ${{ needs.resolve-context.outputs.deployment-lane != 'development' }}
-    needs: [resolve-context, lane-config-validate, deploy-api]
-    uses: ./.github/workflows/deploy-container.yml
-    secrets:
-      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-      stitch-client-bearer-token: ${{ secrets.STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN }}
-      registry-password: ${{ secrets.GHCR_ETL_PULL_TOKEN }}
-    with:
-      deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
-      full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-gem:${{ vars.ETL_GEM_IMAGE_TAG || 'main' }}
-      container-app-name: ${{ format('{0}-etl-gem', needs.resolve-context.outputs.deployment-name) }}
-      registry-server: ghcr.io
-      registry-username: ${{ needs.lane-config-validate.outputs.ghcr-etl-pull-username }}
-      # Single job at a time + in-memory /status state: keep exactly one replica.
-      min-replicas: "1"
-      max-replicas: "1"
-      environment-variables: >-
-        LOG_LEVEL=info
-        AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}
-        DEPLOYMENT_LANE=${{ needs.resolve-context.outputs.deployment-lane }}
-        DEPLOYMENT_NAME=${{ needs.resolve-context.outputs.deployment-name }}
-        AUTH_ISSUER=${{ needs.lane-config-validate.outputs.auth-issuer }}
-        AUTH_AUDIENCE=${{ needs.lane-config-validate.outputs.auth-audience }}
-        AUTH_JWKS_URI=${{ needs.lane-config-validate.outputs.auth-jwks-uri }}
-        API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
-        ETL_GEM_FRONTEND_ORIGIN_URL=${{ needs.lane-config-validate.outputs.frontend-origin-url }}
-        GEM_FILE_DIR=/mnt/data/gem
-      deployment-label: etl-gem
-      # Mount the lane's Azure Files share; GEM reads its xlsx from the gem/ subdir.
-      storage-name: ${{ needs.lane-config-validate.outputs.etl-storage-name }}
-      storage-mount-path: /mnt/data
-
-  deploy-etl-woodmac:
-    name: "Deploy ETL WoodMac"
+  deploy-etl:
+    name: "Deploy ETL"
     if: ${{ needs.resolve-context.outputs.deployment-lane != 'development' }}
     needs: [resolve-context, lane-config-validate, deploy-api]
     uses: ./.github/workflows/deploy-container.yml
@@ -388,30 +352,29 @@ jobs:
       registry-password: ${{ secrets.GHCR_ETL_PULL_TOKEN }}
     with:
       deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
-      full-image-name: ghcr.io/rmi/stitch-etl-poc-etl-woodmac:${{ vars.ETL_WOODMAC_IMAGE_TAG || 'main' }}
-      container-app-name: ${{ format('{0}-etl-woodmac', needs.resolve-context.outputs.deployment-name) }}
+      full-image-name: ghcr.io/rmi/stitch-etl-poc:${{ vars.ETL_IMAGE_TAG || 'main' }}
+      container-app-name: ${{ format('{0}-etl', needs.resolve-context.outputs.deployment-name) }}
       registry-server: ghcr.io
       registry-username: ${{ needs.lane-config-validate.outputs.ghcr-etl-pull-username }}
-      # Single job at a time + in-memory /status state: keep exactly one replica.
+      # One job per dataset + in-memory /status state: keep exactly one replica.
       min-replicas: "1"
       max-replicas: "1"
-      # Unoptimized ETL; needs more than the default ~0.5 vCPU / 1 GiB.
+      # WoodMac is unoptimized; needs more than the default ~0.5 vCPU / 1 GiB.
       # 4 GiB on the Consumption profile is only valid paired with 2.0 vCPU.
       cpu: "2.0"
       memory: "4.0Gi"
       environment-variables: >-
-        LOG_LEVEL=info
+        ETL_LOG_LEVEL=info
         AUTH_DISABLED=${{ needs.lane-config-validate.outputs.auth-disabled }}
-        DEPLOYMENT_LANE=${{ needs.resolve-context.outputs.deployment-lane }}
-        DEPLOYMENT_NAME=${{ needs.resolve-context.outputs.deployment-name }}
         AUTH_ISSUER=${{ needs.lane-config-validate.outputs.auth-issuer }}
         AUTH_AUDIENCE=${{ needs.lane-config-validate.outputs.auth-audience }}
         AUTH_JWKS_URI=${{ needs.lane-config-validate.outputs.auth-jwks-uri }}
         API_BASE_URL=${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
-        ETL_WOODMAC_FRONTEND_ORIGIN_URL=${{ needs.lane-config-validate.outputs.frontend-origin-url }}
+        ETL_FRONTEND_ORIGIN_URL=${{ needs.lane-config-validate.outputs.frontend-origin-url }}
+        GEM_FILE_DIR=/mnt/data/gem
         WOODMAC_DATA_DIR=/mnt/data/woodmac
-      deployment-label: etl-woodmac
-      # Mount the lane's Azure Files share; WoodMac caches under the woodmac/ subdir.
+      deployment-label: etl
+      # Mount the lane's Azure Files share; GEM reads gem/, WoodMac caches under woodmac/.
       storage-name: ${{ needs.lane-config-validate.outputs.etl-storage-name }}
       storage-mount-path: /mnt/data
 
@@ -433,7 +396,7 @@ jobs:
     # ETL deploys are skipped in the development lane; gate on no-failure rather
     # than all-success so the frontend still deploys when they are skipped.
     if: ${{ !failure() && !cancelled() }}
-    needs: [resolve-context, lane-config-validate, build-frontend, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl-gem, deploy-etl-woodmac]
+    needs: [resolve-context, lane-config-validate, build-frontend, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl]
     uses: ./.github/workflows/azure-static-web-apps.yml
     secrets:
       azure-static-web-apps-deploy-token: ${{ secrets.AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN }}
@@ -444,8 +407,7 @@ jobs:
       api-url: ${{ format('{0}/api/v1', needs.deploy-api.outputs.container-app-url) }}
       entity-linkage-url: ${{ format('{0}/api/v1', needs.deploy-entity-linkage.outputs.container-app-url) }}
       stitch-llm-url: ${{ format('{0}/api/v1', needs.deploy-stitch-llm.outputs.container-app-url) }}
-      etl-gem-url: ${{ needs.deploy-etl-gem.result == 'success' && format('{0}/api/v1', needs.deploy-etl-gem.outputs.container-app-url) || '' }}
-      etl-woodmac-url: ${{ needs.deploy-etl-woodmac.result == 'success' && format('{0}/api/v1', needs.deploy-etl-woodmac.outputs.container-app-url) || '' }}
+      etl-url: ${{ needs.deploy-etl.result == 'success' && format('{0}/api/v1/etl', needs.deploy-etl.outputs.container-app-url) || '' }}
       auth0-domain: ${{ needs.lane-config-validate.outputs.auth0-domain }}
       auth0-client-id: ${{ needs.lane-config-validate.outputs.auth0-client-id }}
       auth0-audience: ${{ needs.lane-config-validate.outputs.auth0-audience }}
@@ -455,4 +417,4 @@ jobs:
     if: ${{ always() && github.event_name == 'pull_request' }}
     uses: ./.github/workflows/comment-pr-summary.yml
     secrets: inherit
-    needs: [resolve-context, build-api-docker-image, build-entity-linkage-docker-image, build-stitch-llm-docker-image, build-seed-docker-image, deploy-db, run-db-migrations, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl-gem, deploy-etl-woodmac, run-seed, deploy-frontend]
+    needs: [resolve-context, build-api-docker-image, build-entity-linkage-docker-image, build-stitch-llm-docker-image, build-seed-docker-image, deploy-db, run-db-migrations, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl, run-seed, deploy-frontend]

--- a/.github/workflows/close-ci-environment.yml
+++ b/.github/workflows/close-ci-environment.yml
@@ -107,8 +107,8 @@ jobs:
       deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
       container-app-name: ${{ format('{0}-stitch-llm', needs.resolve-context.outputs.deployment-name) }}
 
-  delete-stitch-etl-gem-container-app:
-    name: Delete stitch-etl-gem container app
+  delete-stitch-etl-container-app:
+    name: Delete stitch-etl container app
     needs: [resolve-context]
     uses: ./.github/workflows/delete-container-app.yml
     secrets:
@@ -117,19 +117,7 @@ jobs:
       azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
     with:
       deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
-      container-app-name: ${{ format('{0}-etl-gem', needs.resolve-context.outputs.deployment-name) }}
-
-  delete-stitch-etl-woodmac-container-app:
-    name: Delete stitch-etl-woodmac container app
-    needs: [resolve-context]
-    uses: ./.github/workflows/delete-container-app.yml
-    secrets:
-      azure-client-id: ${{ secrets.AZURE_CLIENT_ID }}
-      azure-tenant-id: ${{ secrets.AZURE_TENANT_ID }}
-      azure-subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
-    with:
-      deployment-lane: ${{ needs.resolve-context.outputs.deployment-lane }}
-      container-app-name: ${{ format('{0}-etl-woodmac', needs.resolve-context.outputs.deployment-name) }}
+      container-app-name: ${{ format('{0}-etl', needs.resolve-context.outputs.deployment-name) }}
 
   close-static-web-app-preview:
     needs: [resolve-context]

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -70,31 +70,6 @@ CORS: the ETL app allows exactly one browser origin, set at deploy time via
 missing value shows up as a browser CORS ("No 'Access-Control-Allow-Origin'
 header") failure, not a server error.
 
-#### Cutover from the two-app topology (one-time)
-
-The ETL wiring was consolidated from two apps (`etl-gem`, `etl-woodmac`, two
-images) to one (`etl`, one image). To migrate a lane safely:
-
-1. Merge the consolidation to `stitch-etl-poc` `main` first, so
-   `ghcr.io/rmi/stitch-etl-poc:main` is published before this repo references it.
-2. On the lane's GitHub Environment, add `ETL_IMAGE_TAG` (`main`) and delete the
-   old `ETL_GEM_IMAGE_TAG` / `ETL_WOODMAC_IMAGE_TAG` variables.
-3. Deploy this repo; confirm the new `<name>-etl` app is healthy
-   (`GET …/api/v1/etl/health/details`) and that GEM and WoodMac runs work from
-   the frontend.
-4. Delete the now-orphaned old apps (they pin `min=max=1`, so they keep billing
-   until removed):
-   ```bash
-   az containerapp delete -g <AZURE_RESOURCE_GROUP> -n <name>-etl-gem --yes
-   az containerapp delete -g <AZURE_RESOURCE_GROUP> -n <name>-etl-woodmac --yes
-   ```
-   Do this in `staging` (its `deployment-name`) and for `production` /
-   `dress-rehearsal`.
-5. Any open PR-into-`production` environment created before this change may
-   still have `-etl-gem` / `-etl-woodmac` apps; the collapsed
-   `close-ci-environment` job won't remove them, so delete them by hand with the
-   commands above.
-
 #### ETL durable storage (Azure Files — wired in CI; storage prerequisites manual)
 
 The ETL app mounts a persistent **SMB Azure Files** share so its data survives
@@ -228,6 +203,31 @@ pins `min = max = 1` and only deploys on non-`development` lanes.
 This only affects the Container Apps. The frontend is an Azure Static Web App
 (always served, no hibernation), and the PostgreSQL flexible server's
 pause behavior, if any, is a separate server-level setting not managed here.
+
+#### Cutover from the two-app topology (one-time)
+
+The ETL wiring was consolidated from two apps (`etl-gem`, `etl-woodmac`, two
+images) to one (`etl`, one image). To migrate a lane safely:
+
+1. Merge the consolidation to `stitch-etl-poc` `main` first, so
+   `ghcr.io/rmi/stitch-etl-poc:main` is published before this repo references it.
+2. On the lane's GitHub Environment, add `ETL_IMAGE_TAG` (`main`) and delete the
+   old `ETL_GEM_IMAGE_TAG` / `ETL_WOODMAC_IMAGE_TAG` variables.
+3. Deploy this repo; confirm the new `<name>-etl` app is healthy
+   (`GET …/api/v1/etl/health/details`) and that GEM and WoodMac runs work from
+   the frontend.
+4. Delete the now-orphaned old apps (they pin `min=max=1`, so they keep billing
+   until removed):
+   ```bash
+   az containerapp delete -g <AZURE_RESOURCE_GROUP> -n <name>-etl-gem --yes
+   az containerapp delete -g <AZURE_RESOURCE_GROUP> -n <name>-etl-woodmac --yes
+   ```
+   Do this in `staging` (its `deployment-name`) and for `production` /
+   `dress-rehearsal`.
+5. Any open PR-into-`production` environment created before this change may
+   still have `-etl-gem` / `-etl-woodmac` apps; the collapsed
+   `close-ci-environment` job won't remove them, so delete them by hand with the
+   commands above.
 
 Reusable workflows now select lane-specific configuration from GitHub
 Environments and are expected to fail loudly when required values are absent.

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -35,51 +35,80 @@ It then handles deployments for:
 * the API Container App, assuming an existing Container Apps environment
 * the entity-linkage Container App in the same environment
 * the stitch-llm Container App in the same environment
-* the ETL Container Apps (`etl-gem`, `etl-woodmac`) in the same environment,
-  on non-`development` lanes only (see below)
+* the ETL Container App (`etl`) in the same environment, on non-`development`
+  lanes only (see below)
 
 ### ETL pipelines (temporary POC wiring)
 
-The `etl-gem` and `etl-woodmac` Container Apps are deployed from pre-built images
-published by the separate `stitch-etl-poc` repository
-(`ghcr.io/rmi/stitch-etl-poc-etl-{gem,woodmac}`). This pipeline does **not** build
-them; it only deploys the tag named by the `ETL_GEM_IMAGE_TAG` /
-`ETL_WOODMAC_IMAGE_TAG` variables (defaulting to `main`).
+The single `etl` Container App is deployed from a pre-built image published by
+the separate `stitch-etl-poc` repository (`ghcr.io/rmi/stitch-etl-poc`). This
+pipeline does **not** build it; it only deploys the tag named by the
+`ETL_IMAGE_TAG` variable (defaulting to `main`). The one app serves both
+datasets under `/api/v1/etl/gem/*` and `/api/v1/etl/wm/*`.
+
+Because it validates every dataset's config at startup (fail-fast), the app
+**requires `WOODMAC_API_KEY` to boot at all** — even for GEM-only runs. The
+`deploy-etl` job therefore always passes it.
 
 Seed and ETL are mutually exclusive per lane:
 
-* `development`: `seed` builds and runs; ETL deploys are skipped.
-* `staging` / `dress-rehearsal`: ETL deploys run; `seed` is skipped.
+* `development`: `seed` builds and runs; ETL deploy is skipped.
+* `staging` / `dress-rehearsal`: ETL deploys; `seed` is skipped.
 
-Because the ETL images live in another repo's GHCR, the Container App needs
+Because the ETL image lives in another repo's GHCR, the Container App needs
 stored pull credentials. The ephemeral `GITHUB_TOKEN` cannot be used (it expires
 and the app re-pulls on every restart), so a long-lived classic PAT with
 `read:packages` is required — GHCR does not support fine-grained tokens. These
 are supplied to `deploy-container.yml` via the `registry-server` /
 `registry-username` inputs and the `registry-password` secret. The frontend
-receives each ETL Container App URL (empty when not deployed) and renders the ETL
-control page.
+receives the single ETL Container App URL (empty when not deployed) and renders
+the ETL control page.
 
-CORS: each ETL app allows exactly one browser origin, set at deploy time via
-`ETL_GEM_FRONTEND_ORIGIN_URL` / `ETL_WOODMAC_FRONTEND_ORIGIN_URL` (sourced from
-the lane's computed `frontend-origin-url`). Unset, they default to
-`http://localhost:3000`, so a missing value shows up as a browser CORS
-("No 'Access-Control-Allow-Origin' header") failure, not a server error.
+CORS: the ETL app allows exactly one browser origin, set at deploy time via
+`ETL_FRONTEND_ORIGIN_URL` (sourced from the lane's computed
+`frontend-origin-url`). Unset, it defaults to `http://localhost:3000`, so a
+missing value shows up as a browser CORS ("No 'Access-Control-Allow-Origin'
+header") failure, not a server error.
+
+#### Cutover from the two-app topology (one-time)
+
+The ETL wiring was consolidated from two apps (`etl-gem`, `etl-woodmac`, two
+images) to one (`etl`, one image). To migrate a lane safely:
+
+1. Merge the consolidation to `stitch-etl-poc` `main` first, so
+   `ghcr.io/rmi/stitch-etl-poc:main` is published before this repo references it.
+2. On the lane's GitHub Environment, add `ETL_IMAGE_TAG` (`main`) and delete the
+   old `ETL_GEM_IMAGE_TAG` / `ETL_WOODMAC_IMAGE_TAG` variables.
+3. Deploy this repo; confirm the new `<name>-etl` app is healthy
+   (`GET …/api/v1/etl/health/details`) and that GEM and WoodMac runs work from
+   the frontend.
+4. Delete the now-orphaned old apps (they pin `min=max=1`, so they keep billing
+   until removed):
+   ```bash
+   az containerapp delete -g <AZURE_RESOURCE_GROUP> -n <name>-etl-gem --yes
+   az containerapp delete -g <AZURE_RESOURCE_GROUP> -n <name>-etl-woodmac --yes
+   ```
+   Do this in `staging` (its `deployment-name`) and for `production` /
+   `dress-rehearsal`.
+5. Any open PR-into-`production` environment created before this change may
+   still have `-etl-gem` / `-etl-woodmac` apps; the collapsed
+   `close-ci-environment` job won't remove them, so delete them by hand with the
+   commands above.
 
 #### ETL durable storage (Azure Files — wired in CI; storage prerequisites manual)
 
-The ETL apps mount a persistent **SMB Azure Files** share so their data survives
-restarts/revisions: `etl-gem` reads its reference spreadsheet from
-`GEM_FILE_DIR=/mnt/data/gem` and `etl-woodmac` keeps its cache at
-`WOODMAC_DATA_DIR=/mnt/data/woodmac`. One share per lane is mounted into both apps
-at `/mnt/data`, with each app using its own subfolder (`gem/`, `woodmac/`).
+The ETL app mounts a persistent **SMB Azure Files** share so its data survives
+restarts/revisions: the `etl` app reads its GEM reference spreadsheet from
+`GEM_FILE_DIR=/mnt/data/gem` and keeps the WoodMac cache at
+`WOODMAC_DATA_DIR=/mnt/data/woodmac`. One share per lane is mounted into the app
+at `/mnt/data`, with each dataset using its own subfolder (`gem/`, `woodmac/`).
 
 The **per-app mount is applied automatically by the pipeline** —
 `azure/container-apps-deploy-action@v1` can't mount volumes, so
 `deploy-container.yml` takes optional `storage-name` / `storage-mount-path` inputs
 and, after the deploy, reads the app spec (`az containerapp show`), injects the
 volume + volumeMount with `jq`, and re-applies it (`az containerapp update
---yaml`). The ETL jobs pass `storage-name` (from the lane's `ETL_STORAGE_NAME`
+--yaml`). The `deploy-etl` job passes `storage-name` (from the lane's `ETL_STORAGE_NAME`
 variable, routed via `lane-config-validate` because env-scoped variables aren't
 visible to reusable-workflow callers) and `storage-mount-path: /mnt/data`. Because
 it runs every deploy, **do not configure the mount by hand in the Portal** — the
@@ -147,9 +176,10 @@ See the Microsoft docs for the full Portal walkthrough:
 
 #### ETL replica pinning (wired in CI)
 
-The ETL apps must run a **single replica**: they hold job state in memory (the
-`/status` endpoint) and run one job at a time, so a second replica would fragment
-status responses and (once the share is mounted) create a concurrent writer.
+The ETL app must run a **single replica**: it holds per-dataset job state in
+memory (the `/status` endpoints) and runs one job per dataset at a time, so a
+second replica would fragment status responses and (once the share is mounted)
+create a concurrent writer.
 
 This is **enforced on every deploy**, not as a one-time manual setting. The
 `azure/container-apps-deploy-action@v1` step (`az containerapp up`) does not
@@ -157,7 +187,7 @@ reliably preserve scale settings, so a value set by hand in the Portal can be
 reset on the next pipeline run. Instead, `deploy-container.yml` takes optional
 `min-replicas` / `max-replicas` inputs and, when either is set, runs a post-deploy
 `az containerapp update --min-replicas … --max-replicas …` to reassert them. The
-ETL jobs pass `min-replicas: "1"` and `max-replicas: "1"`, so the pin is
+`deploy-etl` job passes `min-replicas: "1"` and `max-replicas: "1"`, so the pin is
 self-healing — no manual Portal step needed, and it survives every redeploy.
 
 #### Container CPU / memory sizing (wired in CI)
@@ -165,7 +195,7 @@ self-healing — no manual Portal step needed, and it survives every redeploy.
 Like replica scaling, per-app CPU and memory are reasserted after deploy rather
 than left to the action's defaults (~0.5 vCPU / 1 GiB). `deploy-container.yml`
 takes optional `cpu` / `memory` inputs and folds them into the same post-deploy
-`az containerapp update` that pins replicas. `entity-linkage` and `etl-woodmac`
+`az containerapp update` that pins replicas. `entity-linkage` and the `etl` app
 are unoptimized and need more memory, so both pass `cpu: "2.0"` /
 `memory: "4.0Gi"`.
 
@@ -192,8 +222,8 @@ min-replicas: ${{ needs.resolve-context.outputs.deployment-lane != 'development'
 So on `staging` / `dress-rehearsal` they reassert `min-replicas: 1` (always one
 warm replica, `max` left at the default so they can still scale out), and on
 `development` the input is empty, the post-deploy step is skipped, and they keep
-the default scale-to-zero. The ETL apps are always-on on those lanes too, since
-they pin `min = max = 1` and only deploy on non-`development` lanes.
+the default scale-to-zero. The ETL app is always-on on those lanes too, since it
+pins `min = max = 1` and only deploys on non-`development` lanes.
 
 This only affects the Container Apps. The frontend is an Azure Static Web App
 (always served, no hibernation), and the PostgreSQL flexible server's
@@ -294,15 +324,13 @@ named:
 * `STITCH_LLM_AZURE_OPENAI_MODEL` (example: `gpt-5.1-chat`)
 * `STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS` (example: `30`)
 * `GHCR_ETL_PULL_USERNAME` (example: `your-github-username`) — registry username
-  for pulling the ETL images; not sensitive, so it is a variable. Only needed on
+  for pulling the ETL image; not sensitive, so it is a variable. Only needed on
   `staging` / `dress-rehearsal`.
 * `ETL_STORAGE_NAME` (example: `etl-staging`) — the Azure Files env-storage name
-  registered on the Container Apps environment; mounted into both ETL apps at
+  registered on the Container Apps environment; mounted into the `etl` app at
   `/mnt/data`. Only needed on `staging` / `dress-rehearsal` (see ETL durable
   storage above).
-* `ETL_GEM_IMAGE_TAG` (example: `main`) — optional; ETL GEM image tag to deploy,
-  defaults to `main`. Only used on `staging` / `dress-rehearsal`.
-* `ETL_WOODMAC_IMAGE_TAG` (example: `main`) — optional; ETL WoodMac image tag to
+* `ETL_IMAGE_TAG` (example: `main`) — optional; consolidated ETL image tag to
   deploy, defaults to `main`. Only used on `staging` / `dress-rehearsal`.
   * NOTE: `FRONTEND_PREVIEW_URL_TEMPLATE` must contain the literal `{name}` placeholder.
 For `dress-rehearsal`, the workflow uses `FRONTEND_PRODUCTION_URL` directly. For pull requests, it replaces `{name}` with the raw PR number so PR #106 resolves to `https://witty-mushroom-017a3dc1e-106.westus2.1.azurestaticapps.net`. For other preview deployments, it replaces `{name}` with `deployment_name`.
@@ -316,10 +344,11 @@ For `dress-rehearsal`, the workflow uses `FRONTEND_PRODUCTION_URL` directly. For
 * `STITCH_CLIENT_LLM_BEARER_TOKEN`
 * `STITCH_LLM_AZURE_OPENAI_API_KEY`
 * `AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN`
-* `WOODMAC_API_KEY` — WoodMac API key for the `etl-woodmac` Container App. Only
-  needed on `staging` / `dress-rehearsal`.
+* `WOODMAC_API_KEY` — WoodMac API key for the `etl` Container App. Required for
+  the app to boot (it validates every dataset at startup), so it must be set
+  even though GEM does not use it. Only needed on `staging` / `dress-rehearsal`.
 * `GHCR_ETL_PULL_TOKEN` — classic PAT with `read:packages` used to pull the ETL
-  images from the `stitch-etl-poc` GHCR. Only needed on `staging` /
+  image from the `stitch-etl-poc` GHCR. Only needed on `staging` /
   `dress-rehearsal`.
 
 Current validation behavior:

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -4,38 +4,38 @@ The CD pipeline is managed by the GitHub workflow `build-and-deploy.yml`.
 
 It uses two explicit workflow concepts:
 
-* `deployment_lane`: deploy class / GitHub Environment name
-* `deployment_name`: concrete runtime target name used for DB and app naming
+- `deployment_lane`: deploy class / GitHub Environment name
+- `deployment_name`: concrete runtime target name used for DB and app naming
 
 Branch behavior is:
 
-* push to `main` -> `deployment_lane=development`, `deployment_name=main`
-* any PR not targeting `production` -> `deployment_lane=development`, `deployment_name=pr-<number>`
-* push to `production` -> `deployment_lane=dress-rehearsal`, `deployment_name=production`
-* any PR targeting `production` -> `deployment_lane=staging`, branch-derived `deployment_name`
-* any PR from a `demo/*` branch -> `deployment_lane=staging`, branch-derived `deployment_name` (regardless of whether it targets `main` or `production`)
+- push to `main` -> `deployment_lane=development`, `deployment_name=main`
+- any PR not targeting `production` -> `deployment_lane=development`, `deployment_name=pr-<number>`
+- push to `production` -> `deployment_lane=dress-rehearsal`, `deployment_name=production`
+- any PR targeting `production` -> `deployment_lane=staging`, branch-derived `deployment_name`
+- any PR from a `demo/*` branch -> `deployment_lane=staging`, branch-derived `deployment_name` (regardless of whether it targets `main` or `production`)
 
 Examples:
 
-* PR #57 into `main` -> `deployment_name=pr-57`
-* PR from `next` into `production` -> `deployment_name=next`
-* PR from `hotfix/fix-auth` into `production` -> `deployment_name=hotfix-fix-auth`
-* PR from `demo/q3-pitch` into `main` -> `deployment_name=demo-q3-pitch`
+- PR #57 into `main` -> `deployment_name=pr-57`
+- PR from `next` into `production` -> `deployment_name=next`
+- PR from `hotfix/fix-auth` into `production` -> `deployment_name=hotfix-fix-auth`
+- PR from `demo/q3-pitch` into `main` -> `deployment_name=demo-q3-pitch`
 
 It builds Docker images for:
 
-* `api` (also used for DB migration)
-* `entity-linkage`
-* `stitch-llm`
-* `seed`
+- `api` (also used for DB migration)
+- `entity-linkage`
+- `stitch-llm`
+- `seed`
 
 It then handles deployments for:
 
-* the database, assuming an existing Azure PostgreSQL flexible server
-* the API Container App, assuming an existing Container Apps environment
-* the entity-linkage Container App in the same environment
-* the stitch-llm Container App in the same environment
-* the ETL Container App (`etl`) in the same environment, on non-`development`
+- the database, assuming an existing Azure PostgreSQL flexible server
+- the API Container App, assuming an existing Container Apps environment
+- the entity-linkage Container App in the same environment
+- the stitch-llm Container App in the same environment
+- the ETL Container App (`etl`) in the same environment, on non-`development`
   lanes only (see below)
 
 ### ETL pipelines (temporary POC wiring)
@@ -52,8 +52,8 @@ Because it validates every dataset's config at startup (fail-fast), the app
 
 Seed and ETL are mutually exclusive per lane:
 
-* `development`: `seed` builds and runs; ETL deploy is skipped.
-* `staging` / `dress-rehearsal`: ETL deploys; `seed` is skipped.
+- `development`: `seed` builds and runs; ETL deploy is skipped.
+- `staging` / `dress-rehearsal`: ETL deploys; `seed` is skipped.
 
 Because the ETL image lives in another repo's GHCR, the Container App needs
 stored pull credentials. The ephemeral `GITHUB_TOKEN` cannot be used (it expires
@@ -89,16 +89,16 @@ visible to reusable-workflow callers) and `storage-mount-path: /mnt/data`. Becau
 it runs every deploy, **do not configure the mount by hand in the Portal** — the
 pipeline reasserts it and a manual mount would just be overwritten.
 
-What *is* manual is the storage itself. Do the steps below in the **Azure Portal**
+What _is_ manual is the storage itself. Do the steps below in the **Azure Portal**
 (no `az` needed; SMB registration and mounting are fully Portal-supported — only
 NFS forces CLI/YAML) per lane (`staging`, `dress-rehearsal`), in that lane's
 resource group and Container Apps environment. Each lane gets its own storage
 account / share / environment-storage name:
 
-| Lane | Storage account | File share | Env storage name (`ETL_STORAGE_NAME`) |
-|---|---|---|---|
-| `staging` | `stitchstaging` | `etl-staging` | `etl-staging` |
-| `dress-rehearsal` | `stitchstaging` | `etl-dress-rehearsal` | `etl-dress-rehearsal` |
+| Lane              | Storage account | File share            | Env storage name (`ETL_STORAGE_NAME`) |
+| ----------------- | --------------- | --------------------- | ------------------------------------- |
+| `staging`         | `stitchstaging` | `etl-staging`         | `etl-staging`                         |
+| `dress-rehearsal` | `stitchstaging` | `etl-dress-rehearsal` | `etl-dress-rehearsal`                 |
 
 1. **Create a storage account + file share.** Create a Storage account (Standard
    LRS, StorageV2) or reuse one, then under **File shares** add a share (for
@@ -116,7 +116,7 @@ account / share / environment-storage name:
    enter the storage account name, account key, share name (`etl-staging` for
    staging), and access mode `ReadWrite`; name the environment storage to match
    (`etl-staging`) — this exact name is what `ETL_STORAGE_NAME` must hold. The
-   registration lives on the *environment* and persists across app deploys.
+   registration lives on the _environment_ and persists across app deploys.
    (Container Apps does not support managed-identity access to Azure Files, so the
    account key is required regardless of Portal vs. CLI.)
 
@@ -204,7 +204,7 @@ This only affects the Container Apps. The frontend is an Azure Static Web App
 (always served, no hibernation), and the PostgreSQL flexible server's
 pause behavior, if any, is a separate server-level setting not managed here.
 
-#### Cutover from the two-app topology (one-time)
+#### Migration from the multi-deployment ETL topology (one-time)
 
 The ETL wiring was consolidated from two apps (`etl-gem`, `etl-woodmac`, two
 images) to one (`etl`, one image). To migrate a lane safely:
@@ -218,12 +218,15 @@ images) to one (`etl`, one image). To migrate a lane safely:
    the frontend.
 4. Delete the now-orphaned old apps (they pin `min=max=1`, so they keep billing
    until removed):
+
    ```bash
    az containerapp delete -g <AZURE_RESOURCE_GROUP> -n <name>-etl-gem --yes
    az containerapp delete -g <AZURE_RESOURCE_GROUP> -n <name>-etl-woodmac --yes
    ```
+
    Do this in `staging` (its `deployment-name`) and for `production` /
    `dress-rehearsal`.
+
 5. Any open PR-into-`production` environment created before this change may
    still have `-etl-gem` / `-etl-woodmac` apps; the collapsed
    `close-ci-environment` job won't remove them, so delete them by hand with the
@@ -251,20 +254,20 @@ For this repo, we're using `GHActions-stitch-cicd`.
 
 The repo secrets must point at that exact identity:
 
-* `AZURE_CLIENT_ID`: managed identity client ID
-* `AZURE_SUBSCRIPTION_ID`: Azure subscription containing the target resources
-* `AZURE_TENANT_ID`: tenant for the managed identity
+- `AZURE_CLIENT_ID`: managed identity client ID
+- `AZURE_SUBSCRIPTION_ID`: Azure subscription containing the target resources
+- `AZURE_TENANT_ID`: tenant for the managed identity
 
 Note that federated identity records for this GitHub repository need to be
 added to the managed identity. For the current workflows, the required subjects
 are:
 
-* `repo:RMI/stitch:pull_request`
-* `repo:RMI/stitch:ref:refs/heads/main`
-* `repo:RMI/stitch:ref:refs/heads/production`
-* `repo:RMI/stitch:environment:development`
-* `repo:RMI/stitch:environment:staging`
-* `repo:RMI/stitch:environment:dress-rehearsal`
+- `repo:RMI/stitch:pull_request`
+- `repo:RMI/stitch:ref:refs/heads/main`
+- `repo:RMI/stitch:ref:refs/heads/production`
+- `repo:RMI/stitch:environment:development`
+- `repo:RMI/stitch:environment:staging`
+- `repo:RMI/stitch:environment:dress-rehearsal`
 
 The branch / PR subjects cover workflows that authenticate outside a GitHub
 Environment. The `environment:*` subjects are also required because the
@@ -273,18 +276,18 @@ lane-scoped deploy jobs authenticate from GitHub Environments named
 
 All federated credential fields must match exactly:
 
-* Issuer: `https://token.actions.githubusercontent.com`
-* Audience: `api://AzureADTokenExchange`
-* Subject: case-sensitive exact match
+- Issuer: `https://token.actions.githubusercontent.com`
+- Audience: `api://AzureADTokenExchange`
+- Subject: case-sensitive exact match
 
 If Azure starts returning `AADSTS7002138`, recreating the affected federated
 credential is usually faster than editing it in place.
 
 Managed identity roles:
 
-* `Reader` on `stitch-dev` (Container Apps Environment)
-* `Reader` on `STITCH-DEV-RG` (Resource Group)
-* `Container Apps Contributor` on `STITCH-DEV-RG` (Resource Group)
+- `Reader` on `stitch-dev` (Container Apps Environment)
+- `Reader` on `STITCH-DEV-RG` (Resource Group)
+- `Container Apps Contributor` on `STITCH-DEV-RG` (Resource Group)
 
 ## Setup Notes
 
@@ -292,85 +295,85 @@ In repo settings, under `Secrets and variables` > `Actions`, add Azure identity
 secrets, then define lane-scoped variables and secrets in GitHub Environments
 named:
 
-* `development`
-* `staging`
-* `dress-rehearsal`
+- `development`
+- `staging`
+- `dress-rehearsal`
 
 ### Repo-level secrets
 
-* `AZURE_CLIENT_ID`: Client ID for `GHActions-stitch-cicd`
-* `AZURE_SUBSCRIPTION_ID`: Subscription for the target Azure resources
-* `AZURE_TENANT_ID`: Tenant for `GHActions-stitch-cicd`
+- `AZURE_CLIENT_ID`: Client ID for `GHActions-stitch-cicd`
+- `AZURE_SUBSCRIPTION_ID`: Subscription for the target Azure resources
+- `AZURE_TENANT_ID`: Tenant for `GHActions-stitch-cicd`
 
 ### Environment variables
 
-* `AZURE_RESOURCE_GROUP` (example: `STITCH-DEV-RG`)
-* `AZURE_CONTAINER_APP_ENVIRONMENT` (example: `stitch-dev`)
-* `POSTGRES_HOST` (example: `stitch-dev.postgres.database.azure.com`)
-* `POSTGRES_PORT` (example: `5432`)
-* `POSTGRES_ADMIN_USER` (example: `postgres`)
-* `POSTGRES_SSLMODE` (example: `require`)
-* `POSTGRES_DEFAULT_DB` (example: `postgres`)
-* `FRONTEND_PRODUCTION_URL` (example: `https://witty-mushroom-017a3dc1e.1.azurestaticapps.net`)
-* `FRONTEND_PREVIEW_URL_TEMPLATE` (example: `https://witty-mushroom-017a3dc1e-{name}.westus2.1.azurestaticapps.net`)
-* `AUTH_DISABLED` (example: `true` for `development`, `false` for `staging` / `dress-rehearsal`)
-* `AUTH_ISSUER` (example: `https://rmi-spd.us.auth0.com/`)
-* `AUTH_AUDIENCE` (example: `https://stitch-api.local`)
-* `AUTH_JWKS_URI` (example: `https://rmi-spd.us.auth0.com/.well-known/jwks.json`)
-* `AUTH0_DOMAIN` (example: `rmi-spd.us.auth0.com`)
-* `AUTH0_CLIENT_ID` (example: `<public-client-id>`)
-* `AUTH0_AUDIENCE` (example: `https://stitch-api.local`)
-* `STITCH_LLM_AZURE_OPENAI_BASE_URL` (example: `https://stitch-foundry-dev.openai.azure.com/openai/v1`)
-* `STITCH_LLM_AZURE_OPENAI_MODEL` (example: `gpt-5.1-chat`)
-* `STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS` (example: `30`)
-* `GHCR_ETL_PULL_USERNAME` (example: `your-github-username`) — registry username
+- `AZURE_RESOURCE_GROUP` (example: `STITCH-DEV-RG`)
+- `AZURE_CONTAINER_APP_ENVIRONMENT` (example: `stitch-dev`)
+- `POSTGRES_HOST` (example: `stitch-dev.postgres.database.azure.com`)
+- `POSTGRES_PORT` (example: `5432`)
+- `POSTGRES_ADMIN_USER` (example: `postgres`)
+- `POSTGRES_SSLMODE` (example: `require`)
+- `POSTGRES_DEFAULT_DB` (example: `postgres`)
+- `FRONTEND_PRODUCTION_URL` (example: `https://witty-mushroom-017a3dc1e.1.azurestaticapps.net`)
+- `FRONTEND_PREVIEW_URL_TEMPLATE` (example: `https://witty-mushroom-017a3dc1e-{name}.westus2.1.azurestaticapps.net`)
+- `AUTH_DISABLED` (example: `true` for `development`, `false` for `staging` / `dress-rehearsal`)
+- `AUTH_ISSUER` (example: `https://rmi-spd.us.auth0.com/`)
+- `AUTH_AUDIENCE` (example: `https://stitch-api.local`)
+- `AUTH_JWKS_URI` (example: `https://rmi-spd.us.auth0.com/.well-known/jwks.json`)
+- `AUTH0_DOMAIN` (example: `rmi-spd.us.auth0.com`)
+- `AUTH0_CLIENT_ID` (example: `<public-client-id>`)
+- `AUTH0_AUDIENCE` (example: `https://stitch-api.local`)
+- `STITCH_LLM_AZURE_OPENAI_BASE_URL` (example: `https://stitch-foundry-dev.openai.azure.com/openai/v1`)
+- `STITCH_LLM_AZURE_OPENAI_MODEL` (example: `gpt-5.1-chat`)
+- `STITCH_LLM_AZURE_OPENAI_TIMEOUT_SECONDS` (example: `30`)
+- `GHCR_ETL_PULL_USERNAME` (example: `your-github-username`) — registry username
   for pulling the ETL image; not sensitive, so it is a variable. Only needed on
   `staging` / `dress-rehearsal`.
-* `ETL_STORAGE_NAME` (example: `etl-staging`) — the Azure Files env-storage name
+- `ETL_STORAGE_NAME` (example: `etl-staging`) — the Azure Files env-storage name
   registered on the Container Apps environment; mounted into the `etl` app at
   `/mnt/data`. Only needed on `staging` / `dress-rehearsal` (see ETL durable
   storage above).
-* `ETL_IMAGE_TAG` (example: `main`) — optional; consolidated ETL image tag to
+- `ETL_IMAGE_TAG` (example: `main`) — optional; consolidated ETL image tag to
   deploy, defaults to `main`. Only used on `staging` / `dress-rehearsal`.
-  * NOTE: `FRONTEND_PREVIEW_URL_TEMPLATE` must contain the literal `{name}` placeholder.
-For `dress-rehearsal`, the workflow uses `FRONTEND_PRODUCTION_URL` directly. For pull requests, it replaces `{name}` with the raw PR number so PR #106 resolves to `https://witty-mushroom-017a3dc1e-106.westus2.1.azurestaticapps.net`. For other preview deployments, it replaces `{name}` with `deployment_name`.
+  - NOTE: `FRONTEND_PREVIEW_URL_TEMPLATE` must contain the literal `{name}` placeholder.
+    For `dress-rehearsal`, the workflow uses `FRONTEND_PRODUCTION_URL` directly. For pull requests, it replaces `{name}` with the raw PR number so PR #106 resolves to `https://witty-mushroom-017a3dc1e-106.westus2.1.azurestaticapps.net`. For other preview deployments, it replaces `{name}` with `deployment_name`.
 
 ### Environment secrets
 
-* `PGPASSWORD`
-* `STITCH_APP_PASSWORD`
-* `STITCH_MIGRATOR_PASSWORD`
-* `STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN`
-* `STITCH_CLIENT_LLM_BEARER_TOKEN`
-* `STITCH_LLM_AZURE_OPENAI_API_KEY`
-* `AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN`
-* `WOODMAC_API_KEY` — WoodMac API key for the `etl` Container App. Required for
+- `PGPASSWORD`
+- `STITCH_APP_PASSWORD`
+- `STITCH_MIGRATOR_PASSWORD`
+- `STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN`
+- `STITCH_CLIENT_LLM_BEARER_TOKEN`
+- `STITCH_LLM_AZURE_OPENAI_API_KEY`
+- `AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN`
+- `WOODMAC_API_KEY` — WoodMac API key for the `etl` Container App. Required for
   the app to boot (it validates every dataset at startup), so it must be set
   even though GEM does not use it. Only needed on `staging` / `dress-rehearsal`.
-* `GHCR_ETL_PULL_TOKEN` — classic PAT with `read:packages` used to pull the ETL
+- `GHCR_ETL_PULL_TOKEN` — classic PAT with `read:packages` used to pull the ETL
   image from the `stitch-etl-poc` GHCR. Only needed on `staging` /
   `dress-rehearsal`.
 
 Current validation behavior:
 
-* database deploy validates `PGPASSWORD`
-* `lane-config-validate` validates:
-  * `FRONTEND_PRODUCTION_URL`
-  * `FRONTEND_PREVIEW_URL_TEMPLATE`
-  * `AUTH_DISABLED`
-  * `AUTH_ISSUER`
-  * `AUTH_AUDIENCE`
-  * `AUTH_JWKS_URI`
-  * `AUTH0_DOMAIN`
-  * `AUTH0_CLIENT_ID`
-  * `AUTH0_AUDIENCE`
-  * `STITCH_APP_PASSWORD`
-  * `STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN`
-  * `STITCH_CLIENT_LLM_BEARER_TOKEN`
-  * If any of `STITCH_LLM_AZURE_OPENAI_BASE_URL`, `STITCH_LLM_AZURE_OPENAI_MODEL`, or `STITCH_LLM_AZURE_OPENAI_API_KEY` are set, all three must be set
-* DB migrations validate `STITCH_MIGRATOR_PASSWORD`
-* frontend deploy validates `AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN`
-* container deploy validates that, when `registry-server` is set, both
+- database deploy validates `PGPASSWORD`
+- `lane-config-validate` validates:
+  - `FRONTEND_PRODUCTION_URL`
+  - `FRONTEND_PREVIEW_URL_TEMPLATE`
+  - `AUTH_DISABLED`
+  - `AUTH_ISSUER`
+  - `AUTH_AUDIENCE`
+  - `AUTH_JWKS_URI`
+  - `AUTH0_DOMAIN`
+  - `AUTH0_CLIENT_ID`
+  - `AUTH0_AUDIENCE`
+  - `STITCH_APP_PASSWORD`
+  - `STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN`
+  - `STITCH_CLIENT_LLM_BEARER_TOKEN`
+  - If any of `STITCH_LLM_AZURE_OPENAI_BASE_URL`, `STITCH_LLM_AZURE_OPENAI_MODEL`, or `STITCH_LLM_AZURE_OPENAI_API_KEY` are set, all three must be set
+- DB migrations validate `STITCH_MIGRATOR_PASSWORD`
+- frontend deploy validates `AZURE_STATIC_WEB_APPS_DEPLOY_TOKEN`
+- container deploy validates that, when `registry-server` is set, both
   `registry-username` (variable) and `registry-password` (secret) are present —
   so a missing ETL pull credential fails fast instead of surfacing as an opaque
   registry `UNAUTHORIZED` from `az containerapp up`

--- a/deployments/api/conftest.py
+++ b/deployments/api/conftest.py
@@ -17,9 +17,9 @@ explicit process env above; real env vars still win via ``os.environ``.
 
 import os
 
-os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
+from stitch.api.settings import PostgresConfig, Settings, SqliteConfig
 
-from stitch.api.settings import PostgresConfig, Settings, SqliteConfig  # noqa: E402
+os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
 
 for _settings_cls in (Settings, PostgresConfig, SqliteConfig):
     _settings_cls.model_config["env_file"] = None

--- a/deployments/api/conftest.py
+++ b/deployments/api/conftest.py
@@ -7,8 +7,19 @@ Tracing is process-global and emits span records to stdout on every request;
 the unit/integration suite doesn't exercise it, and benchmarking/trace
 verification runs against real infrastructure instead. Disable it here. Override
 by exporting ``OTEL_TRACES_EXPORTER=console`` when debugging tracing locally.
+
+The settings classes read a ``.env`` file relative to the working directory.
+``make`` runs the suite from the repo root, so ``Settings()`` would otherwise
+pick up a developer's local ``.env`` and mask the declared code defaults that
+tests assert against. Disable dotenv loading so tests see defaults plus the
+explicit process env above; real env vars still win via ``os.environ``.
 """
 
 import os
 
 os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
+
+from stitch.api.settings import PostgresConfig, Settings, SqliteConfig  # noqa: E402
+
+for _settings_cls in (Settings, PostgresConfig, SqliteConfig):
+    _settings_cls.model_config["env_file"] = None

--- a/deployments/api/conftest.py
+++ b/deployments/api/conftest.py
@@ -8,18 +8,10 @@ the unit/integration suite doesn't exercise it, and benchmarking/trace
 verification runs against real infrastructure instead. Disable it here. Override
 by exporting ``OTEL_TRACES_EXPORTER=console`` when debugging tracing locally.
 
-The settings classes read a ``.env`` file relative to the working directory.
-``make`` runs the suite from the repo root, so ``Settings()`` would otherwise
-pick up a developer's local ``.env`` and mask the declared code defaults that
-tests assert against. Disable dotenv loading so tests see defaults plus the
-explicit process env above; real env vars still win via ``os.environ``.
+Dotenv isolation (stopping a developer's local ``.env`` from masking the
+declared code defaults that tests assert) lives in ``tests/conftest.py``.
 """
 
 import os
 
-from stitch.api.settings import PostgresConfig, Settings, SqliteConfig
-
 os.environ.setdefault("OTEL_TRACES_EXPORTER", "none")
-
-for _settings_cls in (Settings, PostgresConfig, SqliteConfig):
-    _settings_cls.model_config["env_file"] = None

--- a/deployments/api/tests/conftest.py
+++ b/deployments/api/tests/conftest.py
@@ -20,8 +20,21 @@ from stitch.api.db.model import (
 from stitch.api.auth import get_current_user, get_token_claims
 from stitch.api.entities import User
 from stitch.api.main import app
+from stitch.api.settings import PostgresConfig, Settings, SqliteConfig, get_settings
 from .factories import OGFieldBaseFactory, ResourceFactory
 from .utils import make_create_resource, make_resource, make_source
+
+
+# The settings classes read a ``.env`` file relative to the working directory,
+# and ``make`` runs the suite from the repo root, so ``Settings()`` would
+# otherwise pick up a developer's local ``.env`` and mask the declared code
+# defaults that tests assert against. Disable dotenv loading here; real env vars
+# (e.g. OTEL_TRACES_EXPORTER, set in the rootdir conftest) still win. Importing
+# ``app`` above already built the cached settings singleton off ``.env``, so
+# clear it — the next read rebuilds it from defaults.
+for _settings_cls in (PostgresConfig, Settings, SqliteConfig):
+    _settings_cls.model_config["env_file"] = None
+get_settings.cache_clear()
 
 
 _ALL_LICENSED_CLAIMS = TokenClaims(

--- a/deployments/stitch-frontend/public/config.json
+++ b/deployments/stitch-frontend/public/config.json
@@ -3,8 +3,7 @@
   "apiUrl": "http://localhost:8000/api/v1",
   "entityLinkageUrl": "http://localhost:8001/api/v1",
   "stitchLlmUrl": "http://localhost:8002/api/v1",
-  "etlGemUrl": "http://localhost:8101/api/v1",
-  "etlWoodmacUrl": "http://localhost:8102/api/v1",
+  "etlUrl": "http://localhost:8100/api/v1/etl",
   "auth0Domain": "rmi-spd.us.auth0.com",
   "auth0ClientId": "TS1V1soQbccAV1sitFFCfUaIlSwHD2S2",
   "auth0Audience": "https://stitch-api.local"

--- a/deployments/stitch-frontend/src/config/env.js
+++ b/deployments/stitch-frontend/src/config/env.js
@@ -11,8 +11,7 @@ const OPTIONAL_STRING_CONFIG_KEYS = [
   "apiUrl",
   "entityLinkageUrl",
   "stitchLlmUrl",
-  "etlGemUrl",
-  "etlWoodmacUrl",
+  "etlUrl",
 ];
 
 const DEFAULT_CONFIG_PATH = "/config.json";
@@ -63,9 +62,7 @@ function freezeConfig(runtimeConfig) {
       runtimeConfig.entityLinkageUrl || "http://localhost:8001/api/v1",
     stitchLlmBaseUrl:
       runtimeConfig.stitchLlmUrl || "http://localhost:8002/api/v1",
-    etlGemBaseUrl: runtimeConfig.etlGemUrl || "http://localhost:8101/api/v1",
-    etlWoodmacBaseUrl:
-      runtimeConfig.etlWoodmacUrl || "http://localhost:8102/api/v1",
+    etlBaseUrl: runtimeConfig.etlUrl || "http://localhost:8100/api/v1/etl",
   });
 }
 

--- a/deployments/stitch-frontend/src/config/env.test.js
+++ b/deployments/stitch-frontend/src/config/env.test.js
@@ -21,8 +21,7 @@ describe("config/env", () => {
         apiUrl: "https://example.test/api/v1",
         entityLinkageUrl: "https://entity-linkage.test/api/v1",
         stitchLlmUrl: "https://stitch-llm.test/api/v1",
-        etlGemUrl: "https://etl-gem.test/api/v1",
-        etlWoodmacUrl: "https://etl-woodmac.test/api/v1",
+        etlUrl: "https://etl.test/api/v1/etl",
         auth0Domain: "my.auth0.com",
         auth0ClientId: "my-client-id",
         auth0Audience: "https://my-api",
@@ -51,8 +50,7 @@ describe("config/env", () => {
       "https://entity-linkage.test/api/v1",
     );
     expect(config.stitchLlmBaseUrl).toBe("https://stitch-llm.test/api/v1");
-    expect(config.etlGemBaseUrl).toBe("https://etl-gem.test/api/v1");
-    expect(config.etlWoodmacBaseUrl).toBe("https://etl-woodmac.test/api/v1");
+    expect(config.etlBaseUrl).toBe("https://etl.test/api/v1/etl");
     expect(config.appEnv).toBe("test");
 
     expect(config.build.buildId).toBe("gha-123");
@@ -125,8 +123,7 @@ describe("config/env", () => {
         apiUrl: "",
         entityLinkageUrl: "",
         stitchLlmUrl: "",
-        etlGemUrl: "",
-        etlWoodmacUrl: "",
+        etlUrl: "",
       }),
     });
 
@@ -136,8 +133,7 @@ describe("config/env", () => {
     expect(config.apiBaseUrl).toBe("http://localhost:8000/api/v1");
     expect(config.entityLinkageBaseUrl).toBe("http://localhost:8001/api/v1");
     expect(config.stitchLlmBaseUrl).toBe("http://localhost:8002/api/v1");
-    expect(config.etlGemBaseUrl).toBe("http://localhost:8101/api/v1");
-    expect(config.etlWoodmacBaseUrl).toBe("http://localhost:8102/api/v1");
+    expect(config.etlBaseUrl).toBe("http://localhost:8100/api/v1/etl");
   });
 
   it("throws when config fetch fails", async () => {

--- a/deployments/stitch-frontend/src/pages/EtlPage.jsx
+++ b/deployments/stitch-frontend/src/pages/EtlPage.jsx
@@ -290,14 +290,14 @@ export default function EtlPage() {
         <EtlPanel
           title="GEM"
           description="Load GEM oil & gas data from the configured spreadsheet and post it to Stitch."
-          baseUrl={config.etlGemBaseUrl}
+          baseUrl={`${config.etlBaseUrl}/gem`}
           fields={GEM_FIELDS}
           getToken={getToken}
         />
         <EtlPanel
           title="WoodMac"
           description="Fetch WoodMac query results and post them to Stitch."
-          baseUrl={config.etlWoodmacBaseUrl}
+          baseUrl={`${config.etlBaseUrl}/wm`}
           fields={WOODMAC_FIELDS}
           getToken={getToken}
         />

--- a/deployments/stitch-frontend/src/pages/EtlPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/EtlPage.test.jsx
@@ -65,7 +65,7 @@ describe("EtlPage", () => {
       authorizationParams: { audience: "https://stitch-api.local" },
     });
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:8101/api/v1/start",
+      "http://localhost:8100/api/v1/etl/gem/start",
       expect.objectContaining({
         method: "POST",
         headers: expect.objectContaining({
@@ -126,7 +126,7 @@ describe("EtlPage", () => {
     });
 
     expect(fetchMock).toHaveBeenCalledWith(
-      "http://localhost:8102/api/v1/status",
+      "http://localhost:8100/api/v1/etl/wm/status",
     );
   });
 });

--- a/deployments/stitch-frontend/src/test/setup.js
+++ b/deployments/stitch-frontend/src/test/setup.js
@@ -10,8 +10,7 @@ const TEST_CONFIG = {
   apiBaseUrl: "http://localhost:8000/api/v1",
   entityLinkageBaseUrl: "http://localhost:8001/api/v1",
   stitchLlmBaseUrl: "http://localhost:8002/api/v1",
-  etlGemBaseUrl: "http://localhost:8101/api/v1",
-  etlWoodmacBaseUrl: "http://localhost:8102/api/v1",
+  etlBaseUrl: "http://localhost:8100/api/v1/etl",
   auth0: {
     domain: "example.auth0.com",
     clientId: "client-id",


### PR DESCRIPTION
## Summary

Consolidates ETL deployment so the Stitch frontend's ETL page and CI point to a **single ETL API behind one domain**, replacing the previous per-source topology. The consolidated app from `RMI/stitch-etl-poc` now exposes dataset endpoints under `/api/v1/etl/<source>/…`.

**Scope:** This is GEM & WM only. C&C reservoirs is implemented but disabled in ETL. A follow up PR in `stitch-etl-poc` can enable it and be coordinated with a PR here to add `ccr` to source keys and handle any unanticipated bugs.

## What changed

**CI / deployment**
- `.github/workflows/build-and-deploy.yml` — `deploy-etl-gem` + `deploy-etl-woodmac` collapse into one `deploy-etl` job pulling `ghcr.io/rmi/stitch-etl-poc:${ETL_IMAGE_TAG || 'main'}`, deploying container app `<name>-etl`.
- `.github/workflows/close-ci-environment.yml` — teardown targets the single `<name>-etl` app.
- `.github/workflows/azure-static-web-apps.yml` — the two `etl-gem-url` / `etl-woodmac-url` inputs collapse into one `etl-url` (`{container-app-url}/api/v1/etl`).
- `deployments/CI_DEPLOYMENTS.md` — rewritten for the single-app topology; includes the one-time migration notes to delete orphaned deployments

**Frontend**
- `deployments/stitch-frontend/public/config.json` + `src/config/env.js` — single `etlUrl` replaces `etlGemUrl` / `etlWoodmacUrl`.
- `deployments/stitch-frontend/src/pages/EtlPage.jsx` — GEM + WoodMac panels build requests against `${etlBaseUrl}/gem` and `/wm`.
- `…/config/env.test.js`, `…/pages/EtlPage.test.jsx`, `…/test/setup.js` — updated to the single-domain URL shape.

## Deployment & cleanup notes

- **Merging is deploy-safe.** Merges to `main` resolve to the `development` lane, which skips `deploy-etl`, so no ETL redeploy happens on merge itself.
- **Consolidated image already exists.** `RMI/stitch-etl-poc` `main` carries the single-api-app consolidation (PR #11) + ccr build-only routes (PR #12), so `ghcr.io/rmi/stitch-etl-poc:main` (the workflow default) is current. Before the next `staging` / `dress-rehearsal` / prod deploy, confirm the `ETL_IMAGE_TAG` Environment var isn't pinned to a stale/pre-consolidation tag (unset → falls back to `main`).
- **One-time cleanup.** Any PR-into-`production` environment opened before this change may still have old `-etl-gem` / `-etl-woodmac` container apps; the collapsed teardown only removes `<name>-etl`. Delete stragglers manually per the `CI_DEPLOYMENTS.md` ETL migration section.

## Verification
- `make check` clean
- from `stitch-etl-poc` with `feat/add-cc-reservoirs` checked out (see https://github.com/RMI/stitch-etl-poc/pull/15)
	- latest GEM xlsx saved to `./data/gem`
	- run `make reboot-docker-full`
	- login to stitch
	- run GEM & WM ETL pipelines (capped to 50 each)
	- logs clean
	- records in db
	- new sources in UI

## Future Notes

- `WOODMAC_API_KEY` has no CI guard, currently a non-issue in practice (present in every lane that runs `deploy-etl`; `development` skips it), but a `${WOODMAC_API_KEY:?}` check would harden it.
- There's a fallback to `localhost:8100` when `etlUrl` is empty, consider failing loudly/hiding the ETL nav when unconfigured.
- Wire the CCR panel into the ETL page once the `ccr` source key is added and associated ETL endpoint is activated