### PR TITLE
ci: run CI for collaborators and members

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -18,9 +18,9 @@ jobs:
   # dependencies and so repeat this guard explicitly.
   resolve-context:
     if: >-
-      github.event_name != 'pull_request' ||
-      (github.event.pull_request.head.repo.full_name == github.repository &&
-       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
+      ${{ github.event_name != 'pull_request'
+      || (github.event.pull_request.head.repo.full_name == github.repository
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) }}
     uses: ./.github/workflows/resolve-deployment-context.yml
 
   lane-config-validate:
@@ -411,10 +411,10 @@ jobs:
     # The author-association clause repeats the resolve-context guard because
     # !failure() also passes when upstream jobs were skipped by that guard.
     if: >-
-      (!failure() && !cancelled()) &&
-      (github.event_name != 'pull_request' ||
-       (github.event.pull_request.head.repo.full_name == github.repository &&
-        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)))
+      ${{ (!failure() && !cancelled())
+      && (github.event_name != 'pull_request'
+      || (github.event.pull_request.head.repo.full_name == github.repository
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))) }}
     needs: [resolve-context, lane-config-validate, build-frontend, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl]
     uses: ./.github/workflows/azure-static-web-apps.yml
     secrets:
@@ -435,9 +435,9 @@ jobs:
   comment-summary:
     # always() ignores the resolve-context guard's skips, so repeat it here too.
     if: >-
-      always() && github.event_name == 'pull_request' &&
-      github.event.pull_request.head.repo.full_name == github.repository &&
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      ${{ always() && github.event_name == 'pull_request'
+      && github.event.pull_request.head.repo.full_name == github.repository
+      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}
     uses: ./.github/workflows/comment-pr-summary.yml
     secrets: inherit
     needs: [resolve-context, build-api-docker-image, build-entity-linkage-docker-image, build-stitch-llm-docker-image, build-seed-docker-image, deploy-db, run-db-migrations, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl, run-seed, deploy-frontend]

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -7,7 +7,17 @@ on:
   workflow_dispatch:
 
 jobs:
+  # This pipeline deploys per-PR preview environments and needs repository
+  # secrets, which are not available to pull requests from actors without write
+  # access (e.g. Dependabot, which runs as CONTRIBUTOR, or external forks).
+  # Gate on author association so those PRs skip the pipeline instead of failing.
+  # Every job transitively needs resolve-context, so skipping it here skips the
+  # rest -- except deploy-frontend and comment-summary, whose always()/!failure()
+  # conditions ignore skipped dependencies and so repeat this guard explicitly.
   resolve-context:
+    if: >-
+      github.event_name != 'pull_request' ||
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     uses: ./.github/workflows/resolve-deployment-context.yml
 
   lane-config-validate:
@@ -395,7 +405,12 @@ jobs:
     name: "Deploy frontend"
     # ETL deploys are skipped in the development lane; gate on no-failure rather
     # than all-success so the frontend still deploys when they are skipped.
-    if: ${{ !failure() && !cancelled() }}
+    # The author-association clause repeats the resolve-context guard because
+    # !failure() also passes when upstream jobs were skipped by that guard.
+    if: >-
+      (!failure() && !cancelled()) &&
+      (github.event_name != 'pull_request' ||
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
     needs: [resolve-context, lane-config-validate, build-frontend, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl]
     uses: ./.github/workflows/azure-static-web-apps.yml
     secrets:
@@ -414,7 +429,10 @@ jobs:
       production-branch: production
 
   comment-summary:
-    if: ${{ always() && github.event_name == 'pull_request' }}
+    # always() ignores the resolve-context guard's skips, so repeat it here too.
+    if: >-
+      always() && github.event_name == 'pull_request' &&
+      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     uses: ./.github/workflows/comment-pr-summary.yml
     secrets: inherit
     needs: [resolve-context, build-api-docker-image, build-entity-linkage-docker-image, build-stitch-llm-docker-image, build-seed-docker-image, deploy-db, run-db-migrations, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl, run-seed, deploy-frontend]

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,16 +8,19 @@ on:
 
 jobs:
   # This pipeline deploys per-PR preview environments and needs repository
-  # secrets, which are not available to pull requests from actors without write
-  # access (e.g. Dependabot, which runs as CONTRIBUTOR, or external forks).
-  # Gate on author association so those PRs skip the pipeline instead of failing.
-  # Every job transitively needs resolve-context, so skipping it here skips the
-  # rest -- except deploy-frontend and comment-summary, whose always()/!failure()
-  # conditions ignore skipped dependencies and so repeat this guard explicitly.
+  # secrets. On the pull_request event those secrets are withheld from two kinds
+  # of PR: authors without write access (e.g. Dependabot, which runs as
+  # CONTRIBUTOR) and PRs opened from a fork (secrets never flow to fork PRs,
+  # regardless of the author's association). Gate on both so such PRs skip the
+  # pipeline instead of failing. Every job transitively needs resolve-context,
+  # so skipping it here skips the rest -- except deploy-frontend and
+  # comment-summary, whose always()/!failure() conditions ignore skipped
+  # dependencies and so repeat this guard explicitly.
   resolve-context:
     if: >-
       github.event_name != 'pull_request' ||
-      contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
     uses: ./.github/workflows/resolve-deployment-context.yml
 
   lane-config-validate:
@@ -410,7 +413,8 @@ jobs:
     if: >-
       (!failure() && !cancelled()) &&
       (github.event_name != 'pull_request' ||
-       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))
+       (github.event.pull_request.head.repo.full_name == github.repository &&
+        contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)))
     needs: [resolve-context, lane-config-validate, build-frontend, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl]
     uses: ./.github/workflows/azure-static-web-apps.yml
     secrets:
@@ -432,6 +436,7 @@ jobs:
     # always() ignores the resolve-context guard's skips, so repeat it here too.
     if: >-
       always() && github.event_name == 'pull_request' &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)
     uses: ./.github/workflows/comment-pr-summary.yml
     secrets: inherit


### PR DESCRIPTION
dependabot (and other main external collaborators) don't have access to the secrets required for deploy pipeline.

Changes triggers so that pipeline only runs from PRs that can actually access secrets (Opened from this repo, by user with correct permissions)