### PR TITLE
ci: Update workflow triggers to allow-gate human contribs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,3 +21,9 @@ updates:
     groups:
       actions:
         patterns: ["*"]
+    ignore:
+      # v2 emits the update-only `--replace-env-vars` flag on `az containerapp
+      # create`, breaking first (create) deploys of per-PR preview apps. Stay on
+      # v1 until a fixed v2.x ships. See deploy-container.yml for details.
+      - dependency-name: "azure/container-apps-deploy-action"
+        update-types: ["version-update:semver-major"]

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -8,19 +8,34 @@ on:
 
 jobs:
   # This pipeline deploys per-PR preview environments and needs repository
-  # secrets. On the pull_request event those secrets are withheld from two kinds
-  # of PR: authors without write access (e.g. Dependabot, which runs as
-  # CONTRIBUTOR) and PRs opened from a fork (secrets never flow to fork PRs,
-  # regardless of the author's association). Gate on both so such PRs skip the
-  # pipeline instead of failing. Every job transitively needs resolve-context,
-  # so skipping it here skips the rest -- except deploy-frontend and
-  # comment-summary, whose always()/!failure() conditions ignore skipped
-  # dependencies and so repeat this guard explicitly.
+  # secrets, which the pull_request event withholds from two kinds of PR: PRs
+  # opened from a fork (secrets never flow to forks) and bot-authored PRs
+  # (Dependabot in particular always runs without secrets, and other bots can't
+  # be reliably told apart from it). Gate on both so those PRs skip the pipeline
+  # instead of failing: require the PR to originate from this repo (not a fork)
+  # and to be authored by a human -- user.type == 'User' excludes every bot,
+  # current or future, with no denylist to maintain.
+  #
+  # NB: author_association is deliberately NOT used. It reports MEMBER only for
+  # *public* org members, so our private-membership humans surface as
+  # CONTRIBUTOR -- indistinguishable from Dependabot -- which silently skips
+  # every internal PR.
+  #
+  # Future option: to let a human opt a specific bot PR into deploying, add a
+  # label trigger (on.pull_request.types: [..., labeled]) and OR a label check
+  # into these guards, e.g.
+  # contains(github.event.pull_request.labels.*.name, 'deploy-preview').
+  # (Dependabot PRs still receive no secrets even when labeled; those need a
+  # human to re-push the branch under their own PR.)
+  #
+  # Every job transitively needs resolve-context, so skipping it here skips the
+  # rest -- except deploy-frontend and comment-summary, whose always()/!failure()
+  # conditions ignore skipped dependencies and so repeat this guard explicitly.
   resolve-context:
     if: >-
       ${{ github.event_name != 'pull_request'
       || (github.event.pull_request.head.repo.full_name == github.repository
-      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association)) }}
+      && github.event.pull_request.user.type == 'User') }}
     uses: ./.github/workflows/resolve-deployment-context.yml
 
   lane-config-validate:
@@ -408,13 +423,13 @@ jobs:
     name: "Deploy frontend"
     # ETL deploys are skipped in the development lane; gate on no-failure rather
     # than all-success so the frontend still deploys when they are skipped.
-    # The author-association clause repeats the resolve-context guard because
+    # The human-author clause repeats the resolve-context guard because
     # !failure() also passes when upstream jobs were skipped by that guard.
     if: >-
       ${{ (!failure() && !cancelled())
       && (github.event_name != 'pull_request'
       || (github.event.pull_request.head.repo.full_name == github.repository
-      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association))) }}
+      && github.event.pull_request.user.type == 'User')) }}
     needs: [resolve-context, lane-config-validate, build-frontend, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl]
     uses: ./.github/workflows/azure-static-web-apps.yml
     secrets:
@@ -437,7 +452,7 @@ jobs:
     if: >-
       ${{ always() && github.event_name == 'pull_request'
       && github.event.pull_request.head.repo.full_name == github.repository
-      && contains(fromJSON('["OWNER", "MEMBER", "COLLABORATOR"]'), github.event.pull_request.author_association) }}
+      && github.event.pull_request.user.type == 'User' }}
     uses: ./.github/workflows/comment-pr-summary.yml
     secrets: inherit
     needs: [resolve-context, build-api-docker-image, build-entity-linkage-docker-image, build-stitch-llm-docker-image, build-seed-docker-image, deploy-db, run-db-migrations, deploy-api, deploy-entity-linkage, deploy-stitch-llm, deploy-etl, run-seed, deploy-frontend]

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -196,7 +196,15 @@ jobs:
           echo "EOF" >> "$GITHUB_OUTPUT"
 
       - name: Build and deploy Container App
-        uses: azure/container-apps-deploy-action@v2
+        # Pinned to v1 deliberately. v2 chooses the env-var flag from an
+        # ingress/credentials heuristic instead of from whether the app exists:
+        # creating a NEW app without registry credentials makes it emit the
+        # update-only `--replace-env-vars` flag on `az containerapp create`,
+        # which fails with "unrecognized arguments". This breaks every first
+        # (create) deploy of a per-PR preview app (e.g. the API). v1 keys the
+        # flag on app existence and is correct. No fixed v2.x point release
+        # exists yet -- revisit when Azure/container-apps-deploy-action ships one.
+        uses: azure/container-apps-deploy-action@v1
         with:
           imageToDeploy: ${{ inputs.full-image-name }}
           resourceGroup: ${{ vars.AZURE_RESOURCE_GROUP }}


### PR DESCRIPTION
RMI's group memberships are private (by default), so gating on membership means that the humans are indistinguishable from either each other or from robots (at least as far as roles are concerned).

This switches the deploy gate to consider if the PR opener is a human (`User` type) or a bot (`Bot` type), with a note that if we want to permit deployments for bots in the future (ex. Claude opening PRs), we can gate that through labelling the PR.

----

Also reverts the Azure container app deploy action to v1 (and prevents dependabot from re-updating), due to breaking changes in how envvars are passed to the created app