### PR TITLE
docs(agents): import project docs via @-references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -106,3 +106,9 @@ For packages, APIs, frameworks, cloud services, security topics, and operational
 
 * Verify current documentation rather than relying solely on memory.
 * Prefer official documentation, release notes, maintainers, and primary sources.
+
+## Project Docs
+
+@ARCHITECTURE.md
+@HACKING.md
+@CONTRIBUTING.md


### PR DESCRIPTION
Append `@ARCHITECTURE.md`, `@HACKING.md`, `@CONTRIBUTING.md` to `AGENTS.md` so agents pick them up as context without duplicating content.

Supersedes #166 as a simpler and less intrusive approach; maintaining the core spirit of the originally merged `AGENTS.md` while giving the robot access to repo-specific development instructions. 

In particular, addresses https://github.com/RMI/stitch/pull/166#discussion_r3560063068

We no longer duplicate dev workflow instrcutions (like `make` targets, etc.), which could risk things falling out of sync. 
