### PR TITLE
ci: better concurrency groups

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -10,6 +10,16 @@ on:
     branches: [main, production]
   workflow_dispatch:
 
+# Serialize per PR (or per pushed ref) so a new commit -- or the 'no-deploy'
+# label event -- supersedes an in-flight deploy for the same target. The group
+# key deliberately omits the event type so 'labeled' and 'synchronize' share a
+# lane and can cancel each other; github.workflow keeps this separate from the
+# node/python check workflows. cancel-in-progress is limited to pull_request so
+# main/production deploys run to completion rather than being killed mid-migration.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   # This pipeline deploys per-PR preview environments and needs repository
   # secrets, which the pull_request event withholds from two kinds of PR: PRs

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -14,11 +14,20 @@ on:
 # label event -- supersedes an in-flight deploy for the same target. The group
 # key deliberately omits the event type so 'labeled' and 'synchronize' share a
 # lane and can cancel each other; github.workflow keeps this separate from the
-# node/python check workflows. cancel-in-progress is limited to pull_request so
-# main/production deploys run to completion rather than being killed mid-migration.
+# node/python check workflows.
+#
+# cancel-in-progress fires for code changes (synchronize/opened/reopened) and for
+# the 'no-deploy' label specifically, but NOT for other label changes: this
+# workflow triggers on every labeled/unlabeled event, and adding an unrelated
+# label (e.g. 'bug') must not interrupt and restart an in-flight deploy. Non-PR
+# events (push/dispatch to main/production) are never cancelled, so they run their
+# migrations to completion.
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+  cancel-in-progress: >-
+    ${{ github.event_name == 'pull_request'
+    && ((github.event.action != 'labeled' && github.event.action != 'unlabeled')
+    || github.event.label.name == 'no-deploy') }}
 
 jobs:
   # This pipeline deploys per-PR preview environments and needs repository

--- a/.github/workflows/close-ci-environment.yml
+++ b/.github/workflows/close-ci-environment.yml
@@ -11,6 +11,15 @@ on:
     types: [closed, labeled]
   workflow_call:
 
+# Serialize teardowns for a PR, but never cancel one in flight: teardown must run
+# to completion so it doesn't leak cloud resources. cancel-in-progress is false
+# (unlike the deploy/check workflows) precisely because this job is the cleanup.
+# Kept in its own lane -- NOT shared with the deploy group -- because both fire on
+# 'labeled'; a shared cancelling group could drop the teardown nondeterministically.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: false
+
 jobs:
   # 'labeled' fires for every label, so gate teardown to the two cases that want
   # it: the PR closing, or the 'no-deploy' label specifically being added. All

--- a/.github/workflows/node.yml
+++ b/.github/workflows/node.yml
@@ -12,7 +12,7 @@ on:
 
 name: Node Package Checks
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event_action }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -12,7 +12,7 @@ on:
 
 name: Python Package Checks
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}-${{ github.event_name }}-${{ github.event_action }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
Set concurrency groups so that PRs have checks and deploys that cancel when a new sync event comes in, or a label (`no-deploy`) is applied.