### PR TITLE
STIT-535 keep filter dropdowns visible while resource query is loading

### DIFF
--- a/deployments/stitch-frontend/src/components/ResourcesView.jsx
+++ b/deployments/stitch-frontend/src/components/ResourcesView.jsx
@@ -181,13 +181,11 @@ export default function ResourcesView({ className = "", endpoint }) {
           <p className="mb-2 text-xs font-semibold uppercase tracking-wide text-ink-muted">
             Filters
           </p>
-          {data && (
-            <FilterBar
-              endpoint={endpoint}
-              filters={filters}
-              onFiltersChange={handleFiltersChange}
-            />
-          )}
+          <FilterBar
+            endpoint={endpoint}
+            filters={filters}
+            onFiltersChange={handleFiltersChange}
+          />
         </div>
       </div>
 

--- a/deployments/stitch-frontend/src/components/ResourcesView.test.jsx
+++ b/deployments/stitch-frontend/src/components/ResourcesView.test.jsx
@@ -247,6 +247,29 @@ describe("ResourcesView", () => {
     expect(screen.getByTestId("filter-bar")).toBeInTheDocument();
   });
 
+  it("keeps showing the previous data (assets count, rows) during a background refetch", () => {
+    // With placeholderData: keepPreviousData on the query, a refetch
+    // triggered by a filter/page/sort change keeps `data` populated:
+    // isFetching is true but isLoading is false, and data is still the
+    // previous result rather than resetting to undefined.
+    vi.mocked(useResources).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockResourceData,
+      isLoading: false,
+      isFetching: true,
+    });
+
+    renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);
+
+    expect(
+      screen.getByText(`${mockResourceData.total_count} assets`),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/awaiting resource count/i),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText("Burgan Field")).toBeInTheDocument();
+  });
+
   it("shows filter bar when the current result set is empty", () => {
     vi.mocked(useResources).mockReturnValue({
       ...defaultHookReturn,
@@ -275,6 +298,20 @@ describe("ResourcesView", () => {
       vi.mocked(useResources).mockReturnValue({
         ...defaultHookReturn,
         data: { ...mockResourceData, total_pages: 5, total_count: 250 },
+      });
+
+      renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);
+
+      expect(screen.getByLabelText("Previous page")).toBeInTheDocument();
+      expect(screen.getByLabelText("Next page")).toBeInTheDocument();
+    });
+
+    it("keeps pagination visible during a background refetch", () => {
+      vi.mocked(useResources).mockReturnValue({
+        ...defaultHookReturn,
+        data: { ...mockResourceData, total_pages: 3, total_count: 150 },
+        isLoading: false,
+        isFetching: true,
       });
 
       renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);

--- a/deployments/stitch-frontend/src/components/ResourcesView.test.jsx
+++ b/deployments/stitch-frontend/src/components/ResourcesView.test.jsx
@@ -226,10 +226,25 @@ describe("ResourcesView", () => {
     ).toBeInTheDocument();
   });
 
-  it("does not show filter bar when no data", () => {
+  it("shows filter bar even before any data has loaded", () => {
     renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);
 
-    expect(screen.queryByTestId("filter-bar")).not.toBeInTheDocument();
+    expect(screen.getByTestId("filter-bar")).toBeInTheDocument();
+  });
+
+  it("keeps filter bar visible while a new query is loading", () => {
+    // Mirrors a refetch triggered by a filter change: TanStack Query resets
+    // `data` to undefined and `isLoading` to true for the new query key.
+    vi.mocked(useResources).mockReturnValue({
+      ...defaultHookReturn,
+      data: undefined,
+      isLoading: true,
+      isFetching: true,
+    });
+
+    renderWithQueryClient(<ResourcesView endpoint={ENDPOINT} />);
+
+    expect(screen.getByTestId("filter-bar")).toBeInTheDocument();
   });
 
   it("shows filter bar when the current result set is empty", () => {

--- a/deployments/stitch-frontend/src/queries/resources.js
+++ b/deployments/stitch-frontend/src/queries/resources.js
@@ -1,3 +1,4 @@
+import { keepPreviousData } from "@tanstack/react-query";
 import {
   getResourceFilterOptions,
   getResource,
@@ -90,6 +91,10 @@ export const resourceQueries = {
       }),
     enabled: false,
     staleTime: DEFAULT_STALE_TIME,
+    // Keeps showing the previous page's rows/filters while a new
+    // page/filter/sort combination fetches, instead of `data` (and anything
+    // gated on it) flashing away for the duration of the request.
+    placeholderData: keepPreviousData,
   }),
 
   filterOptions: (config, endpoint = "resources", field) => ({

--- a/deployments/stitch-frontend/src/queries/resources.test.js
+++ b/deployments/stitch-frontend/src/queries/resources.test.js
@@ -1,0 +1,13 @@
+import { describe, it, expect } from "vitest";
+import { keepPreviousData } from "@tanstack/react-query";
+import { resourceQueries } from "./resources";
+
+describe("resourceQueries.list", () => {
+  it("keeps previous page data visible while a new page/filter/sort fetches", () => {
+    const config = { apiBaseUrl: "http://localhost:8000/api/v1" };
+
+    const query = resourceQueries.list(config, "resources", 1, 10, {});
+
+    expect(query.placeholderData).toBe(keepPreviousData);
+  });
+});


### PR DESCRIPTION
FilterBar was gated on `data &&`, so it unmounted whenever the resources query re-fetched with a new query key (e.g. after applying a filter), since data resets to undefined until the fetch resolves. Filter options come from an independent query, so FilterBar can safely stay mounted regardless of the list's loading state.