### PR TITLE
feat(client): add methods to bulk access oil-gas-field-sources

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -364,10 +364,10 @@ jobs:
       deployment-label: entity-linkage
       # Keep staging / dress-rehearsal always-on; development scales to zero.
       min-replicas: ${{ needs.resolve-context.outputs.deployment-lane != 'development' && '1' || '' }}
-      # Unoptimized service; needs more than the default ~0.5 vCPU / 1 GiB.
-      # 4 GiB on the Consumption profile is only valid paired with 2.0 vCPU.
-      cpu: "2.0"
-      memory: "4.0Gi"
+      # Deliberately unpinned: takes the platform default (~0.5 vCPU / 1 GiB),
+      # the same as the API. This service is I/O-bound waiting on sequential API
+      # responses, so the 2.0 vCPU it used to request bought little while giving
+      # the batch pass 4x the CPU of the API it hammers.
 
   deploy-stitch-llm:
     name: "Deploy stitch-llm"

--- a/packages/stitch-client/src/stitch/client/__init__.py
+++ b/packages/stitch-client/src/stitch/client/__init__.py
@@ -1,4 +1,4 @@
-from .async_client import AsyncStitchClient
+from .async_client import MAX_PAGE_SIZE, AsyncStitchClient
 from .auth import (
     STITCH_CLIENT_BEARER_TOKEN_ENV_VAR,
     env_bearer_token_headers_provider,
@@ -7,6 +7,7 @@ from .errors import StitchAPIError
 
 __all__ = [
     "AsyncStitchClient",
+    "MAX_PAGE_SIZE",
     "STITCH_CLIENT_BEARER_TOKEN_ENV_VAR",
     "StitchAPIError",
     "env_bearer_token_headers_provider",

--- a/packages/stitch-client/src/stitch/client/async_client.py
+++ b/packages/stitch-client/src/stitch/client/async_client.py
@@ -268,6 +268,7 @@ class AsyncStitchClient:
             # which a concurrent insert can land behind the paging cursor and
             # shift every later page, silently skipping rows. Sorting on the
             # source id makes new rows append past the last page instead.
+            # As such, `sort_by` and `sort_order` are deliberately NOT overrideable
             "sort_by": "id",
             "sort_order": "asc",
         }

--- a/packages/stitch-client/src/stitch/client/async_client.py
+++ b/packages/stitch-client/src/stitch/client/async_client.py
@@ -254,6 +254,7 @@ class AsyncStitchClient:
                 dropped -- only a token holding *none* of them gets a 403.
 
         Raises:
+            TypeError: if ``source`` is a bare string rather than a sequence.
             ValueError: if ``page``/``page_size`` are out of range, or ``source``
                 is an empty sequence.
             StitchAPIError: on a non-2xx response (403 when the token holds no
@@ -271,6 +272,15 @@ class AsyncStitchClient:
             "sort_order": "asc",
         }
         if source is not None:
+            if isinstance(source, (str, bytes)):
+                # A bare string is itself a Sequence, so list("gem") would
+                # expand to ["g", "e", "m"] and the request would go out as
+                # source=g&source=e&source=m. The API rejects those as invalid
+                # enum values, so the 422 surfaces far from the actual typo.
+                raise TypeError(
+                    "source must be a sequence of source keys, not a bare "
+                    f"{type(source).__name__} (did you mean [{source!r}]?)"
+                )
             source_keys = list(source)
             if not source_keys:
                 # httpx drops an empty sequence from the query string entirely,
@@ -297,8 +307,8 @@ class AsyncStitchClient:
         """Yield Oil & Gas Field source records one page at a time.
 
         Bounded-memory full scan: only a single page is held in memory at once,
-        so callers can fold the whole result set without materializing it. Page
-        -termination logic mirrors :meth:`iter_oil_gas_fields`.
+        so callers can fold the whole result set without materializing it.
+        Page-termination logic mirrors :meth:`iter_oil_gas_fields`.
         """
         pages_fetched = 0
         page = start_page

--- a/packages/stitch-client/src/stitch/client/async_client.py
+++ b/packages/stitch-client/src/stitch/client/async_client.py
@@ -104,6 +104,13 @@ class AsyncStitchClient:
         name: str | None = None,
         country: str | None = None,
     ) -> dict[str, Any]:
+        """One page of Oil & Gas Field resources.
+
+        Raises:
+            ValueError: if ``page``/``page_size`` are out of range.
+            StitchAPIError: on a non-2xx response.
+        """
+        self._validate_page_params(page, page_size)
         params: dict[str, Any] = {"page": page, "page_size": page_size}
         if q is not None:
             params["q"] = q
@@ -399,7 +406,11 @@ class AsyncStitchClient:
 
     @staticmethod
     def _validate_page_params(page: int, page_size: int) -> None:
-        """Reject out-of-range pagination locally rather than on a server 422."""
+        """Reject out-of-range pagination locally rather than on a server 422.
+
+        Applied by every paging entry point, so the ``iter_``/``collect_``
+        wrappers inherit it through the page fetch they delegate to.
+        """
         if page < 1:
             raise ValueError(f"page must be >= 1, got {page}")
         if not 1 <= page_size <= MAX_PAGE_SIZE:

--- a/packages/stitch-client/src/stitch/client/async_client.py
+++ b/packages/stitch-client/src/stitch/client/async_client.py
@@ -2,15 +2,18 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import AsyncIterator, Callable, Mapping
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
 from typing import Any
 
 import httpx
-from stitch.ogsi.model import OGFieldResource
+from stitch.ogsi.model import OGFieldResource, OGSISrcKey
 
 from .errors import StitchAPIError
 
 logger = logging.getLogger("stitch.client")
+
+MAX_PAGE_SIZE = 200
+"""Server cap on ``page_size`` (``PaginationParams.page_size`` is ``Field(50, ge=1, le=200)``)."""
 
 
 class AsyncStitchClient:
@@ -217,6 +220,113 @@ class AsyncStitchClient:
 
         return items, pages_fetched
 
+    async def list_oil_gas_field_sources_page(
+        self,
+        *,
+        page: int = 1,
+        page_size: int = 50,
+        source: Sequence[OGSISrcKey] | None = None,
+    ) -> dict[str, Any]:
+        """One page of Oil & Gas Field *source* records.
+
+        Unlike :meth:`list_oil_gas_fields_page`, each item is a flat source view
+        -- every business field plus ``id`` and ``source`` -- not an
+        ``{"id": ..., "data": {...}}`` resource envelope. ``source_record`` is
+        never included; use the per-id detail route for that.
+
+        Only sources reachable through an ACTIVE membership on a live
+        (non-merged) resource are listed, so absence from this result does not
+        prove a source is absent from the database.
+
+        Args:
+            page: 1-based page number.
+            page_size: rows per page, 1..``MAX_PAGE_SIZE``.
+            source: restrict to these source keys; omit for every licensed
+                source. Note a token holding only *some* ``source:read:<key>``
+                permissions gets a 200 with the unlicensed rows silently
+                dropped -- only a token holding *none* of them gets a 403.
+
+        Raises:
+            ValueError: if ``page``/``page_size`` are out of range, or ``source``
+                is an empty sequence.
+            StitchAPIError: on a non-2xx response (403 when the token holds no
+                ``source:read:<key>`` permission at all).
+        """
+        self._validate_page_params(page, page_size)
+        params: dict[str, Any] = {
+            "page": page,
+            "page_size": page_size,
+            # Stable forward scan. The route defaults to name-ascending, under
+            # which a concurrent insert can land behind the paging cursor and
+            # shift every later page, silently skipping rows. Sorting on the
+            # source id makes new rows append past the last page instead.
+            "sort_by": "id",
+            "sort_order": "asc",
+        }
+        if source is not None:
+            source_keys = list(source)
+            if not source_keys:
+                # httpx drops an empty sequence from the query string entirely,
+                # which the API reads as "no filter" -- i.e. every source, the
+                # exact opposite of what the caller asked for.
+                raise ValueError("source must not be empty when provided")
+            params["source"] = source_keys
+        payload = await self._request_json(
+            method="GET",
+            path="/oil-gas-field-sources/",
+            operation="GET /oil-gas-field-sources/",
+            params=params,
+        )
+        return self._expect_dict(payload, "GET /oil-gas-field-sources/")
+
+    async def iter_oil_gas_field_sources(
+        self,
+        *,
+        start_page: int = 1,
+        page_size: int = 50,
+        max_pages: int | None = None,
+        source: Sequence[OGSISrcKey] | None = None,
+    ) -> AsyncIterator[dict[str, Any]]:
+        """Yield Oil & Gas Field source records one page at a time.
+
+        Bounded-memory full scan: only a single page is held in memory at once,
+        so callers can fold the whole result set without materializing it. Page
+        -termination logic mirrors :meth:`iter_oil_gas_fields`.
+        """
+        pages_fetched = 0
+        page = start_page
+
+        while True:
+            if max_pages is not None and pages_fetched >= max_pages:
+                return
+
+            payload = await self.list_oil_gas_field_sources_page(
+                page=page,
+                page_size=page_size,
+                source=source,
+            )
+            raw_item_count = self._item_count(payload)
+            page_items = self._extract_items(payload)
+            pages_fetched += 1
+
+            if raw_item_count == 0:
+                return
+
+            for item in page_items:
+                yield item
+
+            total_pages = payload.get("total_pages")
+            if isinstance(total_pages, int) and page >= total_pages:
+                return
+
+            if not isinstance(total_pages, int) and not page_items:
+                return
+
+            if raw_item_count < page_size:
+                return
+
+            page += 1
+
     async def get_oil_gas_field_detail(self, resource_id: int) -> dict[str, Any]:
         payload = await self._request_json(
             method="GET",
@@ -286,6 +396,16 @@ class AsyncStitchClient:
         )
         self._raise_for_status(response, operation)
         return response.json()
+
+    @staticmethod
+    def _validate_page_params(page: int, page_size: int) -> None:
+        """Reject out-of-range pagination locally rather than on a server 422."""
+        if page < 1:
+            raise ValueError(f"page must be >= 1, got {page}")
+        if not 1 <= page_size <= MAX_PAGE_SIZE:
+            raise ValueError(
+                f"page_size must be between 1 and {MAX_PAGE_SIZE}, got {page_size}"
+            )
 
     @staticmethod
     def _expect_dict(payload: Any, operation: str) -> dict[str, Any]:

--- a/packages/stitch-client/tests/test_async_client.py
+++ b/packages/stitch-client/tests/test_async_client.py
@@ -14,6 +14,7 @@ from stitch.client import (
     StitchAPIError,
     env_bearer_token_headers_provider,
 )
+from stitch.client.async_client import MAX_PAGE_SIZE
 
 
 def make_client(
@@ -685,6 +686,302 @@ async def test_create_merge_candidate_sends_expected_request() -> None:
         "path": "/api/v1/oil-gas-fields/merge-candidates",
         "body": {"resource_ids": [7, 8]},
     }
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_list_oil_gas_field_sources_page_sends_expected_request() -> None:
+    """Path, method, and the stable-scan sort defaults reach the wire."""
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["method"] = request.method
+        captured["path"] = request.url.path
+        captured["query"] = request.url.query.decode("utf-8")
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {"id": 1, "source": "gem", "name": "Alpha", "country": "USA"}
+                ],
+                "total_count": 1,
+                "page": 1,
+                "page_size": 50,
+                "total_pages": 1,
+            },
+        )
+
+    client, raw_client = make_client(handler)
+
+    payload = await client.list_oil_gas_field_sources_page()
+
+    assert payload["items"][0]["source"] == "gem"
+    assert captured == {
+        "method": "GET",
+        "path": "/api/v1/oil-gas-field-sources/",
+        "query": "page=1&page_size=50&sort_by=id&sort_order=asc",
+    }
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_list_oil_gas_field_sources_page_repeats_source_param() -> None:
+    """A sequence of source keys serializes as repeated params, not a CSV value."""
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        # dict(request.url.params) would collapse the repeats to the first value.
+        captured["source"] = request.url.params.get_list("source")
+        captured["query"] = request.url.query.decode("utf-8")
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    await client.list_oil_gas_field_sources_page(source=["gem", "wm"])
+
+    assert captured["source"] == ["gem", "wm"]
+    assert captured["query"].endswith("&source=gem&source=wm")
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_list_oil_gas_field_sources_page_omits_source_when_unset() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["query"] = request.url.query.decode("utf-8")
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    await client.list_oil_gas_field_sources_page()
+
+    assert "source" not in captured["query"]
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_list_oil_gas_field_sources_page_rejects_empty_source() -> None:
+    """An empty sequence vanishes from the query string and would select *every*
+    source, so it is refused before the request goes out."""
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(ValueError) as exc_info:
+        await client.list_oil_gas_field_sources_page(source=[])
+
+    assert str(exc_info.value) == "source must not be empty when provided"
+    assert called is False
+
+    await raw_client.aclose()
+
+
+@pytest.mark.parametrize("page_size", [0, 201, 1000])
+@pytest.mark.anyio
+async def test_list_oil_gas_field_sources_page_rejects_out_of_range_page_size(
+    page_size: int,
+) -> None:
+    """The server caps page_size at 200; fail locally instead of on a 422."""
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(ValueError) as exc_info:
+        await client.list_oil_gas_field_sources_page(page_size=page_size)
+
+    assert "page_size must be between 1 and 200" in str(exc_info.value)
+    assert called is False
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_list_oil_gas_field_sources_page_accepts_max_page_size() -> None:
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["page_size"] = request.url.params["page_size"]
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    await client.list_oil_gas_field_sources_page(page_size=MAX_PAGE_SIZE)
+
+    assert captured["page_size"] == "200"
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_iter_oil_gas_field_sources_streams_items_across_pages() -> None:
+    calls: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        page = int(request.url.params["page"])
+        calls.append(page)
+        payloads = {
+            1: {
+                "items": [
+                    {"id": 1, "source": "gem", "name": "Alpha"},
+                    {"id": 2, "source": "gem", "name": "Beta"},
+                ],
+                "total_count": 3,
+                "total_pages": 2,
+            },
+            2: {
+                "items": [{"id": 3, "source": "gem", "name": "Gamma"}],
+                "total_count": 3,
+                "total_pages": 2,
+            },
+        }
+        return httpx.Response(200, json=payloads[page])
+
+    client, raw_client = make_client(handler)
+
+    collected = [
+        item["id"]
+        async for item in client.iter_oil_gas_field_sources(page_size=2, source=["gem"])
+    ]
+
+    assert calls == [1, 2]
+    assert collected == [1, 2, 3]
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_iter_oil_gas_field_sources_forwards_source_on_every_page() -> None:
+    """The source filter must survive into page 2+, not just the first request."""
+    captured: list[list[str]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured.append(request.url.params.get_list("source"))
+        page = int(request.url.params["page"])
+        return httpx.Response(
+            200,
+            json={
+                "items": [{"id": page * 10 + 1}, {"id": page * 10 + 2}],
+                "total_count": 100,
+                "total_pages": 50,
+            },
+        )
+
+    client, raw_client = make_client(handler)
+
+    collected = [
+        item["id"]
+        async for item in client.iter_oil_gas_field_sources(
+            page_size=2, max_pages=2, source=["gem"]
+        )
+    ]
+
+    assert collected == [11, 12, 21, 22]
+    assert captured == [["gem"], ["gem"]]
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_iter_oil_gas_field_sources_yields_nothing_when_empty() -> None:
+    """An empty first page ends the walk without a second request."""
+    calls: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls.append(int(request.url.params["page"]))
+        return httpx.Response(
+            200,
+            json={
+                "items": [],
+                "total_count": 0,
+                "page": 1,
+                "page_size": 50,
+                "total_pages": 0,
+            },
+        )
+
+    client, raw_client = make_client(handler)
+
+    collected = [item async for item in client.iter_oil_gas_field_sources()]
+
+    assert calls == [1]
+    assert collected == []
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_iter_oil_gas_field_sources_stops_on_short_page() -> None:
+    """Terminates on a short page even when total_pages is absent."""
+    calls: list[int] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        page = int(request.url.params["page"])
+        calls.append(page)
+        payloads = {
+            1: {"items": [{"id": 1}, {"id": 2}]},
+            2: {"items": [{"id": 3}]},
+        }
+        return httpx.Response(200, json=payloads[page])
+
+    client, raw_client = make_client(handler)
+
+    collected = [
+        item["id"] async for item in client.iter_oil_gas_field_sources(page_size=2)
+    ]
+
+    assert calls == [1, 2]
+    assert collected == [1, 2, 3]
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_list_oil_gas_field_sources_page_raises_on_forbidden() -> None:
+    """A token carrying no source:read:<key> gets a 403 the caller can branch on."""
+    detail = "Missing required permission(s): source:read:gem"
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"detail": detail})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(StitchAPIError) as exc_info:
+        await client.list_oil_gas_field_sources_page(source=["gem"])
+
+    assert exc_info.value.status_code == 403
+    assert "source:read:" in (exc_info.value.response_text or "")
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_iter_oil_gas_field_sources_propagates_forbidden() -> None:
+    """The 403 surfaces on first iteration rather than as an empty stream."""
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(403, json={"detail": "Missing required permission(s)"})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(StitchAPIError) as exc_info:
+        [item async for item in client.iter_oil_gas_field_sources(source=["gem"])]
+
+    assert exc_info.value.status_code == 403
 
     await raw_client.aclose()
 

--- a/packages/stitch-client/tests/test_async_client.py
+++ b/packages/stitch-client/tests/test_async_client.py
@@ -857,6 +857,52 @@ async def test_list_oil_gas_field_sources_page_rejects_empty_source() -> None:
     await raw_client.aclose()
 
 
+@pytest.mark.parametrize("source", ["gem", b"gem"])
+@pytest.mark.anyio
+async def test_list_oil_gas_field_sources_page_rejects_a_bare_string_source(
+    source: str | bytes,
+) -> None:
+    """A bare string is a Sequence, so list("gem") would send source=g&source=e
+    &source=m. The API rejects those as invalid enum values, surfacing a 422 far
+    from the actual mistake -- so refuse before the request."""
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(TypeError) as exc_info:
+        await client.list_oil_gas_field_sources_page(source=source)
+
+    assert "not a bare" in str(exc_info.value)
+    assert called is False
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_iter_oil_gas_field_sources_rejects_a_bare_string_source() -> None:
+    """The guard reaches the streaming wrapper through the page fetch."""
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(TypeError):
+        [item async for item in client.iter_oil_gas_field_sources(source="gem")]
+
+    assert called is False
+
+    await raw_client.aclose()
+
+
 @pytest.mark.parametrize("page_size", [0, 201, 1000])
 @pytest.mark.anyio
 async def test_list_oil_gas_field_sources_page_rejects_out_of_range_page_size(

--- a/packages/stitch-client/tests/test_async_client.py
+++ b/packages/stitch-client/tests/test_async_client.py
@@ -10,11 +10,11 @@ from stitch.ogsi.model import OGFieldResource
 
 from stitch.client import (
     AsyncStitchClient,
+    MAX_PAGE_SIZE,
     STITCH_CLIENT_BEARER_TOKEN_ENV_VAR,
     StitchAPIError,
     env_bearer_token_headers_provider,
 )
-from stitch.client.async_client import MAX_PAGE_SIZE
 
 
 def make_client(
@@ -688,6 +688,77 @@ async def test_create_merge_candidate_sends_expected_request() -> None:
     }
 
     await raw_client.aclose()
+
+
+@pytest.mark.parametrize("page_size", [0, 201, 1000])
+@pytest.mark.anyio
+async def test_list_oil_gas_fields_page_rejects_out_of_range_page_size(
+    page_size: int,
+) -> None:
+    """The resource list route shares the server's 1..200 cap."""
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(ValueError) as exc_info:
+        await client.list_oil_gas_fields_page(page_size=page_size)
+
+    assert "page_size must be between 1 and 200" in str(exc_info.value)
+    assert called is False
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_iter_oil_gas_fields_rejects_out_of_range_page_size() -> None:
+    """The guard reaches the iter_/collect_ wrappers through the page fetch."""
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(ValueError):
+        [item async for item in client.iter_oil_gas_fields(page_size=201)]
+
+    assert called is False
+
+    await raw_client.aclose()
+
+
+@pytest.mark.anyio
+async def test_list_oil_gas_fields_page_rejects_page_below_one() -> None:
+    called = False
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        nonlocal called
+        called = True
+        return httpx.Response(200, json={"items": [], "total_pages": 1})
+
+    client, raw_client = make_client(handler)
+
+    with pytest.raises(ValueError, match="page must be >= 1"):
+        await client.list_oil_gas_fields_page(page=0)
+
+    assert called is False
+
+    await raw_client.aclose()
+
+
+def test_max_page_size_is_publicly_exported() -> None:
+    """Callers sizing a full scan should not reach into the private module."""
+    import stitch.client
+
+    assert stitch.client.MAX_PAGE_SIZE == 200
+    assert "MAX_PAGE_SIZE" in stitch.client.__all__
 
 
 @pytest.mark.anyio


### PR DESCRIPTION
Contributes to https://rmi1.atlassian.net/browse/STIT-529

Support [etl-poc PR](https://github.com/RMI/stitch-etl-poc/pull/23) to deduplicate before POST

----

Contributes to [STIT-529](https://rmi1.atlassian.net/browse/STIT-529). Supports [stitch-etl-poc#23](https://github.com/RMI/stitch-etl-poc/pull/23), which needs to read existing sources back before POSTing so a second ETL run doesn't duplicate them.

## What changed

**`AsyncStitchClient` gains two source-listing methods** (`9a8965e`) — `list_oil_gas_field_sources_page` and `iter_oil_gas_field_sources`, mirroring the existing `*_oil_gas_fields` pair. Unlike the resource route, each item is a flat source view (every business field plus `id` and `source`), which is what makes a one-pass fingerprint index possible.

Three things in there are load-bearing rather than stylistic:

- **`sort_by=id` is pinned internally, not exposed.** The route defaults to name-ascending, under which a concurrent insert lands *behind* the paging cursor and shifts every later page — silently skipping rows during a full scan. Sorting on the source id makes new rows append past the last page.
- **An empty `source` sequence raises.** httpx drops it from the query string entirely, which the API reads as "no filter" — i.e. all seven sources, the opposite of the intent.
- **Partial `source:read:*` grants return 200 with rows silently dropped**, not 403. Documented on the method so callers don't treat an empty result as authoritative.

**Client-side pagination guard** (`d37583f`) — `page_size` is bounded 1..200 (the server's `PaginationParams` cap) and `page >= 1`, on both routes, failing before the request rather than on a server 422. `MAX_PAGE_SIZE` is now exported from `stitch.client` so callers sizing a full scan don't reach into `async_client`.

**Bare-string `source` guard** (`0438660`) — `str` satisfies `Sequence`, so `source="gem"` expanded to `source=g&source=e&source=m`; the API rejected those as invalid enum values and the 422 surfaced far from the typo. Now a `TypeError` naming the fix. Caught by Copilot review.

**Unrelated:** `68558ca` drops the CPU/memory pin on the entity-linkage deploy job now that it streams via `iter_oil_gas_fields` rather than materializing the full set.

## AI assistance

Claude drafted the two client methods, the pagination and string guards, and all 13 new tests, working from the existing `list_oil_gas_fields_page` / `iter_oil_gas_fields` implementations. The `sort_by=id` decision came out of reading the API's `_build_sort_clauses` to check what offset pagination actually does under a concurrent write.

## Tests

`packages/stitch-client/tests/test_async_client.py`, 46 → 55 cases. New coverage: request shape including the pinned sort params; repeated `source` params reaching the wire (asserted on the raw query string, since `dict(url.params)` collapses repeats); `source` forwarded on page 2+, not just the first request; empty `source` and bare-string `source` rejected before any request; `page_size` bounds on both routes and through the generator; multi-page streaming, empty first page, short-page termination; 403 raising `StitchAPIError` with `status_code`, and propagating out of the async generator rather than yielding empty.

`make py-test` — 543 passed. `make py-lint` / `make py-format-check` clean.

## Follow-up

The four-condition pagination termination loop is now duplicated across three methods (`iter_oil_gas_fields`, `collect_oil_gas_fields`, `iter_oil_gas_field_sources`). Copied verbatim rather than refactored here to keep this PR to one concern — tech-debt ticket to follow.

[STIT-529]: https://rmi1.atlassian.net/browse/STIT-529?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ