### PR TITLE
ci: workarounds for scale to zero

### DIFF
--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -283,6 +283,43 @@ jobs:
             --resource-group "${AZURE_RESOURCE_GROUP}" \
             --yaml /tmp/app.yaml
 
+      - name: Widen the scale-to-zero cooldown
+        # How long an app stays up after its last request before scaling to
+        # zero. Azure's default is 300s, so a five-minute pause costs a cold
+        # start. 900s covers the ordinary gaps inside a working session --
+        # reading code, writing a comment, a short interruption -- while still
+        # dropping to zero when someone stops for the day.
+        #
+        # There is no `--cooldown-period` flag on `az containerapp update`, so
+        # this uses the same show -> mutate -> update --yaml round-trip as the
+        # volume mount above, and runs after it so it re-reads that result.
+        #
+        # Skipped for always-on apps: an app that never scales to zero has no
+        # use for a cooldown.
+        if: ${{ inputs.min-replicas == '' }}
+        shell: bash
+        env:
+          AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
+          COOLDOWN_SECONDS: "900"
+        run: |
+          set -euo pipefail
+
+          az containerapp show \
+            --name "${{ inputs.container-app-name }}" \
+            --resource-group "${AZURE_RESOURCE_GROUP}" \
+            --output json > /tmp/app-cooldown.json
+
+          jq \
+            --argjson cd "${COOLDOWN_SECONDS}" \
+            'del(.systemData)
+             | .properties.template.scale.cooldownPeriod = $cd' \
+            /tmp/app-cooldown.json > /tmp/app-cooldown.yaml
+
+          az containerapp update \
+            --name "${{ inputs.container-app-name }}" \
+            --resource-group "${AZURE_RESOURCE_GROUP}" \
+            --yaml /tmp/app-cooldown.yaml
+
       - name: Export application URL
         id: export-app-url
         shell: bash

--- a/.github/workflows/deploy-container.yml
+++ b/.github/workflows/deploy-container.yml
@@ -292,11 +292,22 @@ jobs:
         #
         # There is no `--cooldown-period` flag on `az containerapp update`, so
         # this uses the same show -> mutate -> update --yaml round-trip as the
-        # volume mount above, and runs after it so it re-reads that result.
+        # volume mount above.
         #
         # Skipped for always-on apps: an app that never scales to zero has no
         # use for a cooldown.
+        #
+        # `continue-on-error` because this is a comfort setting, not a
+        # correctness one, and for `api` and `stitch-llm` on a scale-to-zero
+        # lane it is the only post-deploy ARM write -- the reassert step above
+        # is skipped when no cpu/memory/replica overrides are passed. The deploy
+        # action has just created a revision, so this can lose a race and get a
+        # 409 while that is still provisioning. Failing the job over it would
+        # cascade: every later service and the frontend deploy depend on this
+        # one, so a PR would lose its whole preview environment over a cooldown
+        # tweak. A failed step stays visible in the run summary.
         if: ${{ inputs.min-replicas == '' }}
+        continue-on-error: true
         shell: bash
         env:
           AZURE_RESOURCE_GROUP: ${{ vars.AZURE_RESOURCE_GROUP }}
@@ -308,6 +319,20 @@ jobs:
             --name "${{ inputs.container-app-name }}" \
             --resource-group "${AZURE_RESOURCE_GROUP}" \
             --output json > /tmp/app-cooldown.json
+
+          # Read before writing: the value survives a redeploy, so on most runs
+          # it is already correct and the write would be a no-op that can still
+          # fail. Only pay for the round-trip when it actually changes something.
+          current="$(jq -r \
+            '.properties.template.scale.cooldownPeriod // "unset"' \
+            /tmp/app-cooldown.json)"
+
+          if [ "${current}" = "${COOLDOWN_SECONDS}" ]; then
+            echo "Cooldown already ${COOLDOWN_SECONDS}s; leaving it alone."
+            exit 0
+          fi
+
+          echo "Cooldown is ${current}s; setting ${COOLDOWN_SECONDS}s."
 
           jq \
             --argjson cd "${COOLDOWN_SECONDS}" \

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -228,13 +228,13 @@ round-trip used for volume mounts. Always-on apps skip the step; an app that
 never scales to zero has no use for a cooldown.
 
 Cooldown only helps when requests cluster closer together than the cooldown
-itself, so be sceptical of raising it further without measuring. Over 13 days
-`main-api` ran in 11 of 312 hours, and the gaps between bursts of use were 40,
-110, 120 and 220 minutes — none of which 900s bridges. Worth re-measuring once a
-lane is in real daily use:
+itself, so be sceptical of raising it further without measuring. Sampled over a
+13-day window, `main-api` was running for roughly one hour in twenty, and the
+gaps between bursts of use were 40, 110, 120 and 220 minutes — none of which
+900s bridges. Worth re-measuring once a lane is in real daily use:
 
 ```bash
-az monitor metrics list --resource "$(az containerapp show -n main-api -g STITCH-DEV-RG --query id -o tsv)" --metric Replicas --interval PT1H --start-time "$(date -u -v-13d +%Y-%m-%dT%H:%M:%SZ)" --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --aggregation Maximum -o table
+az monitor metrics list --resource "$(az containerapp show -n main-api -g STITCH-DEV-RG --query id -o tsv)" --metric Replicas --interval PT1H --offset 13d --aggregation Maximum -o table
 ```
 
 Cold starts are most visible at sign-in, when the app's first API call lands on

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -219,6 +219,24 @@ out under load. Empty means the input is skipped entirely and the app keeps the
 default scale-to-zero. The ETL app is separate: it pins `min = max = 1` and only
 deploys on non-`development` lanes, so it stays warm regardless of this policy.
 
+Apps that do scale to zero also get a widened **cooldown** — 900s rather than
+Azure's default 300s — reasserted after every deploy. Cooldown is how long an app
+stays up after its last request, so this covers the ordinary gaps inside a
+working session without keeping anything alive overnight. There is no CLI flag
+for it, so the deploy sets it with the same `show -> jq -> update --yaml`
+round-trip used for volume mounts. Always-on apps skip the step; an app that
+never scales to zero has no use for a cooldown.
+
+Cooldown only helps when requests cluster closer together than the cooldown
+itself, so be sceptical of raising it further without measuring. Over 13 days
+`main-api` ran in 11 of 312 hours, and the gaps between bursts of use were 40,
+110, 120 and 220 minutes — none of which 900s bridges. Worth re-measuring once a
+lane is in real daily use:
+
+```bash
+az monitor metrics list --resource "$(az containerapp show -n main-api -g STITCH-DEV-RG --query id -o tsv)" --metric Replicas --interval PT1H --start-time "$(date -u -v-13d +%Y-%m-%dT%H:%M:%SZ)" --end-time "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --aggregation Maximum -o table
+```
+
 Cold starts are most visible at sign-in, when the app's first API call lands on
 a sleeping container. The frontend absorbs that, so the policy above does not
 have to widen to cover it:

--- a/deployments/CI_DEPLOYMENTS.md
+++ b/deployments/CI_DEPLOYMENTS.md
@@ -219,10 +219,20 @@ out under load. Empty means the input is skipped entirely and the app keeps the
 default scale-to-zero. The ETL app is separate: it pins `min = max = 1` and only
 deploys on non-`development` lanes, so it stays warm regardless of this policy.
 
-Cold starts are most visible at sign-in, when the app's first API call lands on a
-sleeping container. The planned mitigation is to have the login page fire a cheap
-request at the API so it wakes while the user authenticates, rather than widening
-this policy.
+Cold starts are most visible at sign-in, when the app's first API call lands on
+a sleeping container. The frontend absorbs that, so the policy above does not
+have to widen to cover it:
+
+- it wakes the API during bootstrap, before Auth0 mounts, so the container starts
+  while the user is still being redirected through login;
+- queries retry transient failures, so a container that is not ready yet reads as
+  slow rather than broken;
+- the environment banner says the server is waking up once a request has been in
+  flight for more than a couple of seconds.
+
+entity-linkage and stitch-llm are deliberately left out. Waking them the same way
+was tried and set aside: the API is the one every session needs, and better
+options for the other two are still being explored.
 
 This only affects the Container Apps. The frontend is an Azure Static Web App
 (always served, no hibernation), and the PostgreSQL flexible server's

--- a/deployments/stitch-frontend/src/AppProviders.jsx
+++ b/deployments/stitch-frontend/src/AppProviders.jsx
@@ -2,14 +2,20 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Auth0Provider } from "@auth0/auth0-react";
 import AuthGate from "./auth/AuthGate";
 import { ConfigProvider } from "./config/context-provider";
+import { shouldRetryQuery } from "./queries/retry";
 
 // Set global defaults for QueryClient
 const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       refetchOnWindowFocus: false,
-      retry: 1,
+      // Retry transient failures only -- see queries/retry.js. A single retry
+      // was not enough to outlast a Container App waking from zero, and
+      // retrying a 4xx only delays an error that will not change.
+      retry: shouldRetryQuery,
     },
+    // Mutations keep the default of no retries: they are not idempotent, so a
+    // replay after a timeout could apply the same change twice.
   },
 });
 

--- a/deployments/stitch-frontend/src/AppProviders.test.jsx
+++ b/deployments/stitch-frontend/src/AppProviders.test.jsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
+import { useQueryClient } from "@tanstack/react-query";
 import { Auth0Provider } from "@auth0/auth0-react";
 import { AppProviders } from "./AppProviders";
 
@@ -45,6 +46,43 @@ describe("AppProviders", () => {
       cacheLocation: "localstorage",
       useRefreshTokens: true,
     });
+  });
+
+  it("hands the cold-start retry policy down to every query", () => {
+    // The predicate itself is unit-tested in queries/retry.test.js, but nothing
+    // otherwise proves it reaches the app: renderWithQueryClient builds its own
+    // client with `retry: false`, so component tests never exercise this
+    // default. Without this test, dropping the wiring keeps the suite green and
+    // only surfaces as failed first loads against a sleeping container.
+    let defaults;
+    function Probe() {
+      defaults = useQueryClient().getDefaultOptions();
+      return null;
+    }
+
+    render(
+      <AppProviders config={TEST_CONFIG}>
+        <Probe />
+      </AppProviders>,
+    );
+
+    const retry = defaults.queries?.retry;
+
+    // A number here would mean someone reverted to `retry: 1`; undefined would
+    // mean the option was dropped, restoring TanStack's default of retrying
+    // everything three times, 4xx included.
+    expect(typeof retry).toBe("function");
+
+    const httpError = (status) => Object.assign(new Error(status), { status });
+
+    expect(retry(1, httpError(503))).toBe(true);
+    expect(retry(1, new TypeError("Failed to fetch"))).toBe(true);
+    expect(retry(1, httpError(404))).toBe(false);
+    expect(retry(99, httpError(503))).toBe(false);
+
+    // Mutations are deliberately left on the default of no retries: replaying a
+    // non-idempotent write after a timeout is worse than the error.
+    expect(defaults.mutations?.retry).toBeUndefined();
   });
 
   it("renders children through AuthGate when authenticated", () => {

--- a/deployments/stitch-frontend/src/components/EnvironmentBanner.jsx
+++ b/deployments/stitch-frontend/src/components/EnvironmentBanner.jsx
@@ -1,6 +1,45 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { useIsFetching } from "@tanstack/react-query";
 import ColophonPanel from "./ColophonPanel";
 import { useConfig } from "../config/useConfig";
+
+// Long enough that a healthy request never trips it, short enough that the user
+// gets an explanation before they start wondering whether the page is broken.
+const WARMING_DELAY_MS = 2000;
+
+/**
+ * True once a request has been in flight long enough to look like a stall.
+ *
+ * Most deployments let their Container Apps scale to zero when idle (see
+ * `deployments/CI_DEPLOYMENTS.md`), so the first request of a session waits for
+ * a container to start. There is nothing to fix in that moment -- it just needs
+ * saying, so the wait reads as "starting up" rather than "nothing is happening".
+ */
+function useIsWarmingUp(delayMs = WARMING_DELAY_MS) {
+  // Deliberately a boolean, not the count: a second query starting must not
+  // restart the clock on the one that has already been waiting.
+  const isPending = useIsFetching() > 0;
+  const [hasStalled, setHasStalled] = useState(false);
+
+  useEffect(() => {
+    if (!isPending) {
+      return undefined;
+    }
+
+    const timer = setTimeout(() => setHasStalled(true), delayMs);
+
+    return () => {
+      clearTimeout(timer);
+      setHasStalled(false);
+    };
+  }, [isPending, delayMs]);
+
+  // `hasStalled` only ever latches on, from the timer. Pairing it with
+  // `isPending` here is what clears the notice the moment the request lands --
+  // cheaper than a second effect, and it keeps the effect body free of the
+  // synchronous setState that cascades renders.
+  return isPending && hasStalled;
+}
 
 function normalizeEnvLabel(value) {
   return (value ?? "").trim();
@@ -53,6 +92,7 @@ function getBannerAppearance(label) {
 export default function EnvironmentBanner() {
   const config = useConfig();
   const [isOpen, setIsOpen] = useState(false);
+  const isWarmingUp = useIsWarmingUp();
   const label = normalizeEnvLabel(config.appEnv);
   const bannerAppearance = getBannerAppearance(label);
 
@@ -67,9 +107,19 @@ export default function EnvironmentBanner() {
         style={bannerAppearance.style}
       >
         <div className="mx-auto flex max-w-6xl items-center justify-between gap-3 px-4 py-2 text-sm font-medium sm:px-6 lg:px-8">
-          <span className="min-w-0 truncate rounded-md bg-bluespruce px-3 py-1 shadow-sm ring-1 ring-white/20">
-            {label.toUpperCase()} Environment
-          </span>
+          <div className="flex min-w-0 items-center gap-3">
+            <span className="min-w-0 truncate rounded-md bg-bluespruce px-3 py-1 shadow-sm ring-1 ring-white/20">
+              {label.toUpperCase()} Environment
+            </span>
+
+            {isWarmingUp ? (
+              // role="status" announces this politely once it appears, rather
+              // than interrupting whatever a screen reader is already saying.
+              <span role="status" className="min-w-0 truncate font-normal">
+                Server is waking up — this can take a few seconds.
+              </span>
+            ) : null}
+          </div>
 
           <button
             type="button"

--- a/deployments/stitch-frontend/src/components/EnvironmentBanner.jsx
+++ b/deployments/stitch-frontend/src/components/EnvironmentBanner.jsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import { useIsFetching } from "@tanstack/react-query";
+import { useIsFetching, useQueryClient } from "@tanstack/react-query";
 import ColophonPanel from "./ColophonPanel";
 import { useConfig } from "../config/useConfig";
 
@@ -8,18 +8,35 @@ import { useConfig } from "../config/useConfig";
 const WARMING_DELAY_MS = 2000;
 
 /**
- * True once a request has been in flight long enough to look like a stall.
+ * True once a request has been in flight long enough to look like a stall, and
+ * only while a stall is plausibly a container starting up.
  *
  * Most deployments let their Container Apps scale to zero when idle (see
  * `deployments/CI_DEPLOYMENTS.md`), so the first request of a session waits for
  * a container to start. There is nothing to fix in that moment -- it just needs
  * saying, so the wait reads as "starting up" rather than "nothing is happening".
+ *
+ * It is deliberately silent once anything has come back from the server. A slow
+ * filter over a large result set, or the refetch after a save, is slow for some
+ * other reason, and blaming a cold start there sends the reader looking for a
+ * problem that is not the one they have.
  */
 function useIsWarmingUp(delayMs = WARMING_DELAY_MS) {
+  const queryClient = useQueryClient();
   // Deliberately a boolean, not the count: a second query starting must not
   // restart the clock on the one that has already been waiting.
   const isPending = useIsFetching() > 0;
   const [hasStalled, setHasStalled] = useState(false);
+
+  // One successful query proves the container is serving. Read straight from the
+  // cache rather than latching into state: a query keeps `status: "success"`
+  // through later refetches, so this stays true for the rest of the session
+  // without a ref or an effect -- and if every query is eventually garbage
+  // collected, going quiet-then-cold is exactly when the notice is wanted again.
+  const hasServerAnswered = queryClient
+    .getQueryCache()
+    .getAll()
+    .some((query) => query.state.status === "success");
 
   useEffect(() => {
     if (!isPending) {
@@ -38,7 +55,7 @@ function useIsWarmingUp(delayMs = WARMING_DELAY_MS) {
   // `isPending` here is what clears the notice the moment the request lands --
   // cheaper than a second effect, and it keeps the effect body free of the
   // synchronous setState that cascades renders.
-  return isPending && hasStalled;
+  return isPending && hasStalled && !hasServerAnswered;
 }
 
 function normalizeEnvLabel(value) {

--- a/deployments/stitch-frontend/src/components/EnvironmentBanner.test.jsx
+++ b/deployments/stitch-frontend/src/components/EnvironmentBanner.test.jsx
@@ -158,6 +158,22 @@ describe("EnvironmentBanner", () => {
       expect(screen.getByRole("status")).toHaveTextContent(WAKING_TEXT);
     });
 
+    it("stays silent once the server has answered something, however slow a later request is", async () => {
+      vi.mocked(useIsFetching).mockReturnValue(1);
+      const { queryClient } = await renderBanner();
+
+      // A successful query proves the container is serving, so a later stall is
+      // slow for some other reason and must not be blamed on a cold start.
+      queryClient.setQueryData(["already-loaded"], { ok: true });
+
+      // useIsFetching is mocked, so the cache write does not re-render on its
+      // own; the toggle is just a cheap way to force one.
+      fireEvent.click(screen.getByRole("button", { name: "Show diagnostics" }));
+      act(() => vi.advanceTimersByTime(10_000));
+
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
+
     it("clears the notice once the request lands", async () => {
       vi.mocked(useIsFetching).mockReturnValue(1);
       await renderBanner();

--- a/deployments/stitch-frontend/src/components/EnvironmentBanner.test.jsx
+++ b/deployments/stitch-frontend/src/components/EnvironmentBanner.test.jsx
@@ -1,6 +1,7 @@
-import { screen } from "@testing-library/react";
+import { act, fireEvent, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { useIsFetching } from "@tanstack/react-query";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { setConfigForTests } from "../config/env";
 import { renderWithQueryClient } from "../test/utils";
 
@@ -31,6 +32,13 @@ vi.mock("./ColophonPanel", () => ({
       Diagnostics open: {String(diagnosticsOpen)}
     </div>
   ),
+}));
+
+// Only `useIsFetching` is faked; the real QueryClient/Provider are still needed
+// by renderWithQueryClient.
+vi.mock("@tanstack/react-query", async (importOriginal) => ({
+  ...(await importOriginal()),
+  useIsFetching: vi.fn(() => 0),
 }));
 
 describe("EnvironmentBanner", () => {
@@ -102,5 +110,66 @@ describe("EnvironmentBanner", () => {
       screen.getByRole("button", { name: "Show diagnostics" }),
     ).toBeInTheDocument();
     expect(screen.queryByTestId("colophon-panel")).not.toBeInTheDocument();
+  });
+
+  describe("waking-up notice", () => {
+    const WAKING_TEXT = /waking up/i;
+
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    async function renderBanner() {
+      const { default: EnvironmentBanner } =
+        await import("./EnvironmentBanner");
+      return renderWithQueryClient(<EnvironmentBanner />);
+    }
+
+    it("stays quiet while nothing is pending, however long the page is open", async () => {
+      vi.mocked(useIsFetching).mockReturnValue(0);
+      await renderBanner();
+
+      act(() => vi.advanceTimersByTime(60_000));
+
+      expect(screen.queryByText(WAKING_TEXT)).not.toBeInTheDocument();
+    });
+
+    it("stays quiet for a request that is merely in flight", async () => {
+      vi.mocked(useIsFetching).mockReturnValue(1);
+      await renderBanner();
+
+      // A healthy request resolves well inside the delay, so the user should
+      // never see this for a normal page load.
+      act(() => vi.advanceTimersByTime(1_500));
+
+      expect(screen.queryByText(WAKING_TEXT)).not.toBeInTheDocument();
+    });
+
+    it("explains the wait once a request has stalled", async () => {
+      vi.mocked(useIsFetching).mockReturnValue(1);
+      await renderBanner();
+
+      act(() => vi.advanceTimersByTime(2_000));
+
+      expect(screen.getByRole("status")).toHaveTextContent(WAKING_TEXT);
+    });
+
+    it("clears the notice once the request lands", async () => {
+      vi.mocked(useIsFetching).mockReturnValue(1);
+      await renderBanner();
+
+      act(() => vi.advanceTimersByTime(2_000));
+      expect(screen.getByRole("status")).toBeInTheDocument();
+
+      // Fetching stops; the click is just a cheap way to force a re-render.
+      vi.mocked(useIsFetching).mockReturnValue(0);
+      fireEvent.click(screen.getByRole("button", { name: "Show diagnostics" }));
+
+      expect(screen.queryByRole("status")).not.toBeInTheDocument();
+    });
   });
 });

--- a/deployments/stitch-frontend/src/main.jsx
+++ b/deployments/stitch-frontend/src/main.jsx
@@ -7,11 +7,17 @@ import "./index.css";
 import App from "./App.jsx";
 import { AppProviders } from "./AppProviders";
 import { loadConfig } from "./config/env";
+import { prewarmApi } from "./queries/prewarm";
 
 const root = createRoot(document.getElementById("root"));
 
 async function bootstrap() {
   const config = await loadConfig();
+
+  // Start the API waking now, so it does so in parallel with the Auth0 redirect
+  // instead of after it. Not awaited: rendering must not wait on the backend,
+  // and `prewarmApi` never rejects.
+  void prewarmApi(config);
 
   root.render(
     <StrictMode>

--- a/deployments/stitch-frontend/src/queries/api.js
+++ b/deployments/stitch-frontend/src/queries/api.js
@@ -16,7 +16,9 @@ export async function getResources(
   const url = `${config.apiBaseUrl}/${endpoint}/?${params}`;
   const response = await fetcher(url);
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
+    const error = new Error(`HTTP error! status: ${response.status}`);
+    error.status = response.status;
+    throw error;
   }
   return await response.json();
 }
@@ -31,7 +33,9 @@ export async function getResourceFilterOptions(
   const url = `${config.apiBaseUrl}/${endpoint}/filter-options?${params}`;
   const response = await fetcher(url);
   if (!response.ok) {
-    throw new Error(`HTTP error! status: ${response.status}`);
+    const error = new Error(`HTTP error! status: ${response.status}`);
+    error.status = response.status;
+    throw error;
   }
   return await response.json();
 }

--- a/deployments/stitch-frontend/src/queries/prewarm.js
+++ b/deployments/stitch-frontend/src/queries/prewarm.js
@@ -6,7 +6,7 @@
  * cold start. Bootstrap is the earliest useful moment to trigger one: it runs
  * before Auth0 mounts, so the container starts while the user is still being
  * redirected through login, and by the time the first real query fires the API
- * is may be already serving.
+ * may already be serving.
  */
 
 // `/health/details` rather than `/health`: it resolves the database engine, so

--- a/deployments/stitch-frontend/src/queries/prewarm.js
+++ b/deployments/stitch-frontend/src/queries/prewarm.js
@@ -1,0 +1,49 @@
+/**
+ * Wake the backend before the user needs it.
+ *
+ * Most deployments let their Container Apps scale to zero when idle (see
+ * `deployments/CI_DEPLOYMENTS.md`), so the first request of a session pays a
+ * cold start. Bootstrap is the earliest useful moment to trigger one: it runs
+ * before Auth0 mounts, so the container starts while the user is still being
+ * redirected through login, and by the time the first real query fires the API
+ * is may be already serving.
+ */
+
+// `/health/details` rather than `/health`: it resolves the database engine, so
+// it opens a connection too. The container starting and the connection pool
+// filling are the two costs of a cold start, and this pays both during dead
+// time. Neither endpoint requires auth.
+const HEALTH_PATH = "/health/details";
+
+function healthUrl(baseUrl) {
+  return `${baseUrl.replace(/\/+$/, "")}${HEALTH_PATH}`;
+}
+
+/**
+ * Send a throwaway request to the API so its container starts.
+ *
+ * @param {object} config - Resolved runtime config.
+ * @returns {Promise<void>} Always resolves. A prewarm that fails has cost the
+ *   user nothing, so there is no error to report and nothing to retry -- the
+ *   real request behind it carries its own retry policy (see `retry.js`).
+ */
+export function prewarmApi(config) {
+  const baseUrl = config?.apiBaseUrl;
+
+  if (!baseUrl) {
+    return Promise.resolve();
+  }
+
+  // Deliberately not aborted on a timer: Azure holds the request open while it
+  // activates a replica, and that wait is the thing doing the work.
+  //
+  // Deliberately unauthenticated and header-free, which keeps this a
+  // CORS-simple request. It reaches the server without a preflight even when
+  // the deployment's single allowed origin does not match the browser's -- and
+  // since the response is discarded, being blocked from reading it costs
+  // nothing. That matters while a custom domain is being cut over.
+  return fetch(healthUrl(baseUrl), { cache: "no-store" }).then(
+    () => undefined,
+    () => undefined,
+  );
+}

--- a/deployments/stitch-frontend/src/queries/prewarm.js
+++ b/deployments/stitch-frontend/src/queries/prewarm.js
@@ -30,7 +30,11 @@ function healthUrl(baseUrl) {
 export function prewarmApi(config) {
   const baseUrl = config?.apiBaseUrl;
 
-  if (!baseUrl) {
+  // `loadConfig` already rejects a non-string `apiUrl`, so this only guards
+  // callers that build a config by hand. It is here because the contract above
+  // says this never rejects, and `main.jsx` relies on that: a synchronous throw
+  // would escape `bootstrap()` and swap the app for the config-error screen.
+  if (typeof baseUrl !== "string" || !baseUrl) {
     return Promise.resolve();
   }
 

--- a/deployments/stitch-frontend/src/queries/prewarm.test.js
+++ b/deployments/stitch-frontend/src/queries/prewarm.test.js
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { prewarmApi } from "./prewarm";
+
+describe("prewarmApi", () => {
+  let fetchMock;
+
+  beforeEach(() => {
+    fetchMock = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  it("requests the API health endpoint that also opens a database connection", async () => {
+    await prewarmApi({ apiBaseUrl: "https://api.example.test/api/v1" });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/api/v1/health/details",
+      expect.objectContaining({ cache: "no-store" }),
+    );
+  });
+
+  it("sends no headers, so the request stays CORS-simple", async () => {
+    await prewarmApi({ apiBaseUrl: "https://api.example.test/api/v1" });
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.headers).toBeUndefined();
+  });
+
+  it("does not abort on a timer, so Azure can hold the request while it starts a replica", async () => {
+    await prewarmApi({ apiBaseUrl: "https://api.example.test/api/v1" });
+
+    const [, options] = fetchMock.mock.calls[0];
+    expect(options.signal).toBeUndefined();
+  });
+
+  it("tolerates a trailing slash on the base URL", async () => {
+    await prewarmApi({ apiBaseUrl: "https://api.example.test/api/v1/" });
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://api.example.test/api/v1/health/details",
+      expect.anything(),
+    );
+  });
+
+  it("resolves when the request fails, so bootstrap is never blocked", async () => {
+    fetchMock.mockRejectedValue(new TypeError("Failed to fetch"));
+
+    await expect(
+      prewarmApi({ apiBaseUrl: "https://api.example.test/api/v1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("resolves when the API answers with an error status", async () => {
+    fetchMock.mockResolvedValue({ ok: false, status: 503 });
+
+    await expect(
+      prewarmApi({ apiBaseUrl: "https://api.example.test/api/v1" }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("does nothing when no API base URL is configured", async () => {
+    await expect(prewarmApi({})).resolves.toBeUndefined();
+    await expect(prewarmApi(undefined)).resolves.toBeUndefined();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+});

--- a/deployments/stitch-frontend/src/queries/prewarm.test.js
+++ b/deployments/stitch-frontend/src/queries/prewarm.test.js
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, afterEach, beforeEach } from "vitest";
 import { prewarmApi } from "./prewarm";
 
 describe("prewarmApi", () => {
@@ -7,6 +7,10 @@ describe("prewarmApi", () => {
   beforeEach(() => {
     fetchMock = vi.fn().mockResolvedValue({ ok: true });
     vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it("requests the API health endpoint that also opens a database connection", async () => {
@@ -61,6 +65,15 @@ describe("prewarmApi", () => {
   it("does nothing when no API base URL is configured", async () => {
     await expect(prewarmApi({})).resolves.toBeUndefined();
     await expect(prewarmApi(undefined)).resolves.toBeUndefined();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does nothing when the base URL is not a string, rather than throwing", async () => {
+    // The contract is that this never rejects, because bootstrap does not await
+    // it -- a synchronous throw would escape and take the app down with it.
+    await expect(prewarmApi({ apiBaseUrl: 42 })).resolves.toBeUndefined();
+    await expect(prewarmApi({ apiBaseUrl: {} })).resolves.toBeUndefined();
 
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/deployments/stitch-frontend/src/queries/retry.js
+++ b/deployments/stitch-frontend/src/queries/retry.js
@@ -1,0 +1,48 @@
+/**
+ * Which query failures are worth another attempt.
+ *
+ * Most deployments let their Container Apps scale to zero when idle, so the
+ * first request after a quiet period arrives while the container is still
+ * starting. Azure holds the request during activation and answers with a 5xx if
+ * the replica is not ready in time, or drops the connection outright -- which
+ * `fetch` surfaces as a TypeError. Both deserve another attempt a moment later.
+ *
+ * A 4xx does not: the request itself was wrong, and re-sending it unchanged
+ * fails identically while making the user wait longer for the same error.
+ */
+
+/** Retries after the initial attempt, so a query is tried at most 4 times. */
+export const MAX_RETRIES = 3;
+
+/**
+ * @param {unknown} error - The error a query function threw.
+ * @returns {boolean} Whether the failure looks transient.
+ */
+export function isRetriableError(error) {
+  const status = error?.status;
+
+  if (typeof status === "number") {
+    // 408 and 429 are transient by definition; 5xx covers a container that was
+    // not ready in time.
+    return status === 408 || status === 429 || status >= 500;
+  }
+
+  // No HTTP status means the request never completed. A failed `fetch` rejects
+  // with a TypeError in every browser ("Failed to fetch" in Chrome,
+  // "NetworkError when attempting to fetch resource." in Firefox). Anything
+  // else reaching here -- an auth-flow rejection, a bug in a query function --
+  // is not a cold start and gains nothing from being repeated.
+  return error instanceof TypeError;
+}
+
+/**
+ * `retry` predicate for TanStack Query. Called after each failure with the
+ * running failure count, starting at 1.
+ *
+ * @param {number} failureCount - How many times this query has failed so far.
+ * @param {unknown} error - The most recent error.
+ * @returns {boolean} Whether to try again.
+ */
+export function shouldRetryQuery(failureCount, error) {
+  return failureCount <= MAX_RETRIES && isRetriableError(error);
+}

--- a/deployments/stitch-frontend/src/queries/retry.test.js
+++ b/deployments/stitch-frontend/src/queries/retry.test.js
@@ -1,0 +1,54 @@
+import { describe, it, expect } from "vitest";
+import { MAX_RETRIES, isRetriableError, shouldRetryQuery } from "./retry";
+
+function httpError(status) {
+  const error = new Error(`HTTP error! status: ${status}`);
+  error.status = status;
+  return error;
+}
+
+describe("isRetriableError", () => {
+  it.each([500, 502, 503, 504])(
+    "retries %i (container still starting)",
+    (s) => {
+      expect(isRetriableError(httpError(s))).toBe(true);
+    },
+  );
+
+  it.each([408, 429])("retries %i (transient by definition)", (s) => {
+    expect(isRetriableError(httpError(s))).toBe(true);
+  });
+
+  it.each([400, 401, 403, 404, 422])("does not retry %i", (s) => {
+    expect(isRetriableError(httpError(s))).toBe(false);
+  });
+
+  it("retries a failed fetch, which rejects with a TypeError", () => {
+    expect(isRetriableError(new TypeError("Failed to fetch"))).toBe(true);
+  });
+
+  it("does not retry an error with no status that is not a fetch failure", () => {
+    expect(isRetriableError(new Error("login_required"))).toBe(false);
+  });
+
+  it("does not blow up on a null or undefined error", () => {
+    expect(isRetriableError(null)).toBe(false);
+    expect(isRetriableError(undefined)).toBe(false);
+  });
+});
+
+describe("shouldRetryQuery", () => {
+  it("keeps retrying a transient failure up to the cap", () => {
+    for (let failureCount = 1; failureCount <= MAX_RETRIES; failureCount++) {
+      expect(shouldRetryQuery(failureCount, httpError(503))).toBe(true);
+    }
+  });
+
+  it("stops once the cap is exceeded, even while still failing transiently", () => {
+    expect(shouldRetryQuery(MAX_RETRIES + 1, httpError(503))).toBe(false);
+  });
+
+  it("does not retry a client error even on the first failure", () => {
+    expect(shouldRetryQuery(1, httpError(404))).toBe(false);
+  });
+});


### PR DESCRIPTION
Alex's TL;DR here, Claude's fuller summary below the fold:

Last pinged around 1510 Belgrade time. Update this description as needed.

Responding to changes in #234, where we set more environments to scale to zero (fall asleep) this PR is a collection of workarounds to mitigate the impact of that in practice:

* (up for discussion after we try it out): Set timeout before falling asleep to 15 min (900s) up from 5 min (300s)
* Add "waking up" message on env banner (this only affects the same environments as get env banner; prod is always-on). See screenshot below
* ping the API as part of the initial page load (prior to login) so server can be spinning up while user is (maybe) running through login
* add utility to frontend to help it understand which erros should be retried.

<img width="1320" height="798" alt="CleanShot 2026-08-20 at 15 01 00@2x" src="https://github.com/user-attachments/assets/557019b8-936f-44bd-bbac-5befb971e209" />


----

## Why

[#234](https://github.com/RMI/stitch/pull/234) narrows the always-on policy so that only pushes to `production` keep a warm replica. Everything else — `main`, demo lanes, PR previews — now scales to zero and pays a cold start on the first request of a session. This PR makes that acceptable: slightly less frequent, and no longer indistinguishable from the app being broken.

## Widening the cooldown

Cooldown is how long a Container App stays up after its last request. Azure's default is 300s, so a five-minute pause costs a cold start. This raises it to **900s** for apps that actually scale to zero, reasserted after every deploy.

Two things a reviewer should know about it:

**There is no CLI flag.** `az containerapp update` has no `--cooldown-period` and no generic `--set`, only `--yaml`. The step therefore does the same `show → jq → update --yaml` round-trip already used for ETL volume mounts, and runs after that step so it re-reads its result. The jq transform was dry-run against the live `main-api` spec: `cooldownPeriod` 300 → 900, `systemData` stripped (ARM rejects it on write), image digest and the rest of the template intact.

## Absorbing the cold start in the browser

**Retry transient failures instead of surfacing them.** The global `retry: 1` retried once after ~1s — still inside an ACA activation — then showed the user an error. Now a predicate retries only 5xx, 408, 429 and the `TypeError` a dropped `fetch` rejects with, up to 3 times.

**Wake the API during bootstrap.** A throwaway GET fired from `bootstrap()` and not awaited. It runs before Auth0 mounts, so the container starts while the user is still being redirected through login. Targets `/health/details` rather than `/health` because it resolves the database engine, so it opens a connection too — the two costs of a cold start, both paid during dead time. Neither endpoint requires auth.

**Say so when it is still slow.** After 2s of a request in flight, the environment banner shows "Server is waking up — this can take a few seconds" as a `role="status"` live region. Nothing to fix in that moment; it just needs saying, so the wait reads as starting up rather than nothing happening.

## Details that look like omissions but are deliberate

Each is commented at the call site and pinned by a test, so they are not tidied away later.

| Choice | Reason |
| --- | --- |
| The cooldown step is gated on `min-replicas == ''` | An app that never scales to zero has no use for a cooldown, and skipping it saves a round-trip per deploy |
| Prewarm has no abort timer | Azure holds the request open while it activates a replica — that wait is the thing doing the work |
| Prewarm sends no headers and no auth | Keeps it CORS-simple, so it reaches the server without a preflight even when the deployment's single allowed origin does not match the browser's. The response is discarded, so being blocked from reading it costs nothing — which matters during the `stitch-dev.rmi.org` cutover |
| Prewarm never rejects | A failed prewarm has cost the user nothing; the real request behind it carries its own retry policy |
| The warming hook keys on a boolean, not the fetch count | Otherwise a second query starting restarts the 2s clock on the request that was already waiting |
| Mutations keep `retry: 0` | They are not idempotent; replaying a write after a timeout is worse than the error |

## Things to look at

**A 4xx is no longer retried.** `retry: 1` retried every failure once, including 404 and 401. Re-sending an unchanged bad request only delays an error that was never going to change — but this is a change beyond "retry more", so it is worth a reviewer's eye.

**`getResources` and `getResourceFilterOptions` now attach `error.status`.** Every other throw site already did; these two carried the status only in the message string, so a status-based retry predicate could not see them. They back the resources list and its filter options — the first requests after sign-in, and so exactly the ones that meet a cold container. The retry fix does not work without this.

**The cooldown step costs CI time.** A `show` plus an `update` per scale-to-zero app per deploy — four apps on a PR lane, so perhaps 30–60s. Cheap, but not free, and easy to forget once buried in a reusable workflow.

**Existing apps stay at 300s** until their next deploy.

## Not in this PR

- **Prewarming entity-linkage and stitch-llm.** Built, then reverted — better approaches are being explored, and the API is the one every session needs.
- **An HTTP startup probe on `/health`.** No probes are configured on any container app, so ACA falls back to TCP-open, and uvicorn can accept connections before the FastAPI lifespan finishes. That is a plausible source of the 503s the retry policy is defending against. It needs the same `--yaml` round-trip, so it is CI work and belongs in its own PR.
- **Tuning `retryDelay`.** Left at the TanStack default (1s/2s/4s). It is the knob to turn if the retries prove too eager against a real cold start, but picking a curve now would be guessing.

## Notes for review

Stacked on [#234](https://github.com/RMI/stitch/pull/234) — base is `ci/hostnames`, so that needs to merge first.

AI was used to write the frontend changes, the CI step, the tests and this description. The measurements are from `az monitor metrics list` against `main-api`, not estimates. The new banner tests were mutation-checked: forcing the delay never to elapse kills exactly the two tests asserting the notice appears and clears, and leaves the other six green.