### PR TITLE
chore(scripts): fuzzy duplicate-search workflow for merge candidates

### DIFF
--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,3 @@
+# Fetched snapshots and review state are per-run and per-deployment.
+data/
+__pycache__/

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,82 @@
+# Duplicate-hunting scripts (throwaway)
+
+Not shipped code, not committed (`scripts/` is in `.git/info/exclude`).
+
+Finds likely-duplicate oil & gas field resources far more loosely than the
+`entity-linkage` deployment does, records the proposed sets locally for review,
+then creates and approves merge candidates from the reviewed file.
+
+## Why
+
+`entity-linkage` blocks on `name.strip().casefold()` and confirms on
+`country.strip().upper()` — both exact. On the demo corpus (9,187 resources)
+that finds **zero** groups, because GEM writes `Darquain Oil Field (Iran)` while
+CCR/BC/WM write `Darquain`. Normalizing the decoration away finds 273
+high-confidence pairs on the same data.
+
+## Workflow
+
+```bash
+# 1. snapshot the corpus (always fetches everything; a few seconds)
+uv run scripts/fetch_resources.py
+
+# 2. propose candidate groups (high-confidence tier only by default)
+uv run --with rapidfuzz --with numpy scripts/find_candidates.py
+
+# 3. review: edit data/candidates.json, setting "decision" to "merge" or "skip"
+#    and "reason" to one line of justification, for every group.
+
+# 4. create merge candidates from the reviewed file
+uv run scripts/create_merge_candidate.py --from-file --dry-run
+uv run scripts/create_merge_candidate.py --from-file --limit 3
+
+# 5. approve or deny
+uv run scripts/review_merge_candidates.py list --mine
+uv run scripts/review_merge_candidates.py approve 20 --notes "why"
+```
+
+Approving mints a **new** resource, so the snapshot goes stale. Re-run step 1
+before searching again.
+
+## Prioritise, then widen
+
+`find_candidates.py` classifies every group and emits only the `high` tier by
+default:
+
+- **high** — an exact normalized-name pair, one country, two different sources,
+  no conflicting parenthetical. The bare-vs-decorated duplicate.
+- **medium** — exact normalized name but same-source, or a 3-way group, or a
+  very close fuzzy pair.
+- **low** — everything else: geo-linked clusters, operator-split assets.
+
+Merge the high tier, re-fetch, re-run. Each pass makes the next tier cleaner
+than analysing everything at once. Widen with `--min-confidence medium|low`.
+
+## How the matching works
+
+Normalization strips accents, a leading `12345AB/` id prefix, trailing
+`(location)` parentheticals, and trailing type phrases (`Oil and Gas Field`,
+`Gas Asset`, `Oil Phase`, …), then casefolds and collapses punctuation.
+
+Three blocking passes are unioned:
+
+- **exact** — identical normalized name. A name split on ` - ` also blocks on
+  each half, but only when that half is the *rarest* segment on both sides,
+  otherwise `Belmont County - Ascent` matches `Harrison County - Ascent` on the
+  operator.
+- **fuzzy** — `token_sort_ratio >= 90` within a country bucket. Not
+  `token_set_ratio`: it scores `MARTIN` against `MARTIN CREEK` at 100 and chains
+  the corpus into one 1,000-member blob.
+- **geo** — within 10 km and name similarity >= 70.
+
+Two vetoes kill an edge before clustering:
+
+- **conflicting discriminators** — a rare parenthetical that only some records
+  carry, e.g. `Daqing (Lamadian)` vs `Daqing (Saertu)`, or `(MC782)` vs `(DC134)`.
+  Rarity is learned from the corpus, so `(Iran)` is boilerplate and ignored.
+- **conflicting qualifiers** — a directional or ordinal token on one side only:
+  `Blueberry East` is not `Blueberry West`.
+
+Clustering agglomerates the strongest edge first and refuses any join that would
+push a cluster past `--max-group-size`, so weak geo edges lose rather than strong
+exact-name pairs being dropped inside an oversized blob.

--- a/scripts/_common.py
+++ b/scripts/_common.py
@@ -1,0 +1,91 @@
+"""Shared helpers for the throwaway duplicate-hunting scripts.
+
+Not shipped code, not committed. See scripts/README.md for the workflow.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+
+SCRIPTS_DIR = Path(__file__).resolve().parent
+REPO_ROOT = SCRIPTS_DIR.parent
+DATA_DIR = SCRIPTS_DIR / "data"
+RESOURCES_PATH = DATA_DIR / "resources.jsonl"
+CANDIDATES_PATH = DATA_DIR / "candidates.json"
+
+DEFAULT_BASE_URL = (
+    "https://pr-0242-demo-batch-ai-3ae8-api.salmonsea-0e166cd2."
+    "westus2.azurecontainerapps.io/api/v1"
+)
+
+
+def load_dotenv(path: Path | None = None) -> None:
+    """Populate os.environ from .env without overriding what is already set."""
+    env_path = path if path is not None else REPO_ROOT / ".env"
+    if not env_path.is_file():
+        return
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def base_url() -> str:
+    load_dotenv()
+    return os.getenv("STITCH_API_BASE_URL") or DEFAULT_BASE_URL
+
+
+def auth_headers() -> dict[str, str]:
+    """Bearer header from the privileged token. The token is never printed."""
+    load_dotenv()
+    token = os.getenv("STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN") or os.getenv(
+        "STITCH_CLIENT_BEARER_TOKEN"
+    )
+    if not token:
+        raise SystemExit(
+            "no bearer token: set STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN in .env"
+        )
+    return {"Authorization": f"Bearer {token}"}
+
+
+def distinct_sources(provenance: dict[str, Any] | None) -> list[str]:
+    """The set of source keys that won at least one field on a resource."""
+    if not provenance:
+        return []
+    return sorted({value for value in provenance.values() if isinstance(value, str)})
+
+
+def flatten_list_item(item: dict[str, Any]) -> dict[str, Any]:
+    """Project an OGFieldListItemView down to the fields the matcher needs."""
+    data = item.get("data") or {}
+    return {
+        "id": item["id"],
+        "name": data.get("name"),
+        "country": data.get("country"),
+        "latitude": data.get("latitude"),
+        "longitude": data.get("longitude"),
+        "name_local": data.get("name_local"),
+        "state_province": data.get("state_province"),
+        "region": data.get("region"),
+        "basin": data.get("basin"),
+        "operators": [
+            operator.get("name")
+            for operator in (data.get("operators") or [])
+            if isinstance(operator, dict)
+        ],
+        "owners": [
+            owner.get("name")
+            for owner in (data.get("owners") or [])
+            if isinstance(owner, dict)
+        ],
+        "field_status": data.get("field_status"),
+        "sources": distinct_sources(item.get("provenance")),
+    }

--- a/scripts/create_merge_candidate.py
+++ b/scripts/create_merge_candidate.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python
+"""Create merge candidates, either from ids on the command line or from a file.
+
+Throwaway demo helper -- not shipped code, not committed.
+
+    uv run scripts/create_merge_candidate.py 7 8
+    uv run scripts/create_merge_candidate.py --from-file --dry-run
+    uv run scripts/create_merge_candidate.py --from-file --limit 3
+
+In --from-file mode this posts every group in scripts/data/candidates.json whose
+"decision" is "merge", and records the API's answer back into that file. Re-runs
+skip groups that already succeeded, so it is safe to run repeatedly.
+
+Target and credentials come from .env (STITCH_API_BASE_URL,
+STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN); see scripts/_common.py.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+from stitch.client import AsyncStitchClient, StitchAPIError
+
+from _common import CANDIDATES_PATH, auth_headers, base_url
+
+
+def build_client() -> AsyncStitchClient:
+    headers = auth_headers()
+    return AsyncStitchClient(
+        base_url=base_url(),
+        timeout=30.0,
+        headers_provider=lambda: headers,
+    )
+
+
+async def post_one(client: AsyncStitchClient, resource_ids: list[int]) -> dict:
+    """POST a single group. Returns {"candidate": ...} or {"error": ...}."""
+    try:
+        return {"candidate": await client.create_merge_candidate(resource_ids)}
+    except StitchAPIError as exc:
+        # 400 is the API's fingerprint de-dupe: a candidate for this exact id set
+        # already exists (pending, approved, or denied). Expected on a re-run.
+        if exc.status_code == 400:
+            return {"error": "already exists", "status_code": 400}
+        return {
+            "error": str(exc),
+            "status_code": exc.status_code,
+            "body": exc.response_text,
+        }
+
+
+async def run_ids(resource_ids: list[int]) -> int:
+    async with build_client() as client:
+        result = await post_one(client, resource_ids)
+    if "candidate" in result:
+        print(json.dumps(result["candidate"], indent=2))
+        return 0
+    print(f"failed: {result['error']}", file=sys.stderr)
+    if result.get("status_code") == 403:
+        print(
+            "hint: the token is missing the 'merge-candidate:create' permission",
+            file=sys.stderr,
+        )
+    return 1
+
+
+async def run_from_file(path: Path, *, dry_run: bool, limit: int | None) -> int:
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    groups = payload["groups"]
+
+    pending = [
+        group
+        for group in groups
+        if group.get("decision") == "merge" and not group.get("created_candidate_id")
+    ]
+    undecided = sum(1 for group in groups if group.get("decision") is None)
+    if undecided:
+        print(f"note: {undecided} group(s) still undecided", file=sys.stderr)
+
+    if limit is not None:
+        pending = pending[:limit]
+
+    if not pending:
+        print("nothing to create", file=sys.stderr)
+        return 0
+
+    if dry_run:
+        for group in pending:
+            names = " || ".join(m["name"] or "" for m in group["members"])
+            print(f"{group['group_id']} {group['resource_ids']}  {names}")
+        print(f"\n{len(pending)} group(s) would be created", file=sys.stderr)
+        return 0
+
+    created = failed = 0
+    async with build_client() as client:
+        for group in pending:
+            result = await post_one(client, group["resource_ids"])
+            if "candidate" in result:
+                group["created_candidate_id"] = result["candidate"]["id"]
+                group["created_status"] = result["candidate"]["status"]
+                group.pop("created_error", None)
+                created += 1
+                print(
+                    f"{group['group_id']} -> candidate {group['created_candidate_id']}"
+                )
+            else:
+                group["created_error"] = result["error"]
+                failed += 1
+                print(
+                    f"{group['group_id']} -> {result['error']}",
+                    file=sys.stderr,
+                )
+            # Persist after every call so an interruption cannot lose the id of
+            # a candidate that was already created server-side.
+            path.write_text(
+                json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+
+    print(f"\ncreated {created}, failed {failed}", file=sys.stderr)
+    return 1 if failed and not created else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("resource_ids", nargs="*", type=int)
+    parser.add_argument("--from-file", nargs="?", const=str(CANDIDATES_PATH))
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--limit", type=int)
+    args = parser.parse_args()
+
+    if args.from_file:
+        if args.resource_ids:
+            parser.error("pass resource ids or --from-file, not both")
+        return asyncio.run(
+            run_from_file(Path(args.from_file), dry_run=args.dry_run, limit=args.limit)
+        )
+
+    if len(args.resource_ids) < 2:
+        parser.error("need at least 2 resource ids, or --from-file")
+    return asyncio.run(run_ids(args.resource_ids))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fetch_resources.py
+++ b/scripts/fetch_resources.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python
+"""Fetch every oil & gas field resource to scripts/data/resources.jsonl.
+
+Throwaway demo helper -- not shipped code, not committed.
+
+    uv run scripts/fetch_resources.py
+
+The corpus is small (~9k records, 46 pages at page_size=200), so this always
+fetches everything. There is no resume state and no incremental mode: a full
+re-fetch takes seconds and is always the cheapest correct thing to do.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+
+import httpx
+
+from _common import (
+    DATA_DIR,
+    RESOURCES_PATH,
+    auth_headers,
+    base_url,
+    flatten_list_item,
+)
+
+
+PAGE_SIZE = 200
+
+
+def fetch_all() -> tuple[list[dict], int]:
+    """Page through the resource list. Returns (records, total_count)."""
+    records: list[dict] = []
+    total_count = 0
+    page = 1
+
+    with httpx.Client(base_url=base_url(), timeout=60.0) as client:
+        while True:
+            response = client.get(
+                "/oil-gas-fields/",
+                params={
+                    "page": page,
+                    "page_size": PAGE_SIZE,
+                    "sort_by": "id",
+                    "sort_order": "asc",
+                },
+                headers=auth_headers(),
+            )
+            response.raise_for_status()
+            payload = response.json()
+
+            items = payload.get("items") or []
+            records.extend(flatten_list_item(item) for item in items)
+            total_count = payload.get("total_count", total_count)
+            total_pages = payload.get("total_pages")
+
+            print(
+                f"page {page}/{total_pages} -> {len(records)}/{total_count}",
+                file=sys.stderr,
+            )
+
+            if not items or not isinstance(total_pages, int) or page >= total_pages:
+                break
+            page += 1
+
+    return records, total_count
+
+
+def main() -> int:
+    records, total_count = fetch_all()
+
+    if len(records) != total_count:
+        print(
+            f"fetched {len(records)} records but API reported {total_count}",
+            file=sys.stderr,
+        )
+        return 1
+
+    ids = [record["id"] for record in records]
+    if len(set(ids)) != len(ids):
+        print("duplicate resource ids in the fetched pages", file=sys.stderr)
+        return 1
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    tmp_path = RESOURCES_PATH.with_suffix(".jsonl.tmp")
+    with tmp_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+    os.replace(tmp_path, RESOURCES_PATH)
+
+    print(f"wrote {len(records)} records to {RESOURCES_PATH}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/find_candidates.py
+++ b/scripts/find_candidates.py
@@ -1,0 +1,674 @@
+#!/usr/bin/env python
+"""Propose fuzzy duplicate groups from scripts/data/resources.jsonl.
+
+Throwaway demo helper -- not shipped code, not committed.
+
+    uv run --with rapidfuzz --with numpy scripts/find_candidates.py
+
+This script is deliberately recall-oriented. It PROPOSES groups and explains
+why, and never decides: every group comes out with "decision": null for a
+human or an AI to fill in with "merge" or "skip".
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import re
+import sys
+import unicodedata
+from collections import Counter, defaultdict
+from typing import Any, Iterable
+
+import numpy as np
+from rapidfuzz import fuzz, process
+
+from _common import CANDIDATES_PATH, DATA_DIR, RESOURCES_PATH
+
+
+# Longest first: stripping is repeated until nothing more matches.
+TYPE_PHRASES = (
+    "oil and gas field",
+    "oil and gas asset",
+    "cbm gas field",
+    "tight gas field",
+    "oil and gas",
+    "oil field",
+    "gas field",
+    "oil asset",
+    "gas asset",
+    "oil phase",
+    "gas phase",
+    "field",
+    "asset",
+    "phase",
+)
+
+# "10097UUU/Athabasca Oil Asset (Alberta, Canada)" -> drop the record-id prefix.
+ID_PREFIX_RE = re.compile(r"^\s*\d+[A-Za-z]*\s*/\s*")
+PARENTHETICAL_RE = re.compile(r"\(([^()]*)\)")
+SEGMENT_SPLIT_RE = re.compile(r"\s+-\s+")
+PUNCT_RE = re.compile(r"[^\w\s]", flags=re.UNICODE)
+WHITESPACE_RE = re.compile(r"\s+")
+
+# Tokens that turn one field into a *different* field: 'blueberry east' is not
+# 'blueberry west'. If such a token is on one side of a pair and not the other,
+# the two are distinct assets no matter how similar the strings look.
+QUALIFIER_TOKENS = frozenset(
+    {
+        "north",
+        "south",
+        "east",
+        "west",
+        "n",
+        "s",
+        "e",
+        "w",
+        "ne",
+        "nw",
+        "se",
+        "sw",
+        "northeast",
+        "northwest",
+        "southeast",
+        "southwest",
+        "central",
+        "upper",
+        "lower",
+        "deep",
+        "shallow",
+        "main",
+        "extension",
+        "ext",
+        "unit",
+        "i",
+        "ii",
+        "iii",
+        "iv",
+        "v",
+        "vi",
+    }
+)
+
+EARTH_RADIUS_KM = 6371.0088
+
+
+def strip_accents(text: str) -> str:
+    decomposed = unicodedata.normalize("NFKD", text)
+    return "".join(ch for ch in decomposed if not unicodedata.combining(ch))
+
+
+def tidy(text: str) -> str:
+    """Lowercase, drop punctuation, collapse whitespace."""
+    cleaned = PUNCT_RE.sub(" ", strip_accents(text).casefold())
+    return WHITESPACE_RE.sub(" ", cleaned).strip()
+
+
+def strip_type_phrases(text: str) -> str:
+    """Repeatedly remove trailing asset-type words: 'darquain oil field' -> 'darquain'."""
+    current = text
+    changed = True
+    while changed:
+        changed = False
+        for phrase in TYPE_PHRASES:
+            if current.endswith(" " + phrase):
+                current = current[: -(len(phrase) + 1)].strip()
+                changed = True
+                break
+    return current
+
+
+def split_name(raw_name: str) -> tuple[list[str], list[str]]:
+    """Split a raw name into (segments, parentheticals).
+
+    Parentheticals are pulled out wherever they appear; the remaining text is
+    split on ' - ' into segments, each tidied and stripped of type phrases.
+    """
+    without_prefix = ID_PREFIX_RE.sub("", raw_name)
+    parentheticals = [
+        tidy(match) for match in PARENTHETICAL_RE.findall(without_prefix) if tidy(match)
+    ]
+    body = PARENTHETICAL_RE.sub(" ", without_prefix)
+
+    segments = []
+    for part in SEGMENT_SPLIT_RE.split(body):
+        segment = strip_type_phrases(tidy(part))
+        if segment:
+            segments.append(segment)
+    return segments, parentheticals
+
+
+def name_keys(segments: list[str]) -> list[str]:
+    """Blocking keys for a name.
+
+    The whole core, plus each ' - ' segment on its own, because GEM writes both
+    '<Place> - <Operator> Gas Asset' and '<Operator> - <Place> Gas Asset' and we
+    cannot reliably tell which half is the field.
+    """
+    if not segments:
+        return []
+    keys = {" ".join(segments)}
+    if len(segments) > 1:
+        keys.update(segments)
+    return sorted(keys)
+
+
+def haversine_km(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
+    phi1, phi2 = math.radians(lat1), math.radians(lat2)
+    d_phi = phi2 - phi1
+    d_lambda = math.radians(lon2 - lon1)
+    a = (
+        math.sin(d_phi / 2) ** 2
+        + math.cos(phi1) * math.cos(phi2) * math.sin(d_lambda / 2) ** 2
+    )
+    return 2 * EARTH_RADIUS_KM * math.asin(math.sqrt(a))
+
+
+class UnionFind:
+    def __init__(self) -> None:
+        self._parent: dict[int, int] = {}
+        self._size: dict[int, int] = {}
+
+    def find(self, item: int) -> int:
+        self._parent.setdefault(item, item)
+        self._size.setdefault(item, 1)
+        root = item
+        while self._parent[root] != root:
+            root = self._parent[root]
+        while self._parent[item] != root:
+            self._parent[item], item = root, self._parent[item]
+        return root
+
+    def size_of(self, item: int) -> int:
+        return self._size[self.find(item)]
+
+    def union(self, left: int, right: int) -> bool:
+        """Merge two clusters. Returns False if they were already together."""
+        left_root, right_root = self.find(left), self.find(right)
+        if left_root == right_root:
+            return False
+        self._parent[right_root] = left_root
+        self._size[left_root] += self._size[right_root]
+        return True
+
+    def groups(self) -> dict[int, list[int]]:
+        clusters: dict[int, list[int]] = defaultdict(list)
+        for item in self._parent:
+            clusters[self.find(item)].append(item)
+        return clusters
+
+
+def load_records(path) -> list[dict[str, Any]]:
+    records = []
+    with path.open(encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if line:
+                records.append(json.loads(line))
+    return records
+
+
+def prepare(records: Iterable[dict[str, Any]], location_min_count: int) -> list[dict]:
+    """Attach normalized keys and discriminators to each record."""
+    prepared = []
+    for record in records:
+        segments, parentheticals = split_name(record.get("name") or "")
+        prepared.append(
+            {
+                **record,
+                "segments": segments,
+                "core": " ".join(segments),
+                "parentheticals": parentheticals,
+                "keys": name_keys(segments),
+            }
+        )
+
+    # A parenthetical seen on many records is boilerplate location text
+    # ("(iran)", "(alberta canada)"). A rare one discriminates ("(lamadian)",
+    # "(mc782)") and must block a join. This is learned from the corpus rather
+    # than from a hardcoded country list.
+    counts = Counter(
+        paren for record in prepared for paren in set(record["parentheticals"])
+    )
+    for record in prepared:
+        record["discriminators"] = sorted(
+            {
+                paren
+                for paren in record["parentheticals"]
+                if counts[paren] < location_min_count
+            }
+        )
+
+    # In '<A> - <B> Gas Asset' one half is the field and the other is the
+    # operator, and GEM writes it both ways round. The operator half recurs
+    # across many assets, the field half does not, so the rarest segment of a
+    # name is its anchor. Joining on a non-anchor segment is what produces
+    # 'Belmont County - Ascent' ~ 'Harrison County - Ascent': two different
+    # fields sharing an operator.
+    segment_counts = Counter(
+        segment for record in prepared for segment in set(record["segments"])
+    )
+    for record in prepared:
+        segments = record["segments"]
+        if segments:
+            rarest = min(segment_counts[segment] for segment in segments)
+            record["anchors"] = {
+                segment for segment in segments if segment_counts[segment] == rarest
+            }
+        else:
+            record["anchors"] = set()
+    return prepared
+
+
+def key_anchors_pair(key: str, left: dict, right: dict) -> bool:
+    """May ``key`` join these two records?
+
+    Always yes when it is a whole name, or when either side is a single-segment
+    name (the bare-name-versus-decorated-name case this tool exists for).
+    Otherwise the key must be the rarest segment on *both* sides.
+    """
+    if key in (left["core"], right["core"]):
+        return True
+    if len(left["segments"]) == 1 or len(right["segments"]) == 1:
+        return True
+    return key in left["anchors"] and key in right["anchors"]
+
+
+def discriminators_conflict(left: dict, right: dict) -> bool:
+    """Two records with different rare parentheticals are different assets."""
+    left_set, right_set = set(left["discriminators"]), set(right["discriminators"])
+    if not left_set or not right_set:
+        return False
+    return left_set.isdisjoint(right_set)
+
+
+def qualifiers_conflict(left: dict, right: dict) -> bool:
+    """One side carries a directional/ordinal token the other does not."""
+    only_one_side = set(left["core"].split()).symmetric_difference(
+        right["core"].split()
+    )
+    return any(token in QUALIFIER_TOKENS or token.isdigit() for token in only_one_side)
+
+
+def edge_vetoed(left: dict, right: dict) -> bool:
+    return discriminators_conflict(left, right) or qualifiers_conflict(left, right)
+
+
+def exact_edges(
+    prepared: list[dict], max_key_frequency: int
+) -> tuple[list[tuple[int, int, str]], list[tuple[str, int]]]:
+    """Pairs sharing a blocking key, ignoring keys too common to discriminate."""
+    by_key: dict[str, list[int]] = defaultdict(list)
+    for index, record in enumerate(prepared):
+        for key in record["keys"]:
+            by_key[key].append(index)
+
+    edges: list[tuple[int, int, str]] = []
+    suppressed: list[tuple[str, int]] = []
+    for key, indexes in by_key.items():
+        if len(indexes) < 2:
+            continue
+        if len(indexes) > max_key_frequency:
+            suppressed.append((key, len(indexes)))
+            continue
+        for position, left in enumerate(indexes):
+            for right in indexes[position + 1 :]:
+                if key_anchors_pair(key, prepared[left], prepared[right]):
+                    edges.append((left, right, key))
+    return edges, sorted(suppressed, key=lambda pair: -pair[1])
+
+
+def similarity_edges(
+    prepared: list[dict],
+    fuzzy_threshold: int,
+    geo_name_threshold: int,
+    geo_km: float,
+) -> tuple[list[tuple[int, int, int]], list[tuple[int, int, int, float]]]:
+    """Fuzzy and geo pairs, computed per country bucket off one cdist matrix."""
+    buckets: dict[str | None, list[int]] = defaultdict(list)
+    for index, record in enumerate(prepared):
+        buckets[record.get("country")].append(index)
+
+    fuzzy: list[tuple[int, int, int]] = []
+    geo: list[tuple[int, int, int, float]] = []
+    floor = min(fuzzy_threshold, geo_name_threshold)
+
+    for indexes in buckets.values():
+        if len(indexes) < 2:
+            continue
+        cores = [prepared[index]["core"] for index in indexes]
+        scores = process.cdist(
+            cores,
+            cores,
+            scorer=fuzz.token_sort_ratio,
+            score_cutoff=floor,
+            workers=-1,
+        )
+        left_positions, right_positions = np.nonzero(np.triu(scores, k=1))
+        for left_position, right_position in zip(left_positions, right_positions):
+            left = indexes[int(left_position)]
+            right = indexes[int(right_position)]
+            score = int(scores[left_position, right_position])
+            if score >= fuzzy_threshold:
+                fuzzy.append((left, right, score))
+                continue
+            distance = pair_distance_km(prepared[left], prepared[right])
+            if distance is not None and distance <= geo_km:
+                geo.append((left, right, score, distance))
+    return fuzzy, geo
+
+
+def pair_distance_km(left: dict, right: dict) -> float | None:
+    if None in (
+        left.get("latitude"),
+        left.get("longitude"),
+        right.get("latitude"),
+        right.get("longitude"),
+    ):
+        return None
+    return haversine_km(
+        left["latitude"], left["longitude"], right["latitude"], right["longitude"]
+    )
+
+
+CONFIDENCE_ORDER = {"high": 0, "medium": 1, "low": 2}
+
+
+def classify_confidence(group: dict) -> str:
+    """How much a group deserves to be trusted without close reading.
+
+    'high' is the pass-one tier: a clean two-record pair, joined on an exact
+    normalized name, in one country, contributed by two different sources. That
+    is the bare-name-versus-decorated-name duplicate this tool was built for,
+    and it is the shape entity-linkage misses entirely today.
+    """
+    signals = group["signals"]
+    exact = "exact-normalized-name" in group["reasons"]
+    size = len(group["resource_ids"])
+    similarity = signals["min_name_similarity"] or 0
+
+    if (
+        exact
+        and size == 2
+        and signals["same_country"]
+        and not signals["single_source"]
+        and not signals["discriminators"]
+    ):
+        return "high"
+    if exact and size <= 3 and signals["same_country"]:
+        return "medium"
+    if similarity >= 95 and size == 2 and signals["same_country"]:
+        return "medium"
+    return "low"
+
+
+def build_groups(
+    prepared: list[dict],
+    edges: list[tuple[int, int, str, Any]],
+    max_group_size: int,
+) -> tuple[list[dict], list[tuple[int, int]]]:
+    """Cluster the surviving edges, then assemble reviewable groups."""
+    reasons_by_pair: dict[tuple[int, int], set[str]] = defaultdict(set)
+    scores_by_pair: dict[tuple[int, int], int] = {}
+    distance_by_pair: dict[tuple[int, int], float] = {}
+
+    for left, right, reason, detail in edges:
+        if edge_vetoed(prepared[left], prepared[right]):
+            continue
+        pair = (min(left, right), max(left, right))
+        reasons_by_pair[pair].add(reason)
+        if reason == "exact-normalized-name":
+            scores_by_pair[pair] = 100
+        elif reason == "fuzzy-name":
+            scores_by_pair[pair] = max(scores_by_pair.get(pair, 0), int(detail))
+        elif reason == "geo-proximity":
+            score, distance = detail
+            scores_by_pair[pair] = max(scores_by_pair.get(pair, 0), int(score))
+            distance_by_pair[pair] = distance
+
+    # Agglomerate strongest edge first, refusing any join that would push a
+    # cluster past --max-group-size. Dropping whole oversized components (the
+    # obvious alternative) silently discards the strong exact-name pairs buried
+    # inside a geo-chained blob, so instead the weakest edges are the ones that
+    # lose. Ties break on resource id, so a run is reproducible.
+    def edge_strength(pair: tuple[int, int]) -> tuple[int, int, int, int]:
+        reasons = reasons_by_pair[pair]
+        if "exact-normalized-name" in reasons:
+            tier = 3
+        elif "fuzzy-name" in reasons:
+            tier = 2
+        else:
+            tier = 1
+        return (-tier, -scores_by_pair.get(pair, 0), pair[0], pair[1])
+
+    union = UnionFind()
+    deferred: list[tuple[int, int]] = []
+    for pair in sorted(reasons_by_pair, key=edge_strength):
+        left, right = pair
+        if union.find(left) == union.find(right):
+            continue
+        if union.size_of(left) + union.size_of(right) > max_group_size:
+            deferred.append(pair)
+            continue
+        union.union(left, right)
+
+    groups: list[dict] = []
+
+    for members in union.groups().values():
+        if len(members) < 2:
+            continue
+        members = sorted(members, key=lambda index: prepared[index]["id"])
+        records = [prepared[index] for index in members]
+        pairs = [
+            (min(a, b), max(a, b))
+            for position, a in enumerate(members)
+            for b in members[position + 1 :]
+        ]
+        known_pairs = [pair for pair in pairs if pair in reasons_by_pair]
+
+        reasons = sorted({r for pair in known_pairs for r in reasons_by_pair[pair]})
+        similarities = [scores_by_pair[p] for p in known_pairs if p in scores_by_pair]
+        distances = [distance_by_pair[p] for p in known_pairs if p in distance_by_pair]
+        countries = sorted({r["country"] for r in records if r.get("country")})
+        sources = sorted({s for r in records for s in r.get("sources") or []})
+
+        group = {
+            "resource_ids": [r["id"] for r in records],
+            "reasons": reasons,
+            "signals": {
+                "normalized_names": sorted({r["core"] for r in records}),
+                "min_name_similarity": min(similarities) if similarities else None,
+                "countries": countries,
+                "same_country": len(countries) <= 1,
+                "max_distance_km": round(max(distances), 2) if distances else None,
+                "discriminators": sorted(
+                    {d for r in records for d in r["discriminators"]}
+                ),
+                "sources": sources,
+                "single_source": len(sources) <= 1,
+            },
+            "members": [
+                {
+                    "id": r["id"],
+                    "name": r["name"],
+                    "country": r["country"],
+                    "basin": r["basin"],
+                    "state_province": r["state_province"],
+                    "operators": r["operators"],
+                    "sources": r["sources"],
+                }
+                for r in records
+            ],
+            "decision": None,
+            "reason": None,
+        }
+
+        group["confidence"] = classify_confidence(group)
+        groups.append(group)
+
+    # Most trustworthy first: exact-key, cross-source, same-country, tightest.
+    groups.sort(
+        key=lambda g: (
+            CONFIDENCE_ORDER[g["confidence"]],
+            "exact-normalized-name" not in g["reasons"],
+            g["signals"]["single_source"],
+            not g["signals"]["same_country"],
+            -(g["signals"]["min_name_similarity"] or 0),
+            len(g["resource_ids"]),
+        )
+    )
+    return groups, deferred
+
+
+def summarize(
+    groups: list[dict], deferred, prepared, suppressed_keys, withheld
+) -> None:
+    print(f"\n{len(groups)} candidate groups proposed", file=sys.stderr)
+
+    if withheld:
+        detail = ", ".join(f"{count} {tier}" for tier, count in withheld.most_common())
+        print(
+            f"  ({detail} withheld by --min-confidence; re-run wider after "
+            "merging this tier)",
+            file=sys.stderr,
+        )
+
+    by_confidence = Counter(g["confidence"] for g in groups)
+    for tier, count in sorted(
+        by_confidence.items(), key=lambda kv: CONFIDENCE_ORDER[kv[0]]
+    ):
+        print(f"  confidence {tier:<18} {count}", file=sys.stderr)
+
+    by_reason = Counter(reason for g in groups for reason in g["reasons"])
+    for reason, count in by_reason.most_common():
+        print(f"  reason {reason:<22} {count}", file=sys.stderr)
+
+    sizes = Counter(len(g["resource_ids"]) for g in groups)
+    for size in sorted(sizes):
+        print(f"  size {size:<24} {sizes[size]}", file=sys.stderr)
+
+    cross_source = sum(1 for g in groups if not g["signals"]["single_source"])
+    cross_country = sum(1 for g in groups if not g["signals"]["same_country"])
+    print(f"  cross-source groups        {cross_source}", file=sys.stderr)
+    print(f"  single-source groups       {len(groups) - cross_source}", file=sys.stderr)
+    print(f"  cross-country groups       {cross_country}", file=sys.stderr)
+
+    if deferred:
+        print(
+            f"\n{len(deferred)} edge(s) not applied because the cluster had "
+            "already reached --max-group-size:",
+            file=sys.stderr,
+        )
+        for left, right in deferred[:10]:
+            left_name = (prepared[left]["name"] or "")[:34]
+            right_name = (prepared[right]["name"] or "")[:34]
+            print(f"  {left_name}  ~  {right_name}", file=sys.stderr)
+
+    if suppressed_keys:
+        print(
+            f"\n{len(suppressed_keys)} blocking key(s) ignored as too common "
+            "(likely operator names); raise --max-key-frequency to include them:",
+            file=sys.stderr,
+        )
+        for key, count in suppressed_keys[:10]:
+            print(f"  {count:>4}x  {key}", file=sys.stderr)
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--fuzzy-threshold", type=int, default=90)
+    parser.add_argument("--geo-km", type=float, default=10.0)
+    parser.add_argument("--geo-name-threshold", type=int, default=70)
+    parser.add_argument("--max-group-size", type=int, default=6)
+    parser.add_argument(
+        "--max-key-frequency",
+        type=int,
+        default=6,
+        help="ignore a blocking key shared by more than this many resources",
+    )
+    parser.add_argument(
+        "--location-min-count",
+        type=int,
+        default=5,
+        help="a parenthetical seen at least this often is boilerplate location text",
+    )
+    parser.add_argument(
+        "--min-confidence",
+        choices=("high", "medium", "low"),
+        default="high",
+        help=(
+            "only emit groups at this confidence or better (default: high). "
+            "Merge the high tier first, re-fetch, then re-run wider."
+        ),
+    )
+    parser.add_argument("--in", dest="in_path", default=str(RESOURCES_PATH))
+    parser.add_argument("--out", dest="out_path", default=str(CANDIDATES_PATH))
+    args = parser.parse_args()
+
+    from pathlib import Path
+
+    records = load_records(Path(args.in_path))
+    print(f"loaded {len(records)} records", file=sys.stderr)
+
+    prepared = prepare(records, args.location_min_count)
+
+    exact, suppressed_keys = exact_edges(prepared, args.max_key_frequency)
+    fuzzy, geo = similarity_edges(
+        prepared, args.fuzzy_threshold, args.geo_name_threshold, args.geo_km
+    )
+    print(
+        f"edges: exact={len(exact)} fuzzy={len(fuzzy)} geo={len(geo)}", file=sys.stderr
+    )
+
+    edges: list[tuple[int, int, str, Any]] = []
+    edges.extend(
+        (left, right, "exact-normalized-name", key) for left, right, key in exact
+    )
+    edges.extend((left, right, "fuzzy-name", score) for left, right, score in fuzzy)
+    edges.extend(
+        (left, right, "geo-proximity", (score, distance))
+        for left, right, score, distance in geo
+    )
+
+    groups, deferred = build_groups(prepared, edges, args.max_group_size)
+
+    withheld = Counter(
+        group["confidence"]
+        for group in groups
+        if CONFIDENCE_ORDER[group["confidence"]] > CONFIDENCE_ORDER[args.min_confidence]
+    )
+    groups = [
+        group
+        for group in groups
+        if CONFIDENCE_ORDER[group["confidence"]]
+        <= CONFIDENCE_ORDER[args.min_confidence]
+    ]
+    for position, group in enumerate(groups, start=1):
+        group["group_id"] = f"g{position:04d}"
+
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "generated_from": args.in_path,
+        "params": {
+            "fuzzy_threshold": args.fuzzy_threshold,
+            "geo_km": args.geo_km,
+            "geo_name_threshold": args.geo_name_threshold,
+            "max_group_size": args.max_group_size,
+            "max_key_frequency": args.max_key_frequency,
+            "location_min_count": args.location_min_count,
+            "min_confidence": args.min_confidence,
+        },
+        "groups": groups,
+    }
+    Path(args.out_path).write_text(
+        json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+    summarize(groups, deferred, prepared, suppressed_keys, withheld)
+    print(f"\nwrote {len(groups)} groups to {args.out_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/review_merge_candidates.py
+++ b/scripts/review_merge_candidates.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python
+"""List, approve, or deny merge candidates.
+
+Throwaway demo helper -- not shipped code, not committed.
+
+    uv run scripts/review_merge_candidates.py list
+    uv run scripts/review_merge_candidates.py list --mine
+    uv run scripts/review_merge_candidates.py approve 21 22 --notes "bare vs decorated name"
+    uv run scripts/review_merge_candidates.py deny 23 --notes "different reservoirs"
+
+Approving mints a NEW resource (merged_resource_id), so scripts/data/resources.jsonl
+goes stale afterwards -- re-run fetch_resources.py before searching again.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+import httpx
+
+from _common import CANDIDATES_PATH, auth_headers, base_url
+
+
+def load_created_ids(path: Path) -> dict[int, str]:
+    """Map candidate id -> group id for candidates this workflow created."""
+    if not path.is_file():
+        return {}
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    return {
+        group["created_candidate_id"]: group["group_id"]
+        for group in payload.get("groups", [])
+        if group.get("created_candidate_id")
+    }
+
+
+def record_status(path: Path, candidate_id: int, status: str, merged_id) -> None:
+    """Write a review outcome back into candidates.json."""
+    if not path.is_file():
+        return
+    payload = json.loads(path.read_text(encoding="utf-8"))
+    changed = False
+    for group in payload.get("groups", []):
+        if group.get("created_candidate_id") == candidate_id:
+            group["created_status"] = status
+            group["merged_resource_id"] = merged_id
+            changed = True
+    if changed:
+        path.write_text(
+            json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8"
+        )
+
+
+def cmd_list(client: httpx.Client, ours: dict[int, str], mine_only: bool) -> int:
+    response = client.get("/oil-gas-fields/merge-candidates", headers=auth_headers())
+    response.raise_for_status()
+    candidates = response.json()
+
+    if mine_only:
+        candidates = [c for c in candidates if c["id"] in ours]
+
+    if not candidates:
+        print("no merge candidates", file=sys.stderr)
+        return 0
+
+    print(f"{'id':>5}  {'group':<7} {'status':<9} {'merged':>7}  resource_ids")
+    for candidate in candidates:
+        group = ours.get(candidate["id"], "-")
+        merged = candidate.get("merged_resource_id") or "-"
+        print(
+            f"{candidate['id']:>5}  {group:<7} {candidate['status']:<9} "
+            f"{str(merged):>7}  {candidate['resource_ids']}"
+        )
+    print(f"\n{len(candidates)} candidate(s)", file=sys.stderr)
+    return 0
+
+
+def cmd_review(
+    client: httpx.Client,
+    action: str,
+    candidate_ids: list[int],
+    notes: str | None,
+    ours: dict[int, str],
+    path: Path,
+    force: bool,
+) -> int:
+    # Guard against reviewing candidates this workflow did not create, since the
+    # demo deployment is shared and approval is not obviously reversible.
+    foreign = [i for i in candidate_ids if i not in ours]
+    if foreign and not force:
+        print(
+            f"refusing: {foreign} not created by this workflow "
+            f"(not in {path.name}); pass --force to override",
+            file=sys.stderr,
+        )
+        return 1
+
+    body = {"review_notes": notes} if notes else None
+    failed = 0
+    for candidate_id in candidate_ids:
+        response = client.post(
+            f"/oil-gas-fields/merge-candidates/{candidate_id}/{action}",
+            json=body,
+            headers=auth_headers(),
+        )
+        if response.is_success:
+            candidate = response.json()
+            merged = candidate.get("merged_resource_id")
+            record_status(path, candidate_id, candidate["status"], merged)
+            print(
+                f"{candidate_id} -> {candidate['status']}"
+                + (f" (merged resource {merged})" if merged else "")
+            )
+        else:
+            failed += 1
+            print(
+                f"{candidate_id} -> HTTP {response.status_code} {response.text[:200]}",
+                file=sys.stderr,
+            )
+    return 1 if failed else 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--file", default=str(CANDIDATES_PATH))
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    list_parser = sub.add_parser("list", help="show merge candidates")
+    list_parser.add_argument(
+        "--mine",
+        action="store_true",
+        help="only candidates created by this workflow",
+    )
+
+    for action in ("approve", "deny"):
+        action_parser = sub.add_parser(action, help=f"{action} merge candidates")
+        action_parser.add_argument("candidate_ids", nargs="+", type=int)
+        action_parser.add_argument("--notes")
+        action_parser.add_argument(
+            "--force",
+            action="store_true",
+            help="allow reviewing candidates this workflow did not create",
+        )
+
+    args = parser.parse_args()
+    path = Path(args.file)
+    ours = load_created_ids(path)
+
+    with httpx.Client(base_url=base_url(), timeout=30.0) as client:
+        if args.command == "list":
+            return cmd_list(client, ours, args.mine)
+        return cmd_review(
+            client, args.command, args.candidate_ids, args.notes, ours, path, args.force
+        )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Throwaway developer tooling under `scripts/`, opened as a Draft because others may find it useful. Not wired into CI, not imported by any package, no lockfile change.

Discussion in [STIT-673].

## Why

`entity-linkage` blocks on `name.strip().casefold()` and confirms on `country.strip().upper()` — both exact. On the demo corpus (9,187 resources) that finds **zero** groups: GEM writes `Darquain Oil Field (Iran)` while CCR/BC/WM write `Darquain`, so the names never collide. The blocking key is the constraint, not the comparison.

Normalizing the decoration away finds **273 high-confidence pairs** on the same data.

| bare source | GEM |
| --- | --- |
| `Darquain` (IRN, ccr) | `Darquain Oil Field (Iran)` |
| `DEEP BASIN` (CAN, bc) | `Deep Basin Gas Field (British Columbia, Canada)` |
| `Dębowiec Śląski` (POL) | `Dębowiec Śląski Gas Field (Poland)` |

## Workflow

```bash
uv run scripts/fetch_resources.py                                   # corpus -> data/resources.jsonl
uv run --with rapidfuzz --with numpy scripts/find_candidates.py     # -> data/candidates.json
# review: set "decision" to merge/skip per group
uv run scripts/create_merge_candidate.py --from-file --dry-run
uv run scripts/review_merge_candidates.py list --mine
```

The search script **proposes and explains, never decides** — every group comes out with `"decision": null` plus the signals that justified it. Output is gated to a `high` confidence tier by default; merge that tier, re-fetch, re-run wider. Approving mints a new resource, so snapshots go stale by design.

## Matching

- **exact** normalized name; a ` - ` split also blocks on each half, but only when that half is the rarest segment on both sides — otherwise `Belmont County - Ascent` matches `Harrison County - Ascent` on the operator.
- **fuzzy** `token_sort_ratio >= 90` within a country bucket. Deliberately not `token_set_ratio`: it scores `MARTIN` against `MARTIN CREEK` at 100 and chains the corpus into one 1,021-member blob.
- **geo** within 10 km with name similarity >= 70.
- Vetoes on conflicting rare parentheticals (`Daqing (Lamadian)` vs `(Saertu)`) and directional qualifiers (`Blueberry East` vs `West`). Parenthetical rarity is learned from the corpus, so `(Iran)` is treated as boilerplate.

## Verified

Run end-to-end against the PR-0242 demo deployment:

- 8/8 hand-picked ground-truth duplicates group correctly; `Daqing` (3 reservoirs) and `Dalmatian North/South` correctly stay apart.
- Created 6 candidates, approved one; merged resource 9226 correctly combines the `ccr` and `gem` records. Re-running skipped already-created groups.
- `ruff check` and `ruff format --check` pass on `scripts/`.

## Notes for reviewers

- `scripts/data/` is gitignored — fetched snapshots and review state are per-run and per-deployment.
- `_common.py` defaults to the PR-0242 demo URL (inherited from the original helper); that deployment is ephemeral, so set `STITCH_API_BASE_URL` in `.env`. Credentials come from `STITCH_CLIENT_PRIVILEGED_BEARER_TOKEN`; no token is ever printed.
- The normalizer is not folded into `entity-linkage` here. If it proves out, that is a separate pre-approved architectural conversation per `CONTRIBUTING.md`, and it would want the DB-side normalized-name match already tracked as STIT-573.

## AI assistance

Written with Claude Code. Verification was the ground-truth pass/fail check above plus the live end-to-end run against the demo deployment; the 273-row high-confidence tier was read in full during review, which is where the two held-back groups (`OTHER AREAS`, a catch-all bucket, and `Qasr (Pre-2021)`, a vintage qualifier) came from.

[STIT-673]: https://rmi1.atlassian.net/browse/STIT-673?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ