### PR TITLE
chore(frontend): shorten source labels in UI

### DIFF
--- a/deployments/stitch-frontend/README.md
+++ b/deployments/stitch-frontend/README.md
@@ -689,9 +689,9 @@ export const SOURCE_COLORS = {
 };
 
 export const SOURCE_LABELS = {
-  gem: "GEM Database",
-  wm: "Woodmac Database",
-  rmi: "User Generated",
+  gem: "GEM",
+  wm: "Woodmac",
+  rmi: "Custom",
   llm: "LLM",
 };
 ```

--- a/deployments/stitch-frontend/README.md
+++ b/deployments/stitch-frontend/README.md
@@ -691,7 +691,7 @@ export const SOURCE_COLORS = {
 export const SOURCE_LABELS = {
   gem: "GEM",
   wm: "Woodmac",
-  rmi: "Custom",
+  rmi: "RMI",
   llm: "LLM",
 };
 ```

--- a/deployments/stitch-frontend/src/components/ResourceFieldCard.jsx
+++ b/deployments/stitch-frontend/src/components/ResourceFieldCard.jsx
@@ -36,7 +36,7 @@ function arraysEqual(a, b) {
   return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
-// Build a bare "Custom" (rmi) source that populates only `fieldKey`, to
+// Build a bare "RMI" (rmi) source that populates only `fieldKey`, to
 // be created and attached to the resource. `name`/`country` are required-present
 // keys on the field model (null unless the panel's field IS name/country — the
 // [fieldKey] spread then overrides the null). The curator's note and an audit
@@ -123,7 +123,7 @@ function MoveButtons({ onMoveUp, onMoveDown, canMoveUp, canMoveDown, label }) {
 }
 
 // The value entry form, revealed after the curator clicks "+". Lets them enter a
-// new "Custom" value (with an optional note) for this field; on Save it
+// new "RMI" value (with an optional note) for this field; on Save it
 // creates and attaches an rmi source to the resource.
 function AddSourceForm({ endpoint, resourceId, fieldKey, onSaved }) {
   const createSource = useCreateSourceForResource(endpoint);

--- a/deployments/stitch-frontend/src/components/ResourceFieldCard.jsx
+++ b/deployments/stitch-frontend/src/components/ResourceFieldCard.jsx
@@ -36,7 +36,7 @@ function arraysEqual(a, b) {
   return a.length === b.length && a.every((value, index) => value === b[index]);
 }
 
-// Build a bare "User Generated" (rmi) source that populates only `fieldKey`, to
+// Build a bare "Custom" (rmi) source that populates only `fieldKey`, to
 // be created and attached to the resource. `name`/`country` are required-present
 // keys on the field model (null unless the panel's field IS name/country — the
 // [fieldKey] spread then overrides the null). The curator's note and an audit
@@ -123,7 +123,7 @@ function MoveButtons({ onMoveUp, onMoveDown, canMoveUp, canMoveDown, label }) {
 }
 
 // The value entry form, revealed after the curator clicks "+". Lets them enter a
-// new "User Generated" value (with an optional note) for this field; on Save it
+// new "Custom" value (with an optional note) for this field; on Save it
 // creates and attaches an rmi source to the resource.
 function AddSourceForm({ endpoint, resourceId, fieldKey, onSaved }) {
   const createSource = useCreateSourceForResource(endpoint);

--- a/deployments/stitch-frontend/src/components/SourceMixBar.test.jsx
+++ b/deployments/stitch-frontend/src/components/SourceMixBar.test.jsx
@@ -68,7 +68,7 @@ describe("SourceMixBar", () => {
     render(<SourceMixBar provenance={mixedSources} />);
     expect(
       screen.getByRole("group", {
-        name: /data source mix: woodmac database: 1 field \(50%\); gem database: 1 field \(50%\)/i,
+        name: /data source mix: woodmac: 1 field \(50%\); gem: 1 field \(50%\)/i,
       }),
     ).toBeInTheDocument();
   });

--- a/deployments/stitch-frontend/src/constants/sourceMeta.js
+++ b/deployments/stitch-frontend/src/constants/sourceMeta.js
@@ -25,7 +25,7 @@ export const SOURCE_LABELS = {
   ccr: "C&C Reservoirs",
   alb: "Alberta Energy Regulator",
   bc: "BC Energy Regulator",
-  rmi: "Custom",
+  rmi: "RMI",
 };
 
 export const UNKNOWN_SOURCE_LABEL = "Source unavailable";

--- a/deployments/stitch-frontend/src/constants/sourceMeta.js
+++ b/deployments/stitch-frontend/src/constants/sourceMeta.js
@@ -20,12 +20,12 @@ export const SOURCE_COLORS = {
 
 export const SOURCE_LABELS = {
   llm: "LLM",
-  gem: "GEM Database",
-  wm: "Woodmac Database",
+  gem: "GEM",
+  wm: "Woodmac",
   ccr: "C&C Reservoirs",
   alb: "Alberta Energy Regulator",
   bc: "BC Energy Regulator",
-  rmi: "User Generated",
+  rmi: "Custom",
 };
 
 export const UNKNOWN_SOURCE_LABEL = "Source unavailable";


### PR DESCRIPTION
Claude was used to generate the code for this PR. 

## Summary
This PR updates Data source labeling to favour brevity over specificity. 

- Drop "Database" suffix from source labels ("GEM Database" -> "GEM", "Woodmac Database" -> "Woodmac")
- Rename `rmi` label from "User Generated" to "Custom" for brevity

## Related issues
Closes: [STIT-667]

## Before
<img width="924" height="152" alt="Screenshot 2026-08-20 at 10 48 56" src="https://github.com/user-attachments/assets/798739be-2f63-491f-ac5d-359b17a48aec" />

## After
<img width="937" height="156" alt="Screenshot 2026-08-20 at 10 49 06" src="https://github.com/user-attachments/assets/98793d49-51ef-4135-b59d-19018753b731" />

## Testing
- `npx vitest run` — all 287 tests pass
- Load the resources list and a resource detail page; confirm the `SourceMixBar` renders the new labels in both the inline summary and the `showLabels` variant
- Add a custom value via `ResourceFieldCard`; confirm the new source row shows "Custom" instead of "User Generated"

## Checklist
- [x] PR is focused on a single concern
- [x] Tests pass locally and in CI
- [x] Docs updated for user-visible changes
- [x] AI-assisted portions declared (see [CONTRIBUTING.md](https://github.com/RMI/.github/blob/main/CONTRIBUTING.md))


[STIT-667]: https://rmi1.atlassian.net/browse/STIT-667?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ