### PR TITLE
feat(frontend): set browser tab title per route

### DIFF
--- a/deployments/stitch-frontend/src/hooks/useDocumentTitle.js
+++ b/deployments/stitch-frontend/src/hooks/useDocumentTitle.js
@@ -1,8 +1,8 @@
 import { useEffect } from "react";
 
-// Sets the browser tab title while a page is mounted. Callers pass the
-// page-specific portion (e.g. "Resources"); the app name suffix is applied here
-// so the format stays consistent across routes.
+// Sets the browser tab title. Callers pass the page-specific portion
+// (e.g. "Resources"); the app name suffix is applied here so the format
+// stays consistent across routes.
 export function useDocumentTitle(title) {
   useEffect(() => {
     document.title = title ? `${title} - Stitch` : "Stitch";

--- a/deployments/stitch-frontend/src/hooks/useDocumentTitle.js
+++ b/deployments/stitch-frontend/src/hooks/useDocumentTitle.js
@@ -1,0 +1,10 @@
+import { useEffect } from "react";
+
+// Sets the browser tab title while a page is mounted. Callers pass the
+// page-specific portion (e.g. "Resources"); the app name suffix is applied here
+// so the format stays consistent across routes.
+export function useDocumentTitle(title) {
+  useEffect(() => {
+    document.title = title ? `${title} - Stitch` : "Stitch";
+  }, [title]);
+}

--- a/deployments/stitch-frontend/src/pages/EntityLinkagePage.jsx
+++ b/deployments/stitch-frontend/src/pages/EntityLinkagePage.jsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useConfig } from "../config/useConfig";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import StructuredDataView from "../components/StructuredDataView";
 import Button from "../components/Button";
 import StateBadge from "../components/StateBadge";
@@ -136,6 +137,7 @@ function RunResult({ record }) {
 }
 
 export default function EntityLinkagePage() {
+  useDocumentTitle("Entity linkage");
   const config = useConfig();
   const { getAccessTokenSilently } = useAuth0();
   const baseUrl = config.entityLinkageBaseUrl;

--- a/deployments/stitch-frontend/src/pages/EtlPage.jsx
+++ b/deployments/stitch-frontend/src/pages/EtlPage.jsx
@@ -1,6 +1,7 @@
 import { useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useConfig } from "../config/useConfig";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import StructuredDataView from "../components/StructuredDataView";
 import Button from "../components/Button";
 import Input from "../components/Input";
@@ -284,6 +285,7 @@ function EtlPanel({ title, description, baseUrl, fields, getToken }) {
 }
 
 export default function EtlPage() {
+  useDocumentTitle("ETL pipelines");
   const config = useConfig();
   const { getAccessTokenSilently } = useAuth0();
 

--- a/deployments/stitch-frontend/src/pages/HomePage.jsx
+++ b/deployments/stitch-frontend/src/pages/HomePage.jsx
@@ -1,5 +1,7 @@
 import ResourcesView from "../components/ResourcesView";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 
 export default function HomePage() {
+  useDocumentTitle("Resources");
   return <ResourcesView endpoint="oil-gas-fields" />;
 }

--- a/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.jsx
+++ b/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.jsx
@@ -3,6 +3,7 @@ import { Link } from "react-router";
 import Button from "../components/Button";
 import MergeSourceComparison from "../components/MergeSourceComparison";
 import MergedResourceView from "../components/MergedResourceView";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { useMergeCandidateName } from "../hooks/useMergeCandidateName";
 import { useMergedResourceDetail } from "../hooks/useMergedResourceDetail";
 import {
@@ -369,6 +370,7 @@ function CandidateDecisionPanel({
 }
 
 export default function MergeCandidateReviewPage() {
+  useDocumentTitle("Merge review");
   const [selectedId, setSelectedId] = useState(null);
   const [reviewNotes, setReviewNotes] = useState("");
 

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
@@ -6,6 +6,7 @@ import {
   useResourceDetail,
   useSourceDetail,
 } from "../hooks/useResources";
+import { useDocumentTitle } from "../hooks/useDocumentTitle";
 import { createAuthenticatedFetcher } from "../auth/api";
 import { useConfig } from "../config/useConfig";
 import { createLLMSuggestion } from "../queries/api";
@@ -563,6 +564,8 @@ export default function ResourceDetailPage() {
     isLoading,
     isError,
   } = useResourceDetail(endpoint, numericId, validId);
+
+  useDocumentTitle(detailView?.data?.name ?? "Resource");
 
   return (
     <div className="mx-auto max-w-4xl">


### PR DESCRIPTION
Claude was used to support drafting this simple PR. 

## Summary
- Adds a small `useDocumentTitle` hook and wires it into each routed page so the browser tab reflects the current view. 
- List/index pages use their nav label (e.g. `Resources - Stitchh`); `ResourceDetailPagee` uses the resolved resource name, failling back to `Resource - Stitch` while loading or on invalid/errored IDs. 

## Related issues
Closes: [STIT-666] 😈

## Before
<img width="1194" height="50" alt="Screenshot 2026-08-20 at 11 07 13" src="https://github.com/user-attachments/assets/6a5b92d1-5e08-4086-ba50-6cbd49b399bc" />

## After
<img width="1189" height="53" alt="Screenshot 2026-08-20 at 11 08 17" src="https://github.com/user-attachments/assets/abc47228-2ea0-44a1-9f10-74beeb3845bb" />

## Testing
- make frontend-dev, click each nav item, confirm the tab title updates.
- Open a resource detail page, confirm the tab shows Resource - Stitch briefly, then swaps to the resource name.
- Visit an invalid resource ID (e.g. /oil-gas-fields/abc), confirm the tab stays on Resource - Stitch.

## Checklist
- [x] PR is focused on a single concern
- [x] Tests pass locally and in CI
- [x] Docs updated for user-visible changes
- [x] AI-assisted portions declared (see [CONTRIBUTING.md](https://github.com/RMI/.github/blob/main/CONTRIBUTING.md))


[STIT-666]: https://rmi1.atlassian.net/browse/STIT-666?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ