### PR TITLE
fix(frontend): match FieldCard left-border width to source rows

### DIFF
--- a/deployments/stitch-frontend/src/components/FieldCard.jsx
+++ b/deployments/stitch-frontend/src/components/FieldCard.jsx
@@ -57,7 +57,7 @@ export function FieldCard({
   );
 
   const boxClasses =
-    "min-h-[2.5rem] w-full rounded-md border border-line bg-panel px-3 py-2 text-left text-sm text-ink";
+    "min-h-[2.5rem] w-full rounded-md border border-line border-l-4 bg-panel px-3 py-2 text-left text-sm text-ink";
 
   return (
     <div className="min-w-0">


### PR DESCRIPTION
Claude was used in this PR. 

## Summary
- `FieldCard` colored left accent was 1px while `SourceValueRow` in the expanded dropdown uses 4px. This fixes that 

## Related issues
Closes: [STIT-637] 

## Before
<img width="226" height="232" alt="Screenshot 2026-08-20 at 11 23 45" src="https://github.com/user-attachments/assets/8ff6974b-1335-4bd3-bb07-b334d1c308ed" />

## After
<img width="238" height="241" alt="Screenshot 2026-08-20 at 11 23 55" src="https://github.com/user-attachments/assets/80c8b82a-41b5-44c0-ab55-b007fc8b7b4c" />

## Checklist
- [x] PR is focused on a single concern
- [x] Tests pass locally and in CI
- [x] Docs updated for user-visible changes
- [x] AI-assisted portions declared (see [CONTRIBUTING.md](https://github.com/RMI/.github/blob/main/CONTRIBUTING.md))


[STIT-637]: https://rmi1.atlassian.net/browse/STIT-637?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ