### PR TITLE
fix(frontend): show merged resource name in merged review queue

### DIFF
--- a/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.jsx
+++ b/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.jsx
@@ -55,8 +55,18 @@ function candidateSourcesTitle(candidate) {
 }
 
 function CandidateQueueItem({ candidate, isSelected, onSelect }) {
-  const name = useMergeCandidateName(ENDPOINT, candidate.resource_ids);
-  const displayName = name ?? `Candidate #${candidate.id}`;
+  const sourceName = useMergeCandidateName(ENDPOINT, candidate.resource_ids);
+  // Post-merge, the source resources are null shells, so the merged resource
+  // is the authoritative name source. The hook is disabled until an id exists,
+  // so pending candidates skip the fetch.
+  const { data: mergedResource } = useMergedResourceDetail(
+    ENDPOINT,
+    candidate.merged_resource_id,
+  );
+  const mergedName = isEmptyValue(mergedResource?.data?.name)
+    ? null
+    : mergedResource.data.name;
+  const displayName = mergedName ?? sourceName ?? `Candidate #${candidate.id}`;
 
   return (
     <button

--- a/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.test.jsx
@@ -172,9 +172,28 @@ describe("MergeCandidateReviewPage", () => {
     expect(within(pendingItem).queryByText("PENDING")).not.toBeInTheDocument();
 
     const approvedItem = await screen.findByRole("button", {
-      name: /Arabian Consolidated/,
+      name: /Arabian Merged/,
     });
     expect(within(approvedItem).getByText("APPROVED")).toBeInTheDocument();
+  });
+
+  it("resolves an approved queue item's name from the merged resource", async () => {
+    // Post-merge the source resources are null shells, so the queue must
+    // resolve the name from merged_resource_id, not from resource_ids.
+    vi.mocked(getResourceDetail).mockImplementation((_config, id) => {
+      if (id === 201 || id === 202) {
+        return Promise.resolve({ data: { name: null }, provenance: {} });
+      }
+      return Promise.resolve(resourceDetailsById[id]);
+    });
+    renderWithQueryClient(<MergeCandidateReviewPage />);
+
+    expect(
+      await screen.findByRole("button", { name: /Arabian Merged/ }),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByRole("button", { name: /Candidate #12/ }),
+    ).not.toBeInTheDocument();
   });
 
   it("shows the compare-derived name in the detail panel heading", async () => {


### PR DESCRIPTION
Claude was used in support of this PR.

## Summary
-> Before: approved items in the Merge Review queue were falling back to "Candidate #N"
-> After: The queue handles naming in a similar way to how it is already handled in the decision panel: it prefers the merged resource's name (via `useMergedResourceDetail(merged_resource_id)`) and only falls back to the source-derived name. Mirrors the cascade in `CandidateQueueItem`

## Before
<img width="352" height="466" alt="Screenshot 2026-08-20 at 15 09 12" src="https://github.com/user-attachments/assets/2b299b04-83bc-43e1-aeea-5b0a3e567c08" />

## After
<img width="339" height="465" alt="Screenshot 2026-08-20 at 15 09 24" src="https://github.com/user-attachments/assets/415e34df-fbec-4356-9a63-c6c0ff9bf330" />

## Related issues
Closes: [STIT-668]

## Checklist
- [x] PR is focused on a single concern
- [x] Tests pass locally and in CI
- [x] Docs updated for user-visible changes
- [x] AI-assisted portions declared (see [CONTRIBUTING.md](https://github.com/RMI/.github/blob/main/CONTRIBUTING.md))


[STIT-668]: https://rmi1.atlassian.net/browse/STIT-668?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ