### PR TITLE
fix(frontend): bump nanoid and brace-expansion to patch high-severity

### DIFF
--- a/deployments/stitch-frontend/package-lock.json
+++ b/deployments/stitch-frontend/package-lock.json
@@ -1898,9 +1898,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.8",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-      "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3269,9 +3269,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
… advisories

Resolve two high-severity npm advisories in the frontend lockfile. Both are transitive dependencies whose fixed versions satisfy the existing ranges, so only package-lock.json changes.

- nanoid 3.3.17 -> 3.3.18 (via postcss): GHSA-2v37-7h3g-55p8, unbounded loop when a custom generator is called with size zero. This is the open Dependabot alert.
- brace-expansion 5.0.8 -> 5.0.9 (dev-only, via minimatch): GHSA-rgw5-rvv9-x895 / CVE-2026-14257, DoS via unbounded intermediate arrays. Surfaced by `npm audit`; not yet raised as a Dependabot alert.

Verified: `npm audit --audit-level=high` reports 0 vulnerabilities; `npm ci` and `npm run build` succeed.

## Summary
<!-- what changed and why -->

## Related issues
Closes: 

## Testing
<!-- how you validated behavior — automated tests or manual reproduction -->

## Checklist
- [ ] PR is focused on a single concern
- [ ] Tests pass locally and in CI
- [ ] Docs updated for user-visible changes
- [ ] AI-assisted portions declared (see [CONTRIBUTING.md](https://github.com/RMI/.github/blob/main/CONTRIBUTING.md))
