### PR TITLE
chore(readme): update deployment links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,8 @@ Stitch is an oil & gas asset data platform built by [RMI](https://rmi.org). It c
 - **Serves** curated, source-attributed data through a UI and API, with permission-aware access by source
 
 **See it live:**
-
-- Dress rehearsal (prod-ish): https://brave-cliff-09493391e.7.azurestaticapps.net/
-- Dev (`main`): https://witty-mushroom-017a3dc1e.1.azurestaticapps.net/
+- Dev (Deployed from `main` with fake data): https://https://stitch-dev.rmi.org/
+- Dress rehearsal (Deployed from `production` with real data): https://brave-cliff-09493391e.7.azurestaticapps.net/
 
 ## Quick start
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Stitch is an oil & gas asset data platform built by [RMI](https://rmi.org). It c
 - **Serves** curated, source-attributed data through a UI and API, with permission-aware access by source
 
 **See it live:**
-- Dev (Deployed from `main` with fake data): https://https://stitch-dev.rmi.org/
+- Dev (Deployed from `main` with fake data): https://stitch-dev.rmi.org/
 - Dress rehearsal (Deployed from `production` with real data): https://brave-cliff-09493391e.7.azurestaticapps.net/
 
 ## Quick start


### PR DESCRIPTION
Removed duplicate deployment links and fixed a URL.
Relates to [STIT-625]

[STIT-625]: https://rmi1.atlassian.net/browse/STIT-625?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ