### PR TITLE
feat: redirect merged-away resources to their merged target (STIT-418)

### DIFF
--- a/deployments/api/src/stitch/api/db/og_field_resource_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_resource_actions.py
@@ -154,9 +154,7 @@ async def get_resolved(
     by construction (``apply_resource_merge`` always targets a brand-new row), so
     ``get_root`` terminates.
     """
-    model = await session.scalar(
-        select(ResourceModel).where(ResourceModel.id == id)
-    )
+    model = await session.scalar(select(ResourceModel).where(ResourceModel.id == id))
     if model is None:
         raise HTTPException(
             status_code=HTTP_404_NOT_FOUND, detail=f"No Resource with id `{id}` found."

--- a/deployments/api/src/stitch/api/db/og_field_resource_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_resource_actions.py
@@ -139,6 +139,32 @@ async def get(
     )
 
 
+async def get_resolved(
+    session: AsyncSession,
+    id: int,
+    licensed_sources: Collection[OGSISrcKey] | None = None,
+) -> OGFieldResource:
+    """Return resource ``id``, following repoints to the terminal (root) resource.
+
+    Read-only endpoints use this so that a request for a merged-away resource
+    returns the resource it was merged into. The write-path ``get`` intentionally
+    does NOT resolve -- merges must operate on the exact requested row. Resolution
+    collapses the whole chain: ``A -> C -> F -> J`` returns ``J`` for a request of
+    ``A``. A non-repointed id returns itself. The ``repointed_id`` graph is acyclic
+    by construction (``apply_resource_merge`` always targets a brand-new row), so
+    ``get_root`` terminates.
+    """
+    model = await session.scalar(
+        select(ResourceModel).where(ResourceModel.id == id)
+    )
+    if model is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND, detail=f"No Resource with id `{id}` found."
+        )
+    root_id = id if model.repointed_id is None else (await model.get_root(session)).id
+    return await get(session, root_id, licensed_sources=licensed_sources)
+
+
 async def field_source_values(
     session: AsyncSession,
     id: int,

--- a/deployments/api/src/stitch/api/db/og_field_resource_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_resource_actions.py
@@ -139,6 +139,38 @@ async def get(
     )
 
 
+async def resolve_root_id(session: AsyncSession, id: int) -> int:
+    """Resolve a resource id to its terminal (root) resource id, following repoints.
+
+    404 if ``id`` does not exist; a non-repointed id returns itself. Read-only
+    endpoints use this so a request for a merged-away resource acts on the
+    resource it was merged into. The write path (merges, priority edits)
+    intentionally does NOT resolve -- it must act on the exact requested row.
+
+    Resolution collapses the whole chain: ``A -> C -> F -> J`` resolves ``A`` to
+    ``J``. The ``repointed_id`` graph is acyclic by construction
+    (``apply_resource_merge`` always targets a brand-new row), so ``get_root``
+    terminates.
+    """
+    model = await session.scalar(select(ResourceModel).where(ResourceModel.id == id))
+    if model is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND, detail=f"No Resource with id `{id}` found."
+        )
+    if model.repointed_id is None:
+        return id
+    try:
+        return (await model.get_root(session)).id
+    except ResourceNotFoundError as exc:
+        # Unreachable under current invariants (FK + acyclic merges + the
+        # self-reference validator), but a corrupt repoint chain must not surface
+        # as an unhandled 500 on a read path.
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND,
+            detail=f"Resource `{id}` could not be resolved to a current resource.",
+        ) from exc
+
+
 async def get_resolved(
     session: AsyncSession,
     id: int,
@@ -146,20 +178,10 @@ async def get_resolved(
 ) -> OGFieldResource:
     """Return resource ``id``, following repoints to the terminal (root) resource.
 
-    Read-only endpoints use this so that a request for a merged-away resource
-    returns the resource it was merged into. The write-path ``get`` intentionally
-    does NOT resolve -- merges must operate on the exact requested row. Resolution
-    collapses the whole chain: ``A -> C -> F -> J`` returns ``J`` for a request of
-    ``A``. A non-repointed id returns itself. The ``repointed_id`` graph is acyclic
-    by construction (``apply_resource_merge`` always targets a brand-new row), so
-    ``get_root`` terminates.
+    Read-only wrapper over ``resolve_root_id`` + ``get``; see ``resolve_root_id``
+    for the resolution semantics.
     """
-    model = await session.scalar(select(ResourceModel).where(ResourceModel.id == id))
-    if model is None:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND, detail=f"No Resource with id `{id}` found."
-        )
-    root_id = id if model.repointed_id is None else (await model.get_root(session)).id
+    root_id = await resolve_root_id(session, id)
     return await get(session, root_id, licensed_sources=licensed_sources)
 
 
@@ -183,16 +205,16 @@ async def field_source_values(
             status_code=422,
             detail=f"field={field} is not a known resource field.",
         )
-    if await session.get(ResourceModel, id) is None:
-        raise HTTPException(
-            status_code=HTTP_404_NOT_FOUND, detail=f"No Resource with id `{id}` found."
-        )
+    # Resolve repoints so a merged-away id returns the terminal resource's field
+    # sources (and 404s a genuinely missing id), consistent with the
+    # single-resource read endpoints.
+    root_id = await resolve_root_id(session, id)
 
     # field_source_candidates ranks in SQL by the same tiered key as the coalesce
     # winner, so the row order is winner-first and rank is just the enumerate
     # index. Empty text can't be persisted, so every returned row is a real value.
     rows = (
-        await session.execute(field_source_candidates(id, field, licensed_sources))
+        await session.execute(field_source_candidates(root_id, field, licensed_sources))
     ).all()
     return [
         OGFieldSourceValueView(

--- a/deployments/api/src/stitch/api/db/utils.py
+++ b/deployments/api/src/stitch/api/db/utils.py
@@ -245,9 +245,15 @@ def _require_view(resource: OGFieldResource) -> OilGasFieldBase:
     return resource.view
 
 
-def resource_to_view(resource: OGFieldResource) -> OGFieldView:
+def resource_to_view(
+    resource: OGFieldResource, requested_resource_id: int | None = None
+) -> OGFieldView:
     view = _require_view(resource)
-    return OGFieldView(id=resource.id, **view.model_dump())
+    return OGFieldView(
+        id=resource.id,
+        requested_resource_id=requested_resource_id,
+        **view.model_dump(),
+    )
 
 
 def resource_to_list_item_view(resource: OGFieldResource) -> OGFieldListItemView:
@@ -263,10 +269,13 @@ def resource_to_list_item_view(resource: OGFieldResource) -> OGFieldListItemView
     )
 
 
-def resource_to_detail_view(resource: OGFieldResource) -> OGFieldDetailView:
+def resource_to_detail_view(
+    resource: OGFieldResource, requested_resource_id: int | None = None
+) -> OGFieldDetailView:
     base = resource_to_list_item_view(resource)
     return OGFieldDetailView(
         **base.model_dump(),
+        requested_resource_id=requested_resource_id,
         source_data=[
             OG_FIELD_SOURCE_VIEW_ADAPTER.validate_python(source)
             for source in resource.source_data

--- a/deployments/api/src/stitch/api/routers/oil_gas_fields.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_fields.py
@@ -236,6 +236,12 @@ async def deny_merge_candidate(
         )
 
 
+def _requested_resource_id(requested_id: int, resolved: OGFieldResource) -> int | None:
+    """The originally-requested id when the resolver returned a different resource
+    (i.e. the request was redirected through a merge); ``None`` otherwise."""
+    return requested_id if resolved.id != requested_id else None
+
+
 @router.get(
     "/{id}",
     response_model=OGFieldView,
@@ -247,8 +253,9 @@ async def get_resource(
     res: OGFieldResource = await resource_actions.get_resolved(
         session=uow.session, id=id, licensed_sources=licensed_sources(claims)
     )
-    requested = id if res.id != id else None
-    return resource_to_view(resource=res, requested_resource_id=requested)
+    return resource_to_view(
+        resource=res, requested_resource_id=_requested_resource_id(id, res)
+    )
 
 
 @router.get(
@@ -262,8 +269,9 @@ async def get_resource_detail(
     res: OGFieldResource = await resource_actions.get_resolved(
         session=uow.session, id=id, licensed_sources=licensed_sources(claims)
     )
-    requested = id if res.id != id else None
-    return resource_to_detail_view(resource=res, requested_resource_id=requested)
+    return resource_to_detail_view(
+        resource=res, requested_resource_id=_requested_resource_id(id, res)
+    )
 
 
 @router.get(

--- a/deployments/api/src/stitch/api/routers/oil_gas_fields.py
+++ b/deployments/api/src/stitch/api/routers/oil_gas_fields.py
@@ -244,10 +244,11 @@ async def deny_merge_candidate(
 async def get_resource(
     *, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims, id: int
 ) -> OGFieldView:
-    res: OGFieldResource = await resource_actions.get(
+    res: OGFieldResource = await resource_actions.get_resolved(
         session=uow.session, id=id, licensed_sources=licensed_sources(claims)
     )
-    return resource_to_view(resource=res)
+    requested = id if res.id != id else None
+    return resource_to_view(resource=res, requested_resource_id=requested)
 
 
 @router.get(
@@ -258,10 +259,11 @@ async def get_resource(
 async def get_resource_detail(
     *, uow: UnitOfWorkDep, user: CurrentUser, claims: Claims, id: int
 ) -> OGFieldDetailView:
-    res: OGFieldResource = await resource_actions.get(
+    res: OGFieldResource = await resource_actions.get_resolved(
         session=uow.session, id=id, licensed_sources=licensed_sources(claims)
     )
-    return resource_to_detail_view(resource=res)
+    requested = id if res.id != id else None
+    return resource_to_detail_view(resource=res, requested_resource_id=requested)
 
 
 @router.get(

--- a/deployments/api/tests/db/test_resource_actions.py
+++ b/deployments/api/tests/db/test_resource_actions.py
@@ -201,6 +201,78 @@ class TestGetResourceActionIntegration:
         assert exc_info.value.status_code == 404
 
 
+class TestGetResolvedResourceAction:
+    """resource_actions.get_resolved() follows repoints to the terminal resource."""
+
+    @pytest.mark.anyio
+    async def test_resolves_multi_hop_chain_to_root(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        # Build the chain root-first so each repointed_to target already exists:
+        # A -> C -> F -> J, each a distinct row carrying its own data. Only J is
+        # a root (repointed_to is None). Three hops, not two: a 2-hop chain can
+        # pass an implementation that only handles one extra level.
+        session = seeded_integration_session
+        j = await _create_resource_with_sources(
+            session, test_user, {"source": "gem", "name": "Root J", "country": "USA"}
+        )
+        f = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "Mid F", "country": "USA"},
+            repointed_to=j,
+        )
+        c = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "Mid C", "country": "USA"},
+            repointed_to=f,
+        )
+        a = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "Leaf A", "country": "USA"},
+            repointed_to=c,
+        )
+
+        # Every non-root id in the chain resolves to J with J's real data.
+        for origin in (a, c, f):
+            resolved = await resource_actions.get_resolved(session, origin)
+            assert resolved.id == j
+            assert resolved.view is not None
+            assert resolved.view.name == "Root J"
+
+    @pytest.mark.anyio
+    async def test_non_repointed_returns_self(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        session = seeded_integration_session
+        rid = await _create_resource_with_sources(
+            session, test_user, {"source": "gem", "name": "Live", "country": "USA"}
+        )
+
+        resolved = await resource_actions.get_resolved(session, rid)
+
+        assert resolved.id == rid
+        assert resolved.view is not None
+        assert resolved.view.name == "Live"
+
+    @pytest.mark.anyio
+    async def test_nonexistent_raises_404(
+        self,
+        seeded_integration_session: AsyncSession,
+    ):
+        with pytest.raises(HTTPException) as exc_info:
+            await resource_actions.get_resolved(
+                session=seeded_integration_session, id=99999
+            )
+        assert exc_info.value.status_code == 404
+
+
 class TestResourceQueryAction:
     """Integration tests for resource_actions.query() and count()."""
 

--- a/deployments/api/tests/db/test_resource_actions.py
+++ b/deployments/api/tests/db/test_resource_actions.py
@@ -9,7 +9,11 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from stitch.api.db import og_field_resource_actions as resource_actions
 from stitch.api.db import utils
-from stitch.api.db.errors import InvalidActionError, ResourceIntegrityError
+from stitch.api.db.errors import (
+    InvalidActionError,
+    ResourceIntegrityError,
+    ResourceNotFoundError,
+)
 from stitch.api.db.model import (
     MembershipModel,
     MembershipStatus,
@@ -270,6 +274,36 @@ class TestGetResolvedResourceAction:
             await resource_actions.get_resolved(
                 session=seeded_integration_session, id=99999
             )
+        assert exc_info.value.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_broken_chain_raises_404_not_500(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+        monkeypatch,
+    ):
+        # Defensive: an unresolvable repoint chain (corrupt data, impossible under
+        # current invariants) must surface as a 404, not an unhandled
+        # ResourceNotFoundError that FastAPI turns into a 500.
+        session = seeded_integration_session
+        root_id = await _create_resource_with_sources(
+            session, test_user, {"source": "gem", "name": "Root", "country": "USA"}
+        )
+        old_id = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "Old", "country": "USA"},
+            repointed_to=root_id,
+        )
+
+        async def _boom(self, _session):
+            raise ResourceNotFoundError("no root")
+
+        monkeypatch.setattr(ResourceModel, "get_root", _boom)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await resource_actions.resolve_root_id(session, old_id)
         assert exc_info.value.status_code == 404
 
 
@@ -1379,6 +1413,32 @@ class TestFieldSourceValues:
                 seeded_integration_session, 9_999_999, "name"
             )
         assert exc.value.status_code == 404
+
+    @pytest.mark.anyio
+    async def test_repointed_resource_resolves_to_root(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        # STIT-418: a merged-away id returns the terminal resource's field
+        # sources, matching the redirect on the single-resource read endpoints.
+        session = seeded_integration_session
+        root_id = await self._seed(session, test_user)
+        old_id = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "Old Shell", "country": "USA"},
+            repointed_to=root_id,
+        )
+
+        via_old = await resource_actions.field_source_values(session, old_id, "name")
+        via_root = await resource_actions.field_source_values(session, root_id, "name")
+
+        assert [(r.source, r.value) for r in via_old] == [
+            (r.source, r.value) for r in via_root
+        ]
+        # It resolves to the root's data, not the old shell's.
+        assert ("wm", "WM Name") in [(r.source, r.value) for r in via_old]
 
 
 class TestSetFieldSourcePriority:

--- a/deployments/api/tests/routers/test_resources_integration.py
+++ b/deployments/api/tests/routers/test_resources_integration.py
@@ -113,3 +113,77 @@ class TestResourcesIntegration:
         assert data["id"] > 0
         assert (view := data.get("view", None)) is not None
         assert view["name"] == "Minimal Name"
+
+
+class TestRepointedResourceRedirect:
+    """GET on a merged-away resource resolves to its terminal resource (STIT-418)."""
+
+    async def _create(self, client: AsyncClient, fact, name: str) -> int:
+        resp = await client.post(
+            "/oil-gas-fields/", json=fact(name=name).model_dump(mode="json")
+        )
+        assert resp.status_code == 200, resp.text
+        return resp.json()["id"]
+
+    async def _repoint(self, session_factory, old_id: int, new_id: int) -> None:
+        """Point old_id at new_id, mirroring what apply_resource_merge does to a row."""
+        async with session_factory() as session:
+            model = await session.get(ResourceModel, old_id)
+            model.repointed_id = new_id
+            await session.commit()
+
+    @pytest.mark.anyio
+    async def test_detail_resolves_to_root_with_flag(
+        self,
+        integration_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        og_create_res_fact: ResourceCreateFactory,
+    ):
+        root_id = await self._create(
+            integration_client, og_create_res_fact, "Merged Root"
+        )
+        old_id = await self._create(integration_client, og_create_res_fact, "Old Shell")
+        await self._repoint(integration_session_factory, old_id, root_id)
+
+        resp = await integration_client.get(f"/oil-gas-fields/{old_id}/detail")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == root_id
+        assert body["requested_resource_id"] == old_id
+        # Real data from the root, not the old resource's null shell.
+        assert body["data"]["name"] == "Merged Root"
+
+    @pytest.mark.anyio
+    async def test_plain_get_resolves_to_root_with_flag(
+        self,
+        integration_client: AsyncClient,
+        integration_session_factory: async_sessionmaker[AsyncSession],
+        og_create_res_fact: ResourceCreateFactory,
+    ):
+        root_id = await self._create(
+            integration_client, og_create_res_fact, "Merged Root"
+        )
+        old_id = await self._create(integration_client, og_create_res_fact, "Old Shell")
+        await self._repoint(integration_session_factory, old_id, root_id)
+
+        resp = await integration_client.get(f"/oil-gas-fields/{old_id}")
+
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["id"] == root_id
+        assert body["requested_resource_id"] == old_id
+        assert body["name"] == "Merged Root"
+
+    @pytest.mark.anyio
+    async def test_live_resource_has_null_flag(
+        self,
+        integration_client: AsyncClient,
+        og_create_res_fact: ResourceCreateFactory,
+    ):
+        root_id = await self._create(integration_client, og_create_res_fact, "Live")
+
+        resp = await integration_client.get(f"/oil-gas-fields/{root_id}/detail")
+
+        assert resp.status_code == 200, resp.text
+        assert resp.json()["requested_resource_id"] is None

--- a/deployments/api/tests/routers/test_resources_unit.py
+++ b/deployments/api/tests/routers/test_resources_unit.py
@@ -37,7 +37,7 @@ class TestGetResourceUnit:
         app.dependency_overrides[get_uow] = override_get_uow
 
         with patch("stitch.api.routers.oil_gas_fields.resource_actions") as mock_repo:
-            mock_repo.get = AsyncMock(return_value=expected)
+            mock_repo.get_resolved = AsyncMock(return_value=expected)
 
             response = await async_client.get("/oil-gas-fields/42")
 
@@ -45,6 +45,8 @@ class TestGetResourceUnit:
         view_data = response.json()
         assert view_data["id"] == 42
         assert view_data["name"] == "Found Resource"
+        # Requested id matches the resolved id, so no redirect flag is set.
+        assert view_data["requested_resource_id"] is None
 
     @pytest.mark.anyio
     async def test_returns_404_when_not_found(self, async_client, mock_uow):
@@ -56,7 +58,7 @@ class TestGetResourceUnit:
         app.dependency_overrides[get_uow] = override_get_uow
 
         with patch("stitch.api.routers.oil_gas_fields.resource_actions") as mock_repo:
-            mock_repo.get = AsyncMock(
+            mock_repo.get_resolved = AsyncMock(
                 side_effect=HTTPException(
                     status_code=HTTP_404_NOT_FOUND,
                     detail="No Resource with id `999` found.",

--- a/deployments/api/tests/test_openapi.py
+++ b/deployments/api/tests/test_openapi.py
@@ -63,3 +63,13 @@ def test_openapi_exposes_client_library_contract():
 
     assert detail_component["type"] == "object"
     assert {"id", "data"}.issubset(detail_component["properties"])
+
+    # STIT-418: the single-resource read views expose the redirect flag so a
+    # client can tell the returned resource is not the one it requested.
+    get_operation = paths["/api/v1/oil-gas-fields/{id}"]["get"]
+    get_schema = get_operation["responses"]["200"]["content"]["application/json"][
+        "schema"
+    ]
+    get_component = _resolve_component_schema(schema, get_schema)
+    assert "requested_resource_id" in get_component["properties"]
+    assert "requested_resource_id" in detail_component["properties"]

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useId, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
-import { useParams, useNavigate } from "react-router";
+import { useParams, useNavigate, useLocation } from "react-router";
 import {
   useCreateSourceForResource,
   useResourceDetail,
@@ -554,9 +554,15 @@ function SourcesSection({ sources }) {
 export default function ResourceDetailPage() {
   const { id } = useParams();
   const navigate = useNavigate();
+  const location = useLocation();
   const numericId = Number(id);
   const validId = Number.isFinite(numericId);
   const endpoint = "oil-gas-fields";
+  // STIT-418: set by the redirect below when a merged-away id is bounced to its
+  // canonical resource. Ephemeral by design — it lives in router state, so a
+  // fresh load, refresh, or new tab of this URL carries none and shows no
+  // notice; it appears only when the user actually got redirected here.
+  const redirectedFrom = location.state?.redirectedFrom ?? null;
   // Enabled (not manually refetched) so that save mutations' cache
   // invalidations refetch it — invalidation never refetches disabled queries.
   const {
@@ -579,7 +585,10 @@ export default function ResourceDetailPage() {
       Number.isFinite(detailView.id) &&
       detailView.id !== numericId
     ) {
-      navigate(`/${endpoint}/${detailView.id}`, { replace: true });
+      navigate(`/${endpoint}/${detailView.id}`, {
+        replace: true,
+        state: { redirectedFrom: numericId },
+      });
     }
   }, [detailView, numericId, endpoint, navigate]);
 
@@ -588,6 +597,13 @@ export default function ResourceDetailPage() {
       <Button onClick={() => navigate(-1)} variant="ghost" className="mb-6">
         ← Back
       </Button>
+
+      {redirectedFrom != null && (
+        <div className="mb-6 rounded-md border border-line bg-surface px-4 py-3 text-sm text-ink">
+          Resource <span className="font-medium">{redirectedFrom}</span> was
+          merged into this record, so you were brought here.
+        </div>
+      )}
 
       {!validId && <p className="text-danger">Invalid resource ID.</p>}
       {isLoading && <p className="text-ink-muted">Loading…</p>}

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
@@ -1,4 +1,4 @@
-import { useId, useState } from "react";
+import { useEffect, useId, useState } from "react";
 import { useAuth0 } from "@auth0/auth0-react";
 import { useParams, useNavigate } from "react-router";
 import {
@@ -566,6 +566,22 @@ export default function ResourceDetailPage() {
   } = useResourceDetail(endpoint, numericId, validId);
 
   useDocumentTitle(detailView?.data?.name ?? "Resource");
+
+  // STIT-418: the API returns the merged-into (root) resource for a repointed
+  // id, so detailView.id can differ from the id in the URL. Redirect to the
+  // canonical URL. replace:true is mandatory: without it, Back returns to the
+  // old id, which re-resolves and redirects again, trapping Back. No cycle guard
+  // is needed beyond the id check — repointing always targets a brand-new row,
+  // so the chain is acyclic and the root never redirects again.
+  useEffect(() => {
+    if (
+      detailView &&
+      Number.isFinite(detailView.id) &&
+      detailView.id !== numericId
+    ) {
+      navigate(`/${endpoint}/${detailView.id}`, { replace: true });
+    }
+  }, [detailView, numericId, endpoint, navigate]);
 
   return (
     <div className="mx-auto max-w-4xl">

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.jsx
@@ -574,23 +574,24 @@ export default function ResourceDetailPage() {
   useDocumentTitle(detailView?.data?.name ?? "Resource");
 
   // STIT-418: the API returns the merged-into (root) resource for a repointed
-  // id, so detailView.id can differ from the id in the URL. Redirect to the
+  // id, so the resolved id can differ from the id in the URL. Redirect to the
   // canonical URL. replace:true is mandatory: without it, Back returns to the
   // old id, which re-resolves and redirects again, trapping Back. No cycle guard
   // is needed beyond the id check — repointing always targets a brand-new row,
   // so the chain is acyclic and the root never redirects again.
+  //
+  // Coerce with Number() so a string id in the payload still compares and
+  // navigates as a number (a strict `!==` against the numeric URL id would
+  // otherwise loop); NaN when detailView is absent, which the finite check skips.
+  const resolvedId = Number(detailView?.id);
   useEffect(() => {
-    if (
-      detailView &&
-      Number.isFinite(detailView.id) &&
-      detailView.id !== numericId
-    ) {
-      navigate(`/${endpoint}/${detailView.id}`, {
+    if (Number.isFinite(resolvedId) && resolvedId !== numericId) {
+      navigate(`/${endpoint}/${resolvedId}`, {
         replace: true,
         state: { redirectedFrom: numericId },
       });
     }
-  }, [detailView, numericId, endpoint, navigate]);
+  }, [resolvedId, numericId, endpoint, navigate]);
 
   return (
     <div className="mx-auto max-w-4xl">

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
@@ -889,4 +889,46 @@ describe("ResourceDetailPage", () => {
       await screen.findByRole("button", { name: /added to resource/i }),
     ).toBeDisabled();
   });
+
+  it("redirects to the merged-into resource when the returned id differs from the URL", () => {
+    // STIT-418: the API resolved a merged-away id (123) to its terminal
+    // resource (456), so the page redirects to the canonical URL.
+    mockedRouteId = "123";
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: { ...mockDetailView, id: 456, requested_resource_id: 123 },
+    });
+
+    renderWithQueryClient(<ResourceDetailPage />);
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith("/oil-gas-fields/456", {
+      replace: true,
+    });
+  });
+
+  it("does not redirect when the returned resource is the one requested", () => {
+    mockedRouteId = "1";
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView, // id 1 === route id 1
+    });
+
+    renderWithQueryClient(<ResourceDetailPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("does not redirect again once on the canonical resource", () => {
+    // Landed on the root: id matches the URL, so no further redirect (no loop).
+    mockedRouteId = "456";
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: { ...mockDetailView, id: 456, requested_resource_id: null },
+    });
+
+    renderWithQueryClient(<ResourceDetailPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
 });

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
@@ -967,4 +967,34 @@ describe("ResourceDetailPage", () => {
 
     expect(mockNavigate).not.toHaveBeenCalled();
   });
+
+  it("redirects correctly when the API returns the id as a string", () => {
+    mockedRouteId = "123";
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: { ...mockDetailView, id: "456", requested_resource_id: 123 },
+    });
+
+    renderWithQueryClient(<ResourceDetailPage />);
+
+    expect(mockNavigate).toHaveBeenCalledTimes(1);
+    expect(mockNavigate).toHaveBeenCalledWith("/oil-gas-fields/456", {
+      replace: true,
+      state: { redirectedFrom: 123 },
+    });
+  });
+
+  it("does not loop when a string id already matches the URL", () => {
+    // A strict `!==` against the numeric URL id would treat "456" !== 456 as a
+    // mismatch and redirect forever; the numeric coercion prevents that.
+    mockedRouteId = "456";
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: { ...mockDetailView, id: "456", requested_resource_id: null },
+    });
+
+    renderWithQueryClient(<ResourceDetailPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
 });

--- a/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/ResourceDetailPage.test.jsx
@@ -23,6 +23,7 @@ vi.mock("../hooks/useResources", async (importOriginal) => ({
 vi.mock("../hooks/usePermissions");
 
 let mockedRouteId = "1";
+let mockLocationState = null;
 const mockNavigate = vi.fn();
 
 vi.mock("react-router", async () => {
@@ -31,6 +32,7 @@ vi.mock("react-router", async () => {
     ...actual,
     useParams: () => ({ id: mockedRouteId }),
     useNavigate: () => mockNavigate,
+    useLocation: () => ({ state: mockLocationState }),
   };
 });
 
@@ -90,6 +92,7 @@ beforeEach(() => {
   vi.clearAllMocks();
   vi.unstubAllGlobals();
   mockedRouteId = "1";
+  mockLocationState = null;
   mockNavigate.mockReset();
   vi.mocked(useAuth0).mockReturnValue(auth0TestDefaults);
   vi.mocked(useResourceDetail).mockReturnValue({
@@ -904,7 +907,40 @@ describe("ResourceDetailPage", () => {
     expect(mockNavigate).toHaveBeenCalledTimes(1);
     expect(mockNavigate).toHaveBeenCalledWith("/oil-gas-fields/456", {
       replace: true,
+      state: { redirectedFrom: 123 },
     });
+  });
+
+  it("shows an ephemeral notice on the destination when arrived via redirect", () => {
+    // Simulates having landed on the canonical resource via the redirect above:
+    // the router carries the original id in location state.
+    mockedRouteId = "456";
+    mockLocationState = { redirectedFrom: 123 };
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: { ...mockDetailView, id: 456, requested_resource_id: null },
+    });
+
+    renderWithQueryClient(<ResourceDetailPage />);
+
+    expect(screen.getByText(/merged into this record/i)).toBeInTheDocument();
+    expect(screen.getByText("123")).toBeInTheDocument();
+    // It's a notice, not a redirect: no further navigation.
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it("shows no redirect notice on a normal visit (no router state)", () => {
+    mockedRouteId = "1";
+    vi.mocked(useResourceDetail).mockReturnValue({
+      ...defaultHookReturn,
+      data: mockDetailView,
+    });
+
+    renderWithQueryClient(<ResourceDetailPage />);
+
+    expect(
+      screen.queryByText(/merged into this record/i),
+    ).not.toBeInTheDocument();
   });
 
   it("does not redirect when the returned resource is the one requested", () => {

--- a/packages/stitch-ogsi/src/stitch/ogsi/model/__init__.py
+++ b/packages/stitch-ogsi/src/stitch/ogsi/model/__init__.py
@@ -156,6 +156,10 @@ OG_FIELD_SOURCE_VIEW_ADAPTER = TypeAdapter(OGFieldSourceView)
 
 class OGFieldView(OilGasFieldBase):
     id: int
+    # STIT-418: when a request for a merged-away resource is redirected to the
+    # resource it was merged into, this holds the id the caller originally asked
+    # for. ``None`` when the caller received exactly the resource it requested.
+    requested_resource_id: int | None = None
 
 
 class OGFieldListItemView(BaseModel):
@@ -166,6 +170,9 @@ class OGFieldListItemView(BaseModel):
 
 class OGFieldDetailView(OGFieldListItemView):
     source_data: list[OGFieldSourceView] = Field(default_factory=list)
+    # STIT-418: see ``OGFieldView.requested_resource_id``. Set when the detail
+    # endpoint redirected a merged-away resource to its terminal resource.
+    requested_resource_id: int | None = None
 
     @field_validator("source_data", mode="before")
     @classmethod


### PR DESCRIPTION
Enables automatically returning the repointed-to resource (or last along a repointing chain in the case of multiple merges), rather than the empty (null-shell) resource. Includes a new `requested_resource_id` field to inform users that the resource they are seeing is technically different than the one they attempted to access directly.

Generally moves all read-path operations to `get_resolved` instead of the raw `get` operation.

Also includes an update to detail page to let users know in the UI if they click on an outdated link (such as this one: https://witty-mushroom-017a3dc1e-258.westus2.1.azurestaticapps.net/oil-gas-fields/15, which now takes you to resource `38`)

----

## STIT-418 (part 1 of 2) — redirect on the resource detail path

Merging in Stitch is *repointing*: merging A and B creates a new resource C and
sets `repointed_id` on A and B. Previously a request for a merged-away resource
returned HTTP 200 with an all-null "null shell", so `/oil-gas-fields/A` rendered
a blank-but-successful page.

This makes any request that resolves to a repointed resource return the resource
it was merged into:

- **API:** `GET /oil-gas-fields/{id}` and `/{id}/detail` follow the repoint chain
  to the terminal resource and return its data, with a new nullable
  `requested_resource_id` (the originally-requested id, or null when you got
  exactly what you asked for). Additive to the schema.
- **Frontend:** `ResourceDetailPage` redirects to the canonical URL
  (`navigate(..., { replace: true })`) when the returned id differs from the URL.

Resolution lives in a read-only helper (`get_resolved`); the write-path `get`
still returns the exact requested row, since merges must operate on it.

**Scope:** part 1 of 2. Part 2 (Merge Review pane, AC 3) is the stacked
follow-up — do not close STIT-418 when this merges.

### Tests
Backend: multi-hop chain collapse, non-repointed self-resolve, 404; route
integration for the resolved id + `requested_resource_id` + real data; OpenAPI
contract for the new field. Frontend: redirect fires once with `replace:true`;
no redirect for a live resource; no loop.

### AI assistance
Implemented with Claude Code (code + tests). Verified: API pytest + frontend
vitest suites pass locally.