### PR TITLE
Feat/merge review staleness

### DIFF
--- a/deployments/api/src/stitch/api/db/merge_candidate_actions.py
+++ b/deployments/api/src/stitch/api/db/merge_candidate_actions.py
@@ -345,7 +345,10 @@ async def create_merge_candidate(
     )
     await session.flush()
     await session.refresh(candidate, ["items"])
-    return await _candidate_to_view_resolved(session, candidate)
+    # A newly created candidate's members were just validated as unrepointed, so
+    # nothing is stale yet -- pass an empty resolution instead of running the
+    # (always-empty) root lookup.
+    return _candidate_to_view(candidate, [])
 
 
 async def approve_merge_candidate(

--- a/deployments/api/src/stitch/api/db/merge_candidate_actions.py
+++ b/deployments/api/src/stitch/api/db/merge_candidate_actions.py
@@ -22,6 +22,7 @@ from stitch.api.entities import (
     MergeCandidateReviewRequest,
     MergeCandidateStatus,
     MergeCandidateView,
+    RepointedResourceView,
 )
 from stitch.ogsi.model import OGFieldSource
 from stitch.ogsi.model.og_field import OilGasFieldBase
@@ -33,7 +34,7 @@ from .model import (
     OGFieldSourcePriority,
     ResourceModel,
 )
-from .og_field_resource_actions import apply_resource_merge
+from .og_field_resource_actions import apply_resource_merge, repointed_merge_error
 from .utils import coalesce_resources_with_sources
 
 
@@ -62,11 +63,7 @@ async def _load_mergeable_resources(
 
     repointed = [r for r in results if r.repointed_id is not None]
     if repointed:
-        reprs = map(repr, repointed)
-        msg = f"Repointed: [{','.join(reprs)}]"
-        raise ResourceIntegrityError(
-            f"Cannot merge any resource that has already been merged. {msg}"
-        )
+        raise ResourceIntegrityError(await repointed_merge_error(session, repointed))
 
     return results
 
@@ -75,7 +72,13 @@ def _fingerprint(resource_ids: Sequence[int]) -> str:
     return ":".join(map(str, sorted(set(resource_ids))))
 
 
-def _candidate_to_view(model: MergeCandidateModel) -> MergeCandidateView:
+def _candidate_to_view(
+    model: MergeCandidateModel,
+    repointed_resources: Sequence[RepointedResourceView],
+) -> MergeCandidateView:
+    # `repointed_resources` is required so no caller can silently emit an empty
+    # staleness signal; resolve it with `_resolve_candidates` (batched) or
+    # `_candidate_to_view_resolved` (single).
     return MergeCandidateView(
         id=model.id,
         resource_ids=[
@@ -90,7 +93,52 @@ def _candidate_to_view(model: MergeCandidateModel) -> MergeCandidateView:
         last_updated_by_id=model.last_updated_by_id,
         reviewed_at=model.reviewed_at,
         reviewed_by_id=model.reviewed_by_id,
+        repointed_resources=list(repointed_resources),
     )
+
+
+async def _resolve_candidates(
+    session: AsyncSession,
+    candidates: Sequence[MergeCandidateModel],
+) -> dict[int, list[RepointedResourceView]]:
+    """Map each candidate id to the members that have since been merged away.
+
+    Only PENDING candidates are resolved; terminal-status candidates map to an
+    empty list. An APPROVED candidate's own members are repointed at its own
+    merge result, so resolving them would make every approved candidate flag
+    itself as stale -- one status check here beats a compensating rule in the
+    client.
+
+    Batched: a single ``root_id_by_resource_id`` over the union of all pending
+    members' ids keeps the query count constant, because ``GET /merge-candidates``
+    is unpaginated and per-candidate resolution would be an unbounded N+1.
+    """
+    result: dict[int, list[RepointedResourceView]] = {c.id: [] for c in candidates}
+    pending = [c for c in candidates if c.status == MergeCandidateStatus.PENDING]
+    if not pending:
+        return result
+
+    all_ids = {item.resource_id for c in pending for item in c.items}
+    roots = await ResourceModel.root_id_by_resource_id(session, all_ids)
+    for candidate in pending:
+        moved = [
+            RepointedResourceView(
+                resource_id=item.resource_id,
+                repointed_to=roots[item.resource_id],
+            )
+            for item in sorted(candidate.items, key=lambda i: i.position)
+            if roots.get(item.resource_id, item.resource_id) != item.resource_id
+        ]
+        result[candidate.id] = moved
+    return result
+
+
+async def _candidate_to_view_resolved(
+    session: AsyncSession, model: MergeCandidateModel
+) -> MergeCandidateView:
+    """Single-candidate convenience: resolve staleness, then build the view."""
+    resolution = await _resolve_candidates(session, [model])
+    return _candidate_to_view(model, resolution[model.id])
 
 
 def _comparison_status(resource_values: Sequence[Any]) -> str:
@@ -173,11 +221,12 @@ async def _default_source_priority(session: AsyncSession) -> dict[str, int]:
 def _candidate_to_detail_view(
     model: MergeCandidateModel,
     compare: Sequence[FieldComparisonView],
+    repointed_resources: Sequence[RepointedResourceView],
 ) -> MergeCandidateDetailView:
     # MergeCandidateDetailView is MergeCandidateView + `compare`; reuse the base
     # mapping so the shared fields stay defined in one place.
     return MergeCandidateDetailView(
-        **_candidate_to_view(model).model_dump(),
+        **_candidate_to_view(model, repointed_resources).model_dump(),
         compare=list(compare),
     )
 
@@ -205,7 +254,11 @@ async def list_merge_candidates(session: AsyncSession) -> list[MergeCandidateVie
         .order_by(MergeCandidateModel.created.desc())
     )
     candidates = (await session.scalars(stmt)).all()
-    return [_candidate_to_view(candidate) for candidate in candidates]
+    resolution = await _resolve_candidates(session, candidates)
+    return [
+        _candidate_to_view(candidate, resolution[candidate.id])
+        for candidate in candidates
+    ]
 
 
 async def get_merge_candidate(
@@ -245,7 +298,8 @@ async def get_merge_candidate(
     resource_views = [by_id[rid].view for rid in resource_ids]
     compare = _build_comparison(resource_views, sources_with_priority)
 
-    return _candidate_to_detail_view(candidate, compare)
+    resolution = await _resolve_candidates(session, [candidate])
+    return _candidate_to_detail_view(candidate, compare, resolution[candidate.id])
 
 
 async def create_merge_candidate(
@@ -291,7 +345,7 @@ async def create_merge_candidate(
     )
     await session.flush()
     await session.refresh(candidate, ["items"])
-    return _candidate_to_view(candidate)
+    return await _candidate_to_view_resolved(session, candidate)
 
 
 async def approve_merge_candidate(
@@ -325,7 +379,7 @@ async def approve_merge_candidate(
     await session.flush()
 
     candidate = await _load_candidate_model(session, candidate_id)
-    return _candidate_to_view(candidate)
+    return await _candidate_to_view_resolved(session, candidate)
 
 
 async def deny_merge_candidate(
@@ -347,4 +401,4 @@ async def deny_merge_candidate(
     candidate.last_updated_by_id = user.id
     await session.flush()
     candidate = await _load_candidate_model(session, candidate_id)
-    return _candidate_to_view(candidate)
+    return await _candidate_to_view_resolved(session, candidate)

--- a/deployments/api/src/stitch/api/db/model/resource.py
+++ b/deployments/api/src/stitch/api/db/model/resource.py
@@ -134,15 +134,31 @@ class ResourceModel(TimestampMixin, UserAuditMixin, Base):
 
     @classmethod
     def _parent_tree_cte(cls, *resource_ids: int):
+        """Walk ``repointed_id`` upward, tagging every row with its origin input.
+
+        Each row is ``(origin_id, id)``: ``origin_id`` is the input the walk
+        started from, ``id`` is a row on the path from that input to its root.
+        Carrying ``origin_id`` lets a batch map each input to its own root --
+        without it, a multi-input walk returns the *set* of roots and loses which
+        input reached which root (see ``root_id_by_resource_id``). Because
+        ``repointed_id`` is a single scalar, the graph is a forest: each origin
+        traces exactly one path, so ``union_all`` stays correct.
+        """
+        # Anchor: each input maps to itself.
         parent_tree = (
-            select(cls.id)
+            select(cls.id.label("origin_id"), cls.id.label("id"))
             .where(cls.id.in_(resource_ids))
             .distinct()
             .cte(name="parent_tree", recursive=True)
         )
 
+        # Recursive term: carry origin_id forward, step one hop up repointed_id.
+        # ``select_from(cls)`` is required: the first selected column belongs to
+        # the CTE, so without it SQLAlchemy infers the wrong FROM (same reason as
+        # the ``select_from(m)`` in ``source_data_by_resource_id`` above).
         ancestors = (
-            select(cls.repointed_id)
+            select(parent_tree.c.origin_id, cls.repointed_id)
+            .select_from(cls)
             .join(parent_tree, cls.id == parent_tree.c.id)
             .where(cls.repointed_id.is_not(None))
         )
@@ -175,9 +191,38 @@ class ResourceModel(TimestampMixin, UserAuditMixin, Base):
 
     @classmethod
     def _root_select(cls, *resource_ids: int):
+        """Select the terminal (non-repointed) rows reachable from the inputs.
+
+        Single-id use only (``get_root``): it selects whole ``cls`` rows and joins
+        on ``parent_cte.c.id``, so a multi-input batch that shares a root would
+        yield duplicate root rows. For batch input use ``root_id_by_resource_id``,
+        which keys results back to each origin.
+        """
         parent_cte = cls._parent_tree_cte(*resource_ids)
         return (
             select(cls)
             .join(parent_cte, cls.id == parent_cte.c.id)
             .where(cls.repointed_id.is_(None))
         )
+
+    @classmethod
+    async def root_id_by_resource_id(
+        cls, session: AsyncSession, resource_ids: Collection[int]
+    ) -> dict[int, int]:
+        """Map each input id to its terminal (root) resource id, in one query.
+
+        A non-repointed input maps to itself. Mirrors the batch, dict-returning
+        convention of ``source_data_by_resource_id``. Used to resolve merged-away
+        resources without an N+1 over a candidate list.
+        """
+        if not resource_ids:
+            return {}
+        parent_cte = cls._parent_tree_cte(*resource_ids)
+        stmt = (
+            select(parent_cte.c.origin_id, cls.id)
+            .select_from(cls)
+            .join(parent_cte, cls.id == parent_cte.c.id)
+            .where(cls.repointed_id.is_(None))
+        )
+        rows = await session.execute(stmt)
+        return {origin_id: root_id for origin_id, root_id in rows.all()}

--- a/deployments/api/src/stitch/api/db/og_field_resource_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_resource_actions.py
@@ -178,11 +178,28 @@ async def get_resolved(
 ) -> OGFieldResource:
     """Return resource ``id``, following repoints to the terminal (root) resource.
 
-    Read-only wrapper over ``resolve_root_id`` + ``get``; see ``resolve_root_id``
-    for the resolution semantics.
+    Loads the row once: a non-repointed id (the common case) is built from that
+    row directly, avoiding the second fetch a ``resolve_root_id`` + ``get`` round
+    trip would cost. A repointed id resolves via ``resolve_root_id`` (which also
+    maps a broken chain to 404) and loads the terminal resource.
     """
-    root_id = await resolve_root_id(session, id)
-    return await get(session, root_id, licensed_sources=licensed_sources)
+    stmt = (
+        select(ResourceModel)
+        .options(selectinload(ResourceModel.memberships))
+        .where(ResourceModel.id == id)
+    )
+    model = await session.scalar(stmt)
+    if model is None:
+        raise HTTPException(
+            status_code=HTTP_404_NOT_FOUND, detail=f"No Resource with id `{id}` found."
+        )
+    if model.repointed_id is not None:
+        root_id = await resolve_root_id(session, id)
+        return await get(session, root_id, licensed_sources=licensed_sources)
+    await session.refresh(model, ["memberships"])
+    return await resource_model_to_entity(
+        session, model, licensed_sources=licensed_sources
+    )
 
 
 async def field_source_values(

--- a/deployments/api/src/stitch/api/db/og_field_resource_actions.py
+++ b/deployments/api/src/stitch/api/db/og_field_resource_actions.py
@@ -350,6 +350,26 @@ async def create(
     return await resource_model_to_entity(session, model)
 
 
+async def repointed_merge_error(
+    session: AsyncSession, repointed: Sequence[ResourceModel]
+) -> str:
+    """Message naming each already-merged resource and its terminal target.
+
+    Shared by the two merge guards (here and in ``merge_candidate_actions``) so a
+    curator sees "resource 102 is now resource 301" instead of a ``repr()`` memory
+    address. The root lookup runs only on the error path. Fixed here rather than in
+    ``ResourceModel.__repr__`` because a repr cannot name the terminal target.
+    """
+    roots = await ResourceModel.root_id_by_resource_id(
+        session, [r.id for r in repointed]
+    )
+    moves = "; ".join(
+        f"resource {r.id} is now resource {roots.get(r.id, r.id)}"
+        for r in sorted(repointed, key=lambda r: r.id)
+    )
+    return f"Cannot merge a resource that has already been merged: {moves}."
+
+
 async def apply_resource_merge(
     session: AsyncSession,
     user: CurrentUser,
@@ -377,12 +397,8 @@ async def apply_resource_merge(
         msg = f"Resources not found for ids: [{','.join(map(str, missing_ids))}]"
         raise ResourceNotFoundError(msg)
 
-    if len(repointed := [r for r in results if r.repointed_id is not None]) > 0:
-        reprs = map(repr, repointed)
-        msg = f"Repointed: [{','.join(reprs)}]"
-        raise ResourceIntegrityError(
-            f"Cannot merge any resource that has already been merged. {msg}"
-        )
+    if repointed := [r for r in results if r.repointed_id is not None]:
+        raise ResourceIntegrityError(await repointed_merge_error(session, repointed))
 
     # all ids exist, none have already been repointed
     #

--- a/deployments/api/src/stitch/api/entities.py
+++ b/deployments/api/src/stitch/api/entities.py
@@ -171,6 +171,17 @@ class SetFieldPriorityRequest(BaseModel):
     ordered_source_pks: list[int]
 
 
+class RepointedResourceView(BaseModel):
+    """A candidate member that has since been merged away.
+
+    ``resource_id`` is the member as originally recorded on the candidate;
+    ``repointed_to`` is the terminal resource it now lives on.
+    """
+
+    resource_id: int
+    repointed_to: int
+
+
 class MergeCandidateView(BaseModel):
     id: int
     resource_ids: list[int]
@@ -183,6 +194,10 @@ class MergeCandidateView(BaseModel):
     last_updated_by_id: int
     reviewed_at: datetime | None = None
     reviewed_by_id: int | None = None
+    # Members that have been merged away since this candidate was recorded, each
+    # with the terminal resource it now lives on. Only populated for PENDING
+    # candidates; an empty list means the candidate is still valid.
+    repointed_resources: list[RepointedResourceView] = Field(default_factory=list)
 
 
 class ComparisonValueView(OGFieldSourceValueView):

--- a/deployments/api/tests/db/actions/test_merge.py
+++ b/deployments/api/tests/db/actions/test_merge.py
@@ -1,6 +1,43 @@
+import pytest
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from stitch.api.db import og_field_resource_actions as resource_actions
+from stitch.api.db.errors import ResourceIntegrityError
+from stitch.api.db.model import ResourceModel
+from stitch.api.entities import User
+
+
 class TestMergeResourcesUnit:
-    """
-    test cases:
-    * with mocked session
-      *
-    """
+    """Direct coverage for apply_resource_merge's guards."""
+
+    @pytest.mark.anyio
+    async def test_apply_resource_merge_rejects_already_repointed_input(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        """An already-merged input is rejected with an actionable, id-naming message.
+
+        Regression guard for STIT-418: the error must name the terminal resource,
+        not leak a ``repr()`` memory address.
+        """
+        session = seeded_integration_session
+        root = ResourceModel.create(created_by=test_user)
+        session.add(root)
+        await session.flush()
+
+        moved = ResourceModel.create(created_by=test_user, repointed_to=root.id)
+        other = ResourceModel.create(created_by=test_user)
+        session.add_all([moved, other])
+        await session.flush()
+
+        with pytest.raises(ResourceIntegrityError) as exc_info:
+            await resource_actions.apply_resource_merge(
+                session=session,
+                user=test_user,
+                resource_ids=[moved.id, other.id],
+            )
+
+        message = str(exc_info.value)
+        assert f"resource {moved.id} is now resource {root.id}" in message
+        assert "object at 0x" not in message

--- a/deployments/api/tests/db/test_resource_actions.py
+++ b/deployments/api/tests/db/test_resource_actions.py
@@ -307,6 +307,65 @@ class TestGetResolvedResourceAction:
         assert exc_info.value.status_code == 404
 
 
+class TestRootIdByResourceId:
+    """ResourceModel.root_id_by_resource_id() batch-maps each input to its root."""
+
+    @pytest.mark.anyio
+    async def test_maps_each_origin_to_its_own_root(
+        self,
+        seeded_integration_session: AsyncSession,
+        test_user: User,
+    ):
+        # Two inputs (A, B) share a chain to J; D is live. The origin column is
+        # what keeps A->J and B->J distinct from D->D in one query -- without it
+        # the CTE would just return the set of roots and lose the mapping.
+        session = seeded_integration_session
+        j = await _create_resource_with_sources(
+            session, test_user, {"source": "gem", "name": "J", "country": "USA"}
+        )
+        f = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "F", "country": "USA"},
+            repointed_to=j,
+        )
+        c = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "C", "country": "USA"},
+            repointed_to=f,
+        )
+        a = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "A", "country": "USA"},
+            repointed_to=c,
+        )
+        b = await _create_resource_with_sources(
+            session,
+            test_user,
+            {"source": "gem", "name": "B", "country": "USA"},
+            repointed_to=c,
+        )
+        d = await _create_resource_with_sources(
+            session, test_user, {"source": "gem", "name": "D", "country": "USA"}
+        )
+
+        roots = await ResourceModel.root_id_by_resource_id(session, [a, b, d])
+
+        assert roots == {a: j, b: j, d: d}
+
+    @pytest.mark.anyio
+    async def test_empty_input_returns_empty(
+        self,
+        seeded_integration_session: AsyncSession,
+    ):
+        assert (
+            await ResourceModel.root_id_by_resource_id(seeded_integration_session, [])
+            == {}
+        )
+
+
 class TestResourceQueryAction:
     """Integration tests for resource_actions.query() and count()."""
 

--- a/deployments/api/tests/routers/test_merge_candidates_integration.py
+++ b/deployments/api/tests/routers/test_merge_candidates_integration.py
@@ -265,3 +265,65 @@ class TestMergeCandidateDetailIntegration:
             (id_a, "gem", "Bar"),
             (id_b, "rmi", "Foo"),
         }
+
+
+class TestStaleCandidateResolution:
+    """STIT-418 AC 3: approving an overlapping merge makes a pending candidate stale.
+
+    candidate1 {A,B} and candidate2 {B,D} both pending; approving candidate1
+    repoints B, so candidate2 now overlaps an already-merged resource.
+    """
+
+    @pytest.mark.anyio
+    async def test_overlapping_approval_surfaces_the_move_and_blocks_reapprove(
+        self,
+        integration_client: AsyncClient,
+        og_create_res_fact: ResourceCreateFactory,
+    ):
+        id_a = await _create_resource(integration_client, og_create_res_fact, "A")
+        id_b = await _create_resource(integration_client, og_create_res_fact, "B")
+        id_d = await _create_resource(integration_client, og_create_res_fact, "D")
+
+        cand1 = await _create_candidate(integration_client, [id_a, id_b])
+        cand2 = await _create_candidate(integration_client, [id_b, id_d])
+
+        approve = await integration_client.post(
+            f"/oil-gas-fields/merge-candidates/{cand1}/approve",
+            json={"review_notes": "ok"},
+        )
+        assert approve.status_code == 200, approve.text
+        merged_id = approve.json()["merged_resource_id"]
+        assert merged_id is not None
+
+        expected_move = [{"resource_id": id_b, "repointed_to": merged_id}]
+
+        # candidate2 detail reports B -> merged_id (only the member that moved).
+        detail = await integration_client.get(
+            f"/oil-gas-fields/merge-candidates/{cand2}"
+        )
+        assert detail.status_code == 200, detail.text
+        assert detail.json()["repointed_resources"] == expected_move
+
+        queue = await integration_client.get("/oil-gas-fields/merge-candidates")
+        assert queue.status_code == 200, queue.text
+        rows = {c["id"]: c for c in queue.json()}
+        # The queue row carries the same signal...
+        assert rows[cand2]["repointed_resources"] == expected_move
+        # ...and the APPROVED candidate reports no staleness (PENDING-only rule).
+        assert rows[cand1]["repointed_resources"] == []
+
+        # Approving candidate2 now fails with an id-naming message, not a repr()
+        # memory address (the STIT-418 bug), and leaves it untouched.
+        reapprove = await integration_client.post(
+            f"/oil-gas-fields/merge-candidates/{cand2}/approve",
+        )
+        assert reapprove.status_code == 400, reapprove.text
+        message = reapprove.json()["detail"]
+        assert str(id_b) in message
+        assert str(merged_id) in message
+        assert "object at 0x" not in message
+
+        after = await integration_client.get(
+            f"/oil-gas-fields/merge-candidates/{cand2}"
+        )
+        assert after.json()["status"] == "PENDING"

--- a/deployments/api/tests/test_merge_candidate_actions.py
+++ b/deployments/api/tests/test_merge_candidate_actions.py
@@ -52,6 +52,9 @@ class FakeMergedResource:
 class FakeSession:
     scalar_result: object | None = None
     scalars_result: list[object] = field(default_factory=list)
+    # (origin_id, root_id) rows returned by root_id_by_resource_id's query;
+    # empty means nothing is repointed, so no candidate is stale.
+    execute_result: list[tuple[int, int]] = field(default_factory=list)
     added: list[object] = field(default_factory=list)
     added_all: list[object] = field(default_factory=list)
     flush_calls: int = 0
@@ -62,6 +65,9 @@ class FakeSession:
 
     async def scalars(self, _stmt):
         return SimpleNamespace(all=lambda: list(self.scalars_result))
+
+    async def execute(self, _stmt):
+        return SimpleNamespace(all=lambda: list(self.execute_result))
 
     def add(self, obj):
         self.added.append(obj)
@@ -105,11 +111,58 @@ def test_candidate_to_view_sorts_items_by_position():
         ],
     )
 
-    view = mca._candidate_to_view(candidate)
+    view = mca._candidate_to_view(candidate, [])
 
     assert view.resource_ids == [18, 19]
     assert view.status == MergeCandidateStatus.PENDING
     assert view.id == 1
+    assert view.repointed_resources == []
+
+
+@pytest.mark.anyio
+async def test_resolve_candidates_batches_root_lookup_once(monkeypatch):
+    # Two pending candidates sharing member 19; the resolver must look up roots
+    # in ONE batched call over the union of member ids (GET /merge-candidates is
+    # unpaginated, so per-candidate lookups would be an unbounded N+1).
+    c1 = FakeCandidate(
+        id=1,
+        status=MergeCandidateStatus.PENDING,
+        items=[FakeItem(18, 0), FakeItem(19, 1)],
+    )
+    c2 = FakeCandidate(
+        id=2,
+        status=MergeCandidateStatus.PENDING,
+        items=[FakeItem(19, 0), FakeItem(20, 1)],
+    )
+    root_lookup = AsyncMock(return_value={18: 18, 19: 31, 20: 20})
+    monkeypatch.setattr(mca.ResourceModel, "root_id_by_resource_id", root_lookup)
+
+    result = await mca._resolve_candidates(AsyncMock(), [c1, c2])
+
+    root_lookup.assert_awaited_once()
+    _session, ids = root_lookup.call_args.args
+    assert set(ids) == {18, 19, 20}
+    # Only member 19 moved (19 -> 31); it surfaces on both candidates.
+    assert [(m.resource_id, m.repointed_to) for m in result[1]] == [(19, 31)]
+    assert [(m.resource_id, m.repointed_to) for m in result[2]] == [(19, 31)]
+
+
+@pytest.mark.anyio
+async def test_resolve_candidates_skips_terminal_status(monkeypatch):
+    # An APPROVED candidate's own members are repointed at its own merge result,
+    # so resolving them would make every approved candidate flag itself as stale.
+    approved = FakeCandidate(
+        id=5,
+        status=MergeCandidateStatus.APPROVED,
+        items=[FakeItem(18, 0), FakeItem(19, 1)],
+    )
+    root_lookup = AsyncMock()
+    monkeypatch.setattr(mca.ResourceModel, "root_id_by_resource_id", root_lookup)
+
+    result = await mca._resolve_candidates(AsyncMock(), [approved])
+
+    assert result == {5: []}
+    root_lookup.assert_not_awaited()
 
 
 @pytest.mark.anyio
@@ -446,9 +499,13 @@ async def test_get_merge_candidate_returns_detail_view_in_item_order(monkeypatch
     async def fake_default_priority(session_arg):
         return {"rmi": 1, "gem": 2, "wm": 3, "llm": 4}
 
+    async def fake_resolve(session_arg, candidates):
+        return {c.id: [] for c in candidates}
+
     monkeypatch.setattr(mca, "_load_candidate_model", fake_load_candidate_model)
     monkeypatch.setattr(mca, "coalesce_resources_with_sources", fake_coalesce)
     monkeypatch.setattr(mca, "_default_source_priority", fake_default_priority)
+    monkeypatch.setattr(mca, "_resolve_candidates", fake_resolve)
 
     view = await mca.get_merge_candidate(
         AsyncMock(), candidate_id=1, licensed_sources=["gem"]

--- a/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.jsx
+++ b/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.jsx
@@ -13,6 +13,7 @@ import {
 } from "../hooks/useResources";
 import { pickCompareName } from "../utils/candidateCompare";
 import { isEmptyValue } from "../utils/mergeComparison";
+import { readCandidateStaleness } from "../utils/mergeCandidateStaleness";
 
 const ENDPOINT = "oil-gas-fields";
 
@@ -135,6 +136,8 @@ function QueuePanel({
 }
 
 function CandidateFacts({ candidate }) {
+  const { moves } = readCandidateStaleness(candidate);
+  const movedTo = new Map(moves.map((m) => [m.resource_id, m.repointed_to]));
   return (
     <dl className="grid gap-3 text-sm sm:grid-cols-3">
       <div>
@@ -153,6 +156,19 @@ function CandidateFacts({ candidate }) {
               >
                 {id}
               </Link>
+              {movedTo.has(id) ? (
+                <span className="text-ink-muted">
+                  {" "}
+                  (now{" "}
+                  <Link
+                    to={`/${ENDPOINT}/${movedTo.get(id)}`}
+                    className="text-primary underline"
+                  >
+                    {movedTo.get(id)}
+                  </Link>
+                  )
+                </span>
+              ) : null}
             </span>
           ))}
         </dd>
@@ -307,6 +323,11 @@ function CandidateDecisionPanel({
     );
   }
 
+  // STIT-418: a member merged away since this candidate was recorded. Approving
+  // would fail and Deny would record a judgment no one made, so the decision
+  // controls are hidden below and this banner points at the combined record.
+  const { isStale, moves } = readCandidateStaleness(candidate);
+
   return (
     <article className="min-w-0 overflow-hidden rounded-md border border-line bg-panel">
       {candidateError ? (
@@ -314,6 +335,34 @@ function CandidateDecisionPanel({
           These details could not be refreshed and may be out of date.{" "}
           {candidateErrorObj?.message ?? "Failed to load candidate."}
         </p>
+      ) : null}
+
+      {isStale ? (
+        <div className="border-b border-warning/30 bg-warning-soft px-5 py-4 text-sm text-warning">
+          {moves.map((move) => (
+            <p key={move.resource_id}>
+              Resource{" "}
+              <Link
+                to={`/${ENDPOINT}/${move.resource_id}`}
+                className="underline"
+              >
+                {move.resource_id}
+              </Link>{" "}
+              was merged into{" "}
+              <Link
+                to={`/${ENDPOINT}/${move.repointed_to}`}
+                className="underline"
+              >
+                {move.repointed_to}
+              </Link>
+              .
+            </p>
+          ))}
+          <p className="mt-2">
+            This candidate is out of date and can no longer be merged. Review
+            the combined record instead.
+          </p>
+        </div>
       ) : null}
 
       <div className="space-y-4 px-5 py-5">
@@ -360,7 +409,7 @@ function CandidateDecisionPanel({
         />
       )}
 
-      {candidate.status === "PENDING" ? (
+      {candidate.status === "PENDING" && !isStale ? (
         <DecisionControls
           reviewNotes={reviewNotes}
           onReviewNotesChange={onReviewNotesChange}

--- a/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.test.jsx
+++ b/deployments/stitch-frontend/src/pages/MergeCandidateReviewPage.test.jsx
@@ -463,4 +463,54 @@ describe("MergeCandidateReviewPage", () => {
       screen.queryByRole("heading", { name: "Candidate #11" }),
     ).not.toBeInTheDocument();
   });
+
+  describe("stale candidates", () => {
+    const staleDetail = {
+      ...pendingDetail,
+      repointed_resources: [{ resource_id: 102, repointed_to: 301 }],
+    };
+
+    it("shows a stale banner and hides the decision controls when a member was merged away", async () => {
+      vi.mocked(useMergeCandidate).mockReturnValue({
+        ...defaultHookReturn,
+        data: staleDetail,
+      });
+      renderWithQueryClient(<MergeCandidateReviewPage />);
+
+      // Banner explains the move, naming both the old id and the new one...
+      expect(await screen.findByText(/was merged into/i)).toBeInTheDocument();
+      const links301 = screen.getAllByRole("link", { name: "301" });
+      expect(links301[0]).toHaveAttribute("href", "/oil-gas-fields/301");
+
+      // ...and Approve/Deny/notes are gone (not merely disabled): approving
+      // would fail and denying would record a judgment no one made.
+      expect(
+        screen.queryByRole("button", { name: "Approve merge" }),
+      ).not.toBeInTheDocument();
+      expect(
+        screen.queryByRole("button", { name: "Deny merge" }),
+      ).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Decision notes")).not.toBeInTheDocument();
+    });
+
+    it("annotates the moved source resource with its new resource in the facts", () => {
+      vi.mocked(useMergeCandidate).mockReturnValue({
+        ...defaultHookReturn,
+        data: staleDetail,
+      });
+      renderWithQueryClient(<MergeCandidateReviewPage />);
+
+      expect(screen.getByText(/\(now/)).toBeInTheDocument();
+    });
+
+    it("shows no banner and keeps the controls when no member has been merged away", () => {
+      // Compat guard: a payload without `repointed_resources` renders as before.
+      renderWithQueryClient(<MergeCandidateReviewPage />);
+
+      expect(screen.queryByText(/was merged into/i)).not.toBeInTheDocument();
+      expect(
+        screen.getByRole("button", { name: "Approve merge" }),
+      ).toBeInTheDocument();
+    });
+  });
 });

--- a/deployments/stitch-frontend/src/utils/mergeCandidateStaleness.js
+++ b/deployments/stitch-frontend/src/utils/mergeCandidateStaleness.js
@@ -1,0 +1,20 @@
+// Single place that reads the API's merge-candidate staleness signal
+// (`repointed_resources`), so a field rename is a one-file change.
+//
+// STIT-418: when an overlapping candidate is approved, a member of this
+// candidate gets merged away (repointed). The API reports each moved member and
+// the terminal resource it now lives on; an empty/absent list means the
+// candidate is still valid.
+
+/**
+ * @param {{ repointed_resources?: Array<{resource_id: number, repointed_to: number}> }} [candidate]
+ * @returns {{ isStale: boolean, moves: Array<{resource_id: number, repointed_to: number}> }}
+ */
+export function readCandidateStaleness(candidate) {
+  // Degrade to "not stale" when the field is absent (older backend, or a payload
+  // shape that predates this feature) rather than throwing.
+  const moves = Array.isArray(candidate?.repointed_resources)
+    ? candidate.repointed_resources
+    : [];
+  return { isStale: moves.length > 0, moves };
+}

--- a/deployments/stitch-frontend/src/utils/mergeCandidateStaleness.test.js
+++ b/deployments/stitch-frontend/src/utils/mergeCandidateStaleness.test.js
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { readCandidateStaleness } from "./mergeCandidateStaleness";
+
+describe("readCandidateStaleness", () => {
+  it("reports the moves and isStale when repointed_resources is non-empty", () => {
+    const { isStale, moves } = readCandidateStaleness({
+      repointed_resources: [{ resource_id: 102, repointed_to: 301 }],
+    });
+    expect(isStale).toBe(true);
+    expect(moves).toEqual([{ resource_id: 102, repointed_to: 301 }]);
+  });
+
+  it("is not stale when repointed_resources is an empty list", () => {
+    const { isStale, moves } = readCandidateStaleness({
+      repointed_resources: [],
+    });
+    expect(isStale).toBe(false);
+    expect(moves).toEqual([]);
+  });
+
+  it("degrades to not-stale when the field is absent", () => {
+    expect(readCandidateStaleness({})).toEqual({ isStale: false, moves: [] });
+  });
+
+  it("degrades to not-stale for a null or undefined candidate", () => {
+    expect(readCandidateStaleness(undefined)).toEqual({
+      isStale: false,
+      moves: [],
+    });
+    expect(readCandidateStaleness(null)).toEqual({ isStale: false, moves: [] });
+  });
+
+  it("ignores a non-array repointed_resources", () => {
+    expect(readCandidateStaleness({ repointed_resources: "nope" })).toEqual({
+      isStale: false,
+      moves: [],
+    });
+  });
+});


### PR DESCRIPTION
Extends #258 to address the merge-review dead end: when two pending merge
candidates share a source resource, approving one merges that resource away
(its original becomes an all-null shell), leaving the other candidate
functionally invalid. This surfaces that state — hiding the approve/deny
controls and telling the reviewer which resource was merged into which.

Added as a separate PR (stack) primarily because this one has some choices around the ergonomics of merge review that we may want to discuss more without blocking #258

----

## STIT-418 (part 2 of 2) — resolve repointed resources in the Merge Review pane

**Stacked on #258** (base branch `feat/redirect-detail`); review/merge part 1
first, then this retargets to `main`.

When an overlapping candidate is approved, a member of another pending candidate
gets merged away. Previously that candidate's Approve was guaranteed to 400 with
a message interpolating `repr()` on ORM objects (`Repointed: [<...object at
0x...>]`), and the only exit was Deny — recording a judgment no one made.

- **API:** merge-candidate views carry `repointed_resources` (which members moved
  and their terminal resource), computed for PENDING candidates via a single
  batched root lookup. The approve-time guard now names the terminal resource
  ("resource 102 is now resource 301") on both the merge-candidate and
  write-path guards.
- **Frontend:** the review pane shows a warning banner naming each move (linked),
  hides Approve/Deny when a member has moved, and annotates moved members with
  "(now 301)".

Also includes a small perf commit dropping redundant queries on the resolve
paths (`get_resolved` builds the entity from the row it already loaded; `create`
skips an always-empty staleness lookup).

The retire/requeue/`SUPERSEDED`-status flow is intentionally deferred until the
stale-candidate dead end actually blocks a reviewer.

### Tests
Backend: origin-column batch mapping, N+1 batch guard, PENDING-only rule, the
cross-candidate case end-to-end (approve 400s naming both ids, no `object at
0x`, stays PENDING), and the apply_resource_merge guard case. Frontend: stale
banner + hidden controls, facts annotation, compat guard, and a pure-function
suite for the staleness util.

### AI assistance
Implemented with Claude Code. Verified: API pytest + frontend vitest green.